### PR TITLE
build: set JUJU_DISPATCH_PATH so we get the right hook

### DIFF
--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -34,6 +34,10 @@ VENV_DIRNAME = 'venv'
 
 # The file name and template for the dispatch script
 DISPATCH_FILENAME = 'dispatch'
+# If Juju doesn't support the dispatch mechanism, it will execute the
+# hook, and we'd need sys.argv[0] to be the name of the hook but it's
+# geting lost by calling this dispatch, so we fake JUJU_DISPATCH_PATH
+# to be the value it would've otherwise been.
 DISPATCH_CONTENT = """#!/bin/sh
 
 JUJU_DISPATCH_PATH="${{JUJU_DISPATCH_PATH:-$0}}" PYTHONPATH=lib:venv ./{entrypoint_relative_path}

--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -36,7 +36,7 @@ VENV_DIRNAME = 'venv'
 DISPATCH_FILENAME = 'dispatch'
 DISPATCH_CONTENT = """#!/bin/sh
 
-PYTHONPATH=lib:venv ./{entrypoint_relative_path}
+JUJU_DISPATCH_PATH="${{JUJU_DISPATCH_PATH:-$0}}" PYTHONPATH=lib:venv ./{entrypoint_relative_path}
 """
 
 # The minimum set of hooks to be provided for compatibility with old Juju


### PR DESCRIPTION
We're launching the charm via dispatch even when dispatch is not
supported: this means we need to set up JUJU_DISPATCH_PATH ourselves
if it isn't done for us.