### PR TITLE
A small refactor creating a "store api" layer between commands and the client

### DIFF
--- a/charmcraft/commands/store/__init__.py
+++ b/charmcraft/commands/store/__init__.py
@@ -18,8 +18,11 @@
 
 import logging
 
+from tabulate import tabulate
+
 from charmcraft.cmdbase import BaseCommand
-from charmcraft.commands.store.client import Client
+
+from .store import Store
 
 logger = logging.getLogger('charmcraft.commands.store')
 
@@ -31,11 +34,8 @@ class LoginCommand(BaseCommand):
 
     def run(self, parsed_args):
         """Run the command."""
-        # The login happens on every request to the Store (if current credentials were not
-        # enough), so here we just exercise the simplest command regarding developer identity.
-        client = Client()
-        client.clear_credentials()
-        client.get('/v1/whoami')
+        store = Store()
+        store.login()
         logger.info("Login successful")
 
 
@@ -46,8 +46,8 @@ class LogoutCommand(BaseCommand):
 
     def run(self, parsed_args):
         """Run the command."""
-        client = Client()
-        client.clear_credentials()
+        store = Store()
+        store.logout()
         logger.info("Credentials cleared")
 
 
@@ -57,16 +57,17 @@ class WhoamiCommand(BaseCommand):
     help_msg = "returns your login information relevant to the store"
 
     _titles = [
-        ('name:', 'display-name'),
+        ('name:', 'name'),
         ('username:', 'username'),
-        ('id:', 'id'),
+        ('id:', 'userid'),
     ]
 
     def run(self, parsed_args):
         """Run the command."""
-        client = Client()
-        result = client.get('/v1/whoami')
+        store = Store()
+        result = store.whoami()
 
-        longest_title = max(len(t[0]) for t in self._titles)
-        for title, key in self._titles:
-            logger.info("%-*s %s", longest_title, title, result[key])
+        data = [(title, getattr(result, attr)) for title, attr in self._titles]
+        table = tabulate(data, tablefmt='plain')
+        for line in table.split('\n'):
+            logger.info(line)

--- a/charmcraft/commands/store/__init__.py
+++ b/charmcraft/commands/store/__init__.py
@@ -69,5 +69,5 @@ class WhoamiCommand(BaseCommand):
 
         data = [(title, getattr(result, attr)) for title, attr in self._titles]
         table = tabulate(data, tablefmt='plain')
-        for line in table.split('\n'):
+        for line in table.splitlines():
             logger.info(line)

--- a/charmcraft/commands/store/__init__.py
+++ b/charmcraft/commands/store/__init__.py
@@ -56,18 +56,16 @@ class WhoamiCommand(BaseCommand):
     name = 'whoami'
     help_msg = "returns your login information relevant to the store"
 
-    _titles = [
-        ('name:', 'name'),
-        ('username:', 'username'),
-        ('id:', 'userid'),
-    ]
-
     def run(self, parsed_args):
         """Run the command."""
         store = Store()
         result = store.whoami()
 
-        data = [(title, getattr(result, attr)) for title, attr in self._titles]
+        data = [
+            ('name:', result.name),
+            ('username:', result.username),
+            ('id:', result.userid),
+        ]
         table = tabulate(data, tablefmt='plain')
         for line in table.splitlines():
             logger.info(line)

--- a/charmcraft/commands/store/store.py
+++ b/charmcraft/commands/store/store.py
@@ -1,0 +1,61 @@
+# Copyright 2020 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For further info, check https://github.com/canonical/charmcraft
+
+"""The Store API handling."""
+
+from collections import namedtuple
+
+from charmcraft.commands.store.client import Client
+
+# helper to build responses from this layer
+User = namedtuple('User', 'name username userid')
+
+
+class Store:
+    """The main interface to the Store's API."""
+
+    def __init__(self):
+        self._client = Client()
+
+    def login(self):
+        """Login into the store.
+
+        The login happens on every request to the Store (if current credentials were not
+        enough), so to trigger a new login we...
+
+            - remove local credentials
+
+            - exercise the simplest command regarding developer identity
+        """
+        self._client.clear_credentials()
+        self._client.get('/v1/whoami')
+
+    def logout(self):
+        """Logout from the store.
+
+        There's no action really in the Store to logout, we just remove local credentials.
+        """
+        self._client.clear_credentials()
+
+    def whoami(self):
+        """Return authenticated user details."""
+        response = self._client.get('/v1/whoami')
+        result = User(
+            name=response['display-name'],
+            username=response['username'],
+            userid=response['id'],
+        )
+        return result

--- a/charmcraft/main.py
+++ b/charmcraft/main.py
@@ -35,7 +35,9 @@ logger = logging.getLogger(__name__)
 COMMAND_GROUPS = [
     ('basic', "basics", [version.VersionCommand, build.BuildCommand]),
     ('store', "interaction with the store", [
-        store.LoginCommand, store.LogoutCommand, store.WhoamiCommand]),
+        # auth
+        store.LoginCommand, store.LogoutCommand, store.WhoamiCommand,
+    ]),
 ]
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 appdirs == 1.4.4
 macaroonbakery == 1.3.1
 PyYAML == 5.3.1
+tabulate == 0.8.7

--- a/tests/commands/test_store_api.py
+++ b/tests/commands/test_store_api.py
@@ -1,0 +1,64 @@
+# Copyright 2020 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For further info, check https://github.com/canonical/charmcraft
+
+"""Tests for the Store API layer (code in store/store.py)."""
+
+from unittest.mock import patch, call, MagicMock
+
+import pytest
+
+from charmcraft.commands.store.store import Store
+
+
+@pytest.fixture
+def client_mock():
+    client_mock = MagicMock()
+    with patch('charmcraft.commands.store.store.Client', lambda: client_mock):
+        yield client_mock
+
+
+def test_login(client_mock):
+    store = Store()
+    result = store.login()
+    assert client_mock.mock_calls == [
+        call.clear_credentials(),
+        call.get('/v1/whoami'),
+    ]
+    assert result is None
+
+
+def test_logout(client_mock):
+    store = Store()
+    result = store.logout()
+    assert client_mock.mock_calls == [
+        call.clear_credentials(),
+    ]
+    assert result is None
+
+
+def test_whoami(client_mock):
+    store = Store()
+    auth_response = {'display-name': 'John Doe', 'username': 'jdoe', 'id': '-1'}
+    client_mock.get.return_value = auth_response
+
+    result = store.whoami()
+
+    assert client_mock.mock_calls == [
+        call.get('/v1/whoami'),
+    ]
+    assert result.name == 'John Doe'
+    assert result.username == 'jdoe'
+    assert result.userid == '-1'

--- a/tests/commands/test_store_client.py
+++ b/tests/commands/test_store_client.py
@@ -14,6 +14,8 @@
 #
 # For further info, check https://github.com/canonical/charmcraft
 
+"""Tests for the Store client and authentication (code in store/client.py)."""
+
 import json
 import logging
 import os

--- a/tests/commands/test_store_commands.py
+++ b/tests/commands/test_store_commands.py
@@ -14,57 +14,69 @@
 #
 # For further info, check https://github.com/canonical/charmcraft
 
+"""Tests for the Store commands (code in store/__init__.py)."""
+
 import logging
+from argparse import Namespace
 from unittest.mock import patch, call, MagicMock
 
 import pytest
 
-from charmcraft.commands.store import LoginCommand, LogoutCommand, WhoamiCommand
+from charmcraft.commands.store import (
+    LoginCommand,
+    LogoutCommand,
+    WhoamiCommand,
+)
+from charmcraft.commands.store.store import User
+
+
+# used a lot!
+noargs = Namespace()
 
 
 @pytest.fixture
-def client_mock():
-    client_mock = MagicMock()
-    with patch('charmcraft.commands.store.Client', lambda: client_mock):
-        yield client_mock
+def store_mock():
+    store_mock = MagicMock()
+    with patch('charmcraft.commands.store.Store', lambda: store_mock):
+        yield store_mock
 
 
-def test_login(caplog, client_mock):
+def test_login(caplog, store_mock):
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
-    LoginCommand('group').run([])
+    LoginCommand('group').run(noargs)
 
-    assert client_mock.mock_calls == [
-        call.clear_credentials(),
-        call.get('/v1/whoami'),
+    assert store_mock.mock_calls == [
+        call.login(),
     ]
     assert ["Login successful"] == [rec.message for rec in caplog.records]
 
 
-def test_logout(caplog, client_mock):
+def test_logout(caplog, store_mock):
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
-    LogoutCommand('group').run([])
+    LogoutCommand('group').run(noargs)
 
-    assert client_mock.mock_calls == [
-        call.clear_credentials(),
+    assert store_mock.mock_calls == [
+        call.logout(),
     ]
     assert ["Credentials cleared"] == [rec.message for rec in caplog.records]
 
 
-def test_whoami(caplog, client_mock):
+def test_whoami(caplog, store_mock):
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
-    auth_response = {'display-name': 'John Doe', 'username': 'jdoe', 'id': '-1'}
-    client_mock.get.return_value = auth_response
-    WhoamiCommand('group').run([])
+    store_response = User(name='John Doe', username='jdoe', userid='-1')
+    store_mock.whoami.return_value = store_response
 
-    assert client_mock.mock_calls == [
-        call.get('/v1/whoami'),
+    WhoamiCommand('group').run(noargs)
+
+    assert store_mock.mock_calls == [
+        call.whoami(),
     ]
     expected = [
-        'name:     John Doe',
-        'username: jdoe',
-        'id:       -1',
+        'name:      John Doe',
+        'username:  jdoe',
+        'id:        -1',
     ]
     assert expected == [rec.message for rec in caplog.records]


### PR DESCRIPTION
Note that this new layer returns hard-defined structures to the commands (not leaking whatever the store returns). IOW, all dealing-with-store issues are isolated from the commands.

Also I started using `tabulate` for the Whoami command; it may look as overkill for just that, but will use tabulate for other commands in subsequent branches, so let's start here...

This is a work preparing for bringing more commands later (#62).
