### PR TITLE
Fix pip installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/canonical/charmcraft",
     license="Apache-2.0",
-    packages=["charmcraft"],
+    packages=setuptools.find_namespace_packages(include=['charmcraft', 'charmcraft.*']),
     package_data={'': ["LICENSE", "README.md", "requirements.txt"]},
     classifiers=[
         "Environment :: Console",
@@ -43,7 +43,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3",
     ],
     entry_points={
-        'console_scripts': ["charmcraft = charmcraft:main"],
+        'console_scripts': ["charmcraft = charmcraft.main:main"],
     },
     python_requires='>=3',
     install_requires=requirements,


### PR DESCRIPTION
Installing via pip requires the `charmcraft.commands` module to be included in the list of modules to install, so switching to a setuptools convenience function that finds all available modules.

The `charmcraft` entrypoint was also pointing at the `main` module instead of the `main` function.