### PR TITLE
Include config.yaml in built charm

### DIFF
--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -31,6 +31,7 @@ logger = logging.getLogger(__name__)
 
 # Some constants that are used through the code.
 CHARM_METADATA = 'metadata.yaml'
+CHARM_CONFIG = 'config.yaml'
 BUILD_DIRNAME = 'build'
 VENV_DIRNAME = 'venv'
 
@@ -104,6 +105,9 @@ class Builder:
         # basic files
         logger.debug("Linking in basic files and charm code")
         self._link_to_buildpath(self.charmdir / CHARM_METADATA)
+        config_yaml = self.charmdir / CHARM_CONFIG
+        if config_yaml.exists():
+            self._link_to_buildpath(config_yaml)
 
         # the whole dir/tree if entry point is in a project's subdir, itself alone otherwise
         if self.charmdir in self.entrypoint.parents and self.charmdir != self.entrypoint.parent:

--- a/tests/commands/test_build.py
+++ b/tests/commands/test_build.py
@@ -406,7 +406,7 @@ def test_build_basic_complete_structure(tmp_path, monkeypatch):
     assert zf.read('lib/ops/stuff.txt') == b"ops stuff"
 
 
-@pytest.mark.parametrize('has_config', [False, True], ids=lambda val: f'has_config={val}')
+@pytest.mark.parametrize('has_config', [False, True], ids=lambda val: 'has_config={}'.format(val))
 def test_build_code_simple(tmp_path, has_config):
     """Check transferred metadata and simple entrypoint."""
     build_dir = tmp_path / BUILD_DIRNAME

--- a/tests/commands/test_build.py
+++ b/tests/commands/test_build.py
@@ -356,7 +356,7 @@ def test_politeexec_crashed(caplog, tmp_path):
 # --- (real) build tests
 
 
-def test_build_basic_complete_structure(tmp_path):
+def test_build_basic_complete_structure(tmp_path, monkeypatch):
     """Integration test: a simple structure with custom lib and normal src dir."""
     build_dir = tmp_path / BUILD_DIRNAME
     build_dir.mkdir()
@@ -384,6 +384,7 @@ def test_build_basic_complete_structure(tmp_path):
     with charm_script.open('wb') as fh:
         fh.write(b'all the magic')
 
+    monkeypatch.chdir(tmp_path)  # so the zip file is left in the temp dir
     builder = Builder({
         'from': pathlib.Path(str(tmp_path)),  # bad support for tmp_path's pathlib2 in Py3.5
         'entrypoint': pathlib.Path(str(charm_script)),

--- a/tests/commands/test_build.py
+++ b/tests/commands/test_build.py
@@ -432,13 +432,12 @@ def test_build_code_simple(tmp_path):
     assert linked_entrypoint == built_entrypoint
 
 
-def test_build_code_simple_with_config(tmp_path):
-    """Check transferred metadata, config, and simple entrypoint."""
+def test_build_config(tmp_path):
+    """Check config.yaml included when present."""
     build_dir = tmp_path / BUILD_DIRNAME
     build_dir.mkdir()
-
-    metadata = tmp_path / CHARM_METADATA
     entrypoint = tmp_path / 'crazycharm.py'
+
     config = tmp_path / CHARM_CONFIG
     config.touch()
 
@@ -447,21 +446,11 @@ def test_build_code_simple_with_config(tmp_path):
         'entrypoint': entrypoint,
         'requirement': [],
     })
-    linked_entrypoint = builder.handle_code()
-
-    built_metadata = build_dir / CHARM_METADATA
-    assert built_metadata.is_symlink()
-    assert built_metadata.resolve() == metadata
-
-    built_entrypoint = build_dir / 'crazycharm.py'
-    assert built_entrypoint.is_symlink()
-    assert built_entrypoint.resolve() == entrypoint
+    builder.handle_code()
 
     built_config = build_dir / CHARM_CONFIG
     assert built_config.is_symlink()
     assert built_config.resolve() == config
-
-    assert linked_entrypoint == built_entrypoint
 
 
 def test_build_code_tree(tmp_path):


### PR DESCRIPTION
Include config.yaml in the zipped charm if present in the source.

Test both with and without a config.yaml in the simple-build case.