### PR TITLE
get version from git

### DIFF
--- a/charmcraft/__init__.py
+++ b/charmcraft/__init__.py
@@ -14,5 +14,4 @@
 #
 # For further info, check https://github.com/canonical/charmcraft
 
-VERSION = (0, 2, 0)
-__version__ = "0.2.0"
+from .version import version as __version__  # noqa: F401 (imported but unused)

--- a/charmcraft/version.py
+++ b/charmcraft/version.py
@@ -27,7 +27,7 @@ def _get_version():
     if (p.parent / '.git').exists():
         try:
             proc = subprocess.run(
-                ['git', 'describe', '--tags', '--long', '--dirty'],
+                ['git', 'describe', '--tags', '--dirty'],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.DEVNULL,
                 cwd=p,

--- a/charmcraft/version.py
+++ b/charmcraft/version.py
@@ -1,0 +1,50 @@
+# Copyright 2020 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import subprocess
+from pathlib import Path
+
+__all__ = ('version',)
+
+_FALLBACK = '0.2'  # this gets bumped after release
+
+
+def _get_version():
+    version = _FALLBACK + ".dev0+unknown"
+
+    p = Path(__file__).parent
+    if (p.parent / '.git').exists():
+        try:
+            proc = subprocess.run(
+                ['git', 'describe', '--tags', '--long', '--dirty'],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                cwd=p,
+                check=True)
+        except Exception:
+            pass
+        else:
+            version = proc.stdout.strip().decode('utf8')
+            if '-' in version:
+                # version will look like <tag>-<#commits>-g<hex>[-dirty]
+                # in terms of PEP 440, the tag we'll make sure is a 'public version identifier';
+                # everything after the first - needs to be a 'local version'
+                public, local = version.split('-', 1)
+                version = public + '+' + local.replace('-', '.')
+                # version now <tag>+<#commits>.g<hex>[.dirty]
+                # which is PEP440-compliant (as long as <tag> is :-)
+    return version
+
+
+version = _get_version()

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@
 # For further info, check https://github.com/canonical/charmcraft
 
 from pathlib import Path
-import setuptools
+from textwrap import dedent
+from setuptools import setup
 
 import charmcraft
 
@@ -33,13 +34,13 @@ version_backup = Path("charmcraft/version.py~")
 version_path.rename(version_backup)
 try:
     with version_path.open("wt", encoding="utf8") as fh:
-        fh.write('''\
-# this is a generated file
+        fh.write(dedent('''
+            # this is a generated file
 
-version = {!r}
-'''.format(charmcraft.__version__))
+            version = {!r}
+            ''').format(charmcraft.__version__))
 
-    setuptools.setup(
+    setup(
         name="charmcraft",
         version=charmcraft.__version__,
         author="Facundo Batista",

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@
 #
 # For further info, check https://github.com/canonical/charmcraft
 
+from pathlib import Path
 import setuptools
 
 import charmcraft
@@ -27,26 +28,40 @@ with open("README.md", "rt", encoding='utf8') as fh:
 with open("requirements.txt", "rt", encoding='utf8') as fh:
     requirements = fh.read().split('\n')
 
-setuptools.setup(
-    name="charmcraft",
-    version=charmcraft.__version__,
-    author="Facundo Batista",
-    author_email="facundo.batista@canonical.com",
-    description="The main tool to build, upload, and develop in general the Juju charms.",
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    url="https://github.com/canonical/charmcraft",
-    license="Apache-2.0",
-    packages=['charmcraft', 'charmcraft.commands', 'charmcraft.commands.store'],
-    classifiers=[
-        "Environment :: Console",
-        "License :: OSI Approved :: Apache Software License",
-        "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3",
-    ],
-    entry_points={
-        'console_scripts': ["charmcraft = charmcraft.main:main"],
-    },
-    python_requires='>=3',
-    install_requires=requirements,
-)
+version_path = Path("charmcraft/version.py")
+version_backup = Path("charmcraft/version.py~")
+version_path.rename(version_backup)
+try:
+    with version_path.open("wt", encoding="utf8") as fh:
+        fh.write('''\
+# this is a generated file
+
+version = {!r}
+'''.format(charmcraft.__version__))
+
+    setuptools.setup(
+        name="charmcraft",
+        version=charmcraft.__version__,
+        author="Facundo Batista",
+        author_email="facundo.batista@canonical.com",
+        description="The main tool to build, upload, and develop in general the Juju charms.",
+        long_description=long_description,
+        long_description_content_type="text/markdown",
+        url="https://github.com/canonical/charmcraft",
+        license="Apache-2.0",
+        packages=['charmcraft', 'charmcraft.commands', 'charmcraft.commands.store'],
+        classifiers=[
+            "Environment :: Console",
+            "License :: OSI Approved :: Apache Software License",
+            "Operating System :: OS Independent",
+            "Programming Language :: Python :: 3",
+        ],
+        entry_points={
+            'console_scripts': ["charmcraft = charmcraft.main:main"],
+        },
+        python_requires='>=3',
+        install_requires=requirements,
+    )
+
+finally:
+    version_backup.rename(version_path)


### PR DESCRIPTION
Also drop unused and untested VERSION. It doesn't work well with the
PEP440 suffixes, and if we need something like that using the standard
library's packaging.version.Version directly would be better (but as
long as our versions are pep-compliant users can simply
packaging.version.parse() our version and things work).