### PR TITLE
cope with bionic's slightly broken pip3 command

### DIFF
--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -51,7 +51,7 @@ MANDATORY_HOOK_NAMES = {'install', 'start', 'upgrade-charm'}
 HOOKS_DIR = 'hooks'
 
 
-def _pip_is_bionic():
+def _pip_needs_system():
     """Determines whether pip3 defaults to --user, needing --system to turn it off."""
     try:
         from pip.commands.install import InstallCommand
@@ -232,8 +232,8 @@ class Builder:
                 'pip3', 'install',  # base command
                 '--target={}'.format(venvpath),  # put all the resulting files in that specific dir
             ]
-            if _pip_is_bionic():
-                logger.debug("adding --system to work around broken bionic pip3")
+            if _pip_needs_system():
+                logger.debug("adding --system to work around pip3 defaulting to --user")
                 cmd.append("--system")
             for reqspath in self.requirement_paths:
                 cmd.append('--requirement={}'.format(reqspath))  # the dependencies file(s)

--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -52,6 +52,7 @@ HOOKS_DIR = 'hooks'
 
 
 def _pip_is_bionic():
+    """Determines whether pip3 defaults to --user, needing --system to turn it off."""
     try:
         from pip.commands.install import InstallCommand
         return InstallCommand().cmd_opts.get_option('--system') is not None

--- a/tests/commands/test_build.py
+++ b/tests/commands/test_build.py
@@ -831,8 +831,8 @@ def test_build_dependencies_virtualenv_simple(tmp_path):
     ]
 
 
-def test_build_dependencies_bionic(tmp_path):
-    """pip3 is called with --system when pip3 is bionic-ish."""
+def test_build_dependencies_needs_system(tmp_path):
+    """pip3 is called with --system when pip3 needs it."""
     build_dir = tmp_path / BUILD_DIRNAME
     build_dir.mkdir()
 
@@ -842,7 +842,7 @@ def test_build_dependencies_bionic(tmp_path):
         'requirement': ['reqs'],
     })
 
-    with patch('charmcraft.commands.build._pip_is_bionic') as is_bionic:
+    with patch('charmcraft.commands.build._pip_needs_system') as is_bionic:
         is_bionic.return_value = True
         with patch('charmcraft.commands.build.polite_exec') as mock:
             mock.return_value = 0

--- a/tests/commands/test_build.py
+++ b/tests/commands/test_build.py
@@ -832,7 +832,7 @@ def test_build_dependencies_virtualenv_simple(tmp_path):
 
 
 def test_build_dependencies_bionic(tmp_path):
-    """A virtualenv is created with the specified requirements file."""
+    """pip3 is called with --system when pip3 is bionic-ish."""
     build_dir = tmp_path / BUILD_DIRNAME
     build_dir.mkdir()
 

--- a/tests/commands/test_build.py
+++ b/tests/commands/test_build.py
@@ -831,6 +831,30 @@ def test_build_dependencies_virtualenv_simple(tmp_path):
     ]
 
 
+def test_build_dependencies_bionic(tmp_path):
+    """A virtualenv is created with the specified requirements file."""
+    build_dir = tmp_path / BUILD_DIRNAME
+    build_dir.mkdir()
+
+    builder = Builder({
+        'from': tmp_path,
+        'entrypoint': 'whatever',
+        'requirement': ['reqs'],
+    })
+
+    with patch('charmcraft.commands.build._pip_is_bionic') as is_bionic:
+        is_bionic.return_value = True
+        with patch('charmcraft.commands.build.polite_exec') as mock:
+            mock.return_value = 0
+            builder.handle_dependencies()
+
+    envpath = build_dir / VENV_DIRNAME
+    assert mock.mock_calls == [
+        call(['pip3', 'list']),
+        call(['pip3', 'install', '--target={}'.format(envpath), '--system', '--requirement=reqs']),
+    ]
+
+
 def test_build_dependencies_virtualenv_multiple(tmp_path):
     """A virtualenv is created with multiple requirements files."""
     build_dir = tmp_path / BUILD_DIRNAME


### PR DESCRIPTION
This makes 'charmcraft build' work even when running using the pip
shipped in bionic, which is a bit "off".

fixes: #102