### PR TITLE
charmcraft/commands/build.py: include 'templates' directory

### DIFF
--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -40,7 +40,8 @@ CHARM_OPTIONAL = [
     'metrics.yaml',
     'actions.yaml',
     'lxd-profile.yaml',
-    'version'
+    'templates',
+    'version',
 ]
 
 # The file name and template for the dispatch script

--- a/tests/commands/test_build.py
+++ b/tests/commands/test_build.py
@@ -525,6 +525,25 @@ def test_build_code_tree(tmp_path):
     assert linked_entrypoint == build_dir / 'code_source' / 'crazycharm.py'
 
 
+def test_build_code_includes_templates(tmp_path):
+    """If 'templates' exists, it is included in the build tree."""
+    build_dir = tmp_path / BUILD_DIRNAME
+    build_dir.mkdir()
+
+    source_dir = tmp_path / "templates"
+    entrypoint = tmp_path / 'charm.py'
+    source_dir.mkdir()
+    builder = Builder({
+        'from': tmp_path,
+        'entrypoint': entrypoint,
+        'requirement': [],
+    })
+    builder.handle_code()
+    built_dir = build_dir / 'templates'
+    assert built_dir.is_symlink()
+    assert built_dir.resolve() == source_dir
+
+
 def test_build_dispatcher_modern_dispatch_created(tmp_path):
     """The dispatcher script is properly built."""
     build_dir = tmp_path / BUILD_DIRNAME


### PR DESCRIPTION
fixes: #80

This is the quick fix for issue #80 about adding templates to the built
charm. Ultimately, we want to fix this with issue #39 and handling
.jujuignore properly. However, we feel that ended up bigger than we
could handle for 0.3, and this at least gets people unblocked in the
next release until we land support for jujuignore.