### PR TITLE
Put complete-structure test zip under tmp_path

### DIFF
--- a/tests/commands/test_build.py
+++ b/tests/commands/test_build.py
@@ -365,7 +365,7 @@ def test_politeexec_crashed(caplog, tmp_path):
 # --- (real) build tests
 
 
-def test_build_basic_complete_structure(tmp_path):
+def test_build_basic_complete_structure(tmp_path, monkeypatch):
     """Integration test: a simple structure with custom lib and normal src dir."""
     build_dir = tmp_path / BUILD_DIRNAME
     build_dir.mkdir()
@@ -393,6 +393,7 @@ def test_build_basic_complete_structure(tmp_path):
     with charm_script.open('wb') as fh:
         fh.write(b'all the magic')
 
+    monkeypatch.chdir(tmp_path)  # so the zip file is left in the temp dir
     builder = Builder({
         'from': pathlib.Path(str(tmp_path)),  # bad support for tmp_path's pathlib2 in Py3.5
         'entrypoint': pathlib.Path(str(charm_script)),


### PR DESCRIPTION
Avoid leaving behind a zip after tests.

Run test_build_basic_complete_structure in tmp_path as done in
test_build_package_tree_structure and test_build_package_name. The
latter two call builder.handle_package(), which writes the zip. The
former calls builder.run(), which gets there indirectly.