### PR TITLE
charmcraft/jujuignore.py: Allow extending the list of patterns.

### DIFF
--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -26,6 +26,7 @@ import yaml
 
 from charmcraft.cmdbase import BaseCommand, CommandError
 from .utils import make_executable
+from .jujuignore import JujuIgnore, default_juju_ignore
 
 logger = logging.getLogger(__name__)
 
@@ -87,6 +88,7 @@ class Builder:
         self.requirement_paths = args['requirement']
 
         self.buildpath = self.charmdir / BUILD_DIRNAME
+        self.ignore_rules = self._load_juju_ignore()
 
     def run(self):
         """Main building process."""
@@ -110,11 +112,38 @@ class Builder:
         destpath.symlink_to(srcpath)
         return destpath
 
+    def _load_juju_ignore(self):
+        ignore = JujuIgnore(default_juju_ignore)
+        path = self.charmdir / '.jujuignore'
+        if path.exists():
+            with path.open() as ignores:
+                ignore.extend_patterns(ignores)
+        return ignore
+
+    def _walk_unignored(self, topdir):
+        """Same as os.walk but filter out ignored items."""
+        for top, dirs, nondirs in os.walk(str(topdir)):
+            relpath = pathlib.Path(top).relative_to(topdir)
+            i = 0
+            for d in dirs[:]:
+                if self.ignore_rules.match(str(relpath / d), is_dir=True):
+                    del dirs[i]
+                else:
+                    i++
+            remaining = []
+            for nondir in nondirs:
+                rel = relpath / nondir
+                if not self.ignore_rules.match(rel, is_dir=False):
+                    remaining.append(nondir)
+            yield top, dir, remaining
+
     def handle_code(self):
         """Handle basic files and the charm source code."""
         # basic files
         logger.debug("Linking in basic files and charm code")
         self._link_to_buildpath(self.charmdir / CHARM_METADATA)
+
+
         for fn in CHARM_OPTIONAL:
             path = self.charmdir / fn
             if path.exists():

--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -26,7 +26,7 @@ import yaml
 
 from charmcraft.cmdbase import BaseCommand, CommandError
 from .utils import make_executable
-from .jujuignore import JujuIgnore, default_juju_ignore
+from ..jujuignore import JujuIgnore, default_juju_ignore
 
 logger = logging.getLogger(__name__)
 
@@ -120,29 +120,11 @@ class Builder:
                 ignore.extend_patterns(ignores)
         return ignore
 
-    def _walk_unignored(self, topdir):
-        """Same as os.walk but filter out ignored items."""
-        for top, dirs, nondirs in os.walk(str(topdir)):
-            relpath = pathlib.Path(top).relative_to(topdir)
-            i = 0
-            for d in dirs[:]:
-                if self.ignore_rules.match(str(relpath / d), is_dir=True):
-                    del dirs[i]
-                else:
-                    i++
-            remaining = []
-            for nondir in nondirs:
-                rel = relpath / nondir
-                if not self.ignore_rules.match(rel, is_dir=False):
-                    remaining.append(nondir)
-            yield top, dir, remaining
-
     def handle_code(self):
         """Handle basic files and the charm source code."""
         # basic files
         logger.debug("Linking in basic files and charm code")
         self._link_to_buildpath(self.charmdir / CHARM_METADATA)
-
 
         for fn in CHARM_OPTIONAL:
             path = self.charmdir / fn

--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -116,7 +116,7 @@ class Builder:
         ignore = JujuIgnore(default_juju_ignore)
         path = self.charmdir / '.jujuignore'
         if path.exists():
-            with path.open() as ignores:
+            with path.open('r', encoding='utf-8') as ignores:
                 ignore.extend_patterns(ignores)
         return ignore
 

--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -25,8 +25,8 @@ import zipfile
 import yaml
 
 from charmcraft.cmdbase import BaseCommand, CommandError
+from charmcraft.jujuignore import JujuIgnore, default_juju_ignore
 from .utils import make_executable
-from ..jujuignore import JujuIgnore, default_juju_ignore
 
 logger = logging.getLogger(__name__)
 

--- a/charmcraft/jujuignore.py
+++ b/charmcraft/jujuignore.py
@@ -152,8 +152,7 @@ class JujuIgnore:
         self._compile_from(patterns)
 
     def extend_patterns(self, patterns: typing.Iterable[str]) -> None:
-        """Add more patterns to the ignore list.
-        """
+        """Add more patterns to the ignore list."""
         self._compile_from(patterns)
 
     def _compile_from(self, patterns: typing.Iterable[str]):

--- a/charmcraft/jujuignore.py
+++ b/charmcraft/jujuignore.py
@@ -151,7 +151,12 @@ class JujuIgnore:
         self._matchers = []
         self._compile_from(patterns)
 
-    def _compile_from(self, patterns):
+    def extend_patterns(self, patterns: typing.Iterable[str]) -> None:
+        """Add more patterns to the ignore list.
+        """
+        self._compile_from(patterns)
+
+    def _compile_from(self, patterns: typing.Iterable[str]):
         for line_num, rule in enumerate(patterns, 1):
             orig_rule = rule
             rule = rule.lstrip().rstrip('\r\n')

--- a/tests/test_jujuignore.py
+++ b/tests/test_jujuignore.py
@@ -397,3 +397,12 @@ def test_special_chars_in_brackets():
         ['foob.py', 'fooc.py', 'foo^.py'],
         [r'foo.py', r'fooa.py', r'fooa^.py'],
     )
+
+
+def test_extend_patterns():
+    ignore = jujuignore.JujuIgnore(['foo'])
+    assert ignore.match('foo', is_dir=False)
+    assert not ignore.match('bar', is_dir=False)
+    ignore.extend_patterns(['bar'])
+    assert ignore.match('foo', is_dir=False)
+    assert ignore.match('bar', is_dir=False)


### PR DESCRIPTION
This adds the ability for JujuIgnore to pull in the default ignores and extend them with .jujuignore contents.

I don't have tests around the walk functionality, but I figured I would leave it in there to show you how I was thinking it would look.
