### PR TITLE
Kill bogus commands, and log when an error happens.

### DIFF
--- a/charmcraft/commands/version.py
+++ b/charmcraft/commands/version.py
@@ -32,32 +32,3 @@ class VersionCommand(BaseCommand):
         # XXX: we need to define how we want to store the project version (in config/file/etc.)
         version = '0.0.1'
         logger.info('Version: %s', version)
-
-
-# XXX: the following commands are left here as an example of different commands... but in
-# reality new commands will have new files for them
-
-
-class CommandExampleDebug(BaseCommand):
-    """Just an example."""
-
-    name = 'example-debug'
-    help_msg = "show msg in debug"
-
-    def fill_parser(self, parser):
-        parser.add_argument('foo')
-        parser.add_argument('--bar', action='store_true', help="To use this command in a bar")
-
-    def run(self, parsed_args):
-        logger.debug(
-            "Example showing log in DEBUG: foo=%s bar=%s", parsed_args.foo, parsed_args.bar)
-
-
-class CommandExampleError(BaseCommand):
-    """Just an example."""
-
-    name = 'example-error'
-    help_msg = "show msg in error"
-
-    def run(self, parsed_args):
-        logger.error("Example showing log in ERROR.")

--- a/charmcraft/main.py
+++ b/charmcraft/main.py
@@ -32,8 +32,7 @@ logger = logging.getLogger(__name__)
 # declared in each command because it's much easier to do this separation/grouping in one
 # central place and not distributed in several classes/files.
 COMMAND_GROUPS = [
-    ('basic', "basics", [version.VersionCommand, version.CommandExampleError]),
-    ('advanced', "more complex stuff", [version.CommandExampleDebug]),
+    ('basic', "basics", [version.VersionCommand]),
 ]
 
 
@@ -103,6 +102,7 @@ class Dispatcher:
         try:
             command.run(self.parsed_args)
         except CommandError as err:
+            logger.error(str(err))
             return err.retcode
         return 0
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/canonical/charmcraft",
     license="Apache-2.0",
-    packages=["charmcraft"],
+    packages=["charmcraft", "charmcraft.commands"],
     package_data={'': ["LICENSE", "README.md", "requirements.txt"]},
     classifiers=[
         "Environment :: Console",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -16,6 +16,7 @@
 
 import argparse
 import io
+import logging
 import textwrap
 from unittest.mock import patch
 
@@ -184,8 +185,10 @@ def test_dispatcher_command_execution_crash():
         dispatcher.run()
 
 
-def test_dispatcher_command_execution_controlled_error():
+def test_dispatcher_command_execution_controlled_error(caplog):
     """Commands can indicate "fatal error" through a specific exception."""
+    caplog.set_level(logging.ERROR, logger="charmcraft")
+
     class MyCommand(BaseCommand):
         help_msg = "some help"
         name = 'cmdname'
@@ -197,6 +200,7 @@ def test_dispatcher_command_execution_controlled_error():
     dispatcher = Dispatcher(['cmdname'], groups)
     retcode = dispatcher.run()
     assert retcode == -13
+    assert ["boom"] == [rec.message for rec in caplog.records]
 
 
 @pytest.mark.parametrize("option", ['--verbose', '-v'])


### PR DESCRIPTION
This was previously included in the `build` branch, separated here so the other one is more focused.