### PR TITLE
Always log the charmcraft version when indicated.

### DIFF
--- a/charmcraft/logsetup.py
+++ b/charmcraft/logsetup.py
@@ -20,6 +20,7 @@ import logging
 import os
 import tempfile
 
+from charmcraft import __version__
 
 FORMATTER_SIMPLE = "%(message)s"
 FORMATTER_DETAILED = "%(asctime)s  %(name)-30s %(levelname)-8s %(message)s"
@@ -63,6 +64,8 @@ class _MessageHandler:
         level, format_string = self._modes[mode]
         self._stderr_handler.setFormatter(logging.Formatter(format_string))
         self._stderr_handler.setLevel(level)
+        if mode == self.VERBOSE:
+            _logger.debug("Starting charmcraft version %s", __version__)
 
     def _set_filehandler(self):
         """Set the file handler to log everything to the temp file."""
@@ -77,6 +80,7 @@ class _MessageHandler:
         self._file_logger = logging.getLogger('charmcraft.guard')
         self._file_logger.propagate = False
         self._file_logger.addHandler(file_handler)
+        self._file_logger.debug("Starting charmcraft version %s", __version__)
 
     def ended_ok(self):
         """Cleanup after successful execution."""

--- a/charmcraft/main.py
+++ b/charmcraft/main.py
@@ -21,7 +21,6 @@ import operator
 import os
 import sys
 
-from charmcraft import __version__
 from charmcraft.commands import version, build, store, init
 from charmcraft.cmdbase import CommandError
 from charmcraft.logsetup import message_handler
@@ -94,8 +93,6 @@ class Dispatcher:
     """
 
     def __init__(self, sysargs, commands_groups):
-        logger.debug("Starting charmcraft version %s", __version__)
-
         self.commands = self._load_commands(commands_groups)
         logger.debug("Commands loaded: %s", self.commands)
 

--- a/tests/test_logsetup.py
+++ b/tests/test_logsetup.py
@@ -39,6 +39,9 @@ def create_message_handler(tmp_path):
         patchers.append(p)
 
         if modes is not None:
+            if 'verbose' not in modes:
+                # verbose should always be there, as it's used internally
+                modes['verbose'] = (10, "%(message)s")
             p = patch.object(_MessageHandler, '_modes', modes)
             p.start()
             patchers.append(p)
@@ -93,10 +96,11 @@ def test_logfile_all_stored(create_message_handler):
     with open(mh._log_filepath, 'rt') as fh:
         logcontent = fh.readlines()
 
-    assert 'test debug' in logcontent[0]
-    assert 'test info' in logcontent[1]
-    assert 'test warning' in logcontent[2]
-    assert 'test error' in logcontent[3]
+    # start checking from pos 1, as in 0 we always have the bootstrap message
+    assert 'test debug' in logcontent[1]
+    assert 'test info' in logcontent[2]
+    assert 'test warning' in logcontent[3]
+    assert 'test error' in logcontent[4]
 
 
 def test_ended_success(caplog, create_message_handler):
@@ -215,6 +219,6 @@ def test_ended_crash_while_verbose(caplog, create_message_handler):
     assert 'Traceback' in log_content
 
     # also it shown the error to the user AND also the traceback
-    (record,) = caplog.records
+    (_, record) = caplog.records
     assert record.message == expected_msg
     assert record.exc_info[0] == ValueError

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -16,7 +16,7 @@
 
 import argparse
 import io
-import logging
+import pathlib
 import textwrap
 from unittest.mock import patch
 
@@ -278,14 +278,6 @@ def test_dispatcher_load_commands_repeated():
         Dispatcher([], groups)
 
 
-def test_dispatcher_log_startup(caplog):
-    """The version is logged in debug when started."""
-    caplog.set_level(logging.DEBUG, logger="charmcraft")
-    Dispatcher([], [])
-    expected = "Starting charmcraft version " + __version__
-    assert expected in [rec.message for rec in caplog.records]
-
-
 # --- Tests for the main entry point
 
 # In all the test methods below we patch Dispatcher.run so we don't really exercise any
@@ -349,3 +341,104 @@ def test_main_interrupted():
 
     assert retcode == 1
     assert mh_mock.ended_interrupt.called_once()
+
+
+# --- Tests for the bootstrap version message
+
+
+def test_initmsg_default():
+    """Without any option, the init msg only goes to disk."""
+    cmd = create_command('somecommand')
+    fake_stream = io.StringIO()
+    with patch('charmcraft.main.COMMAND_GROUPS', [('test-group', 'whatever title', [cmd])]):
+        with patch.object(logsetup.message_handler, 'ended_ok') as ended_ok_mock:
+            with patch.object(logsetup.message_handler._stderr_handler, 'stream', fake_stream):
+                main(['charmcraft', 'somecommand'])
+
+    # get the logfile first line before removing it
+    ended_ok_mock.assert_called_once()
+    logged_to_file = pathlib.Path(logsetup.message_handler._log_filepath).read_text()
+    file_first_line = logged_to_file.split('\n')[0]
+    logsetup.message_handler.ended_ok()
+
+    # get the terminal first line
+    captured = fake_stream.getvalue()
+    terminal_first_line = captured.split('\n')[0]
+
+    expected = "Starting charmcraft version " + __version__
+    assert expected in file_first_line
+    assert expected not in terminal_first_line
+
+
+def test_initmsg_quiet():
+    """In quiet mode, the init msg only goes to disk."""
+    cmd = create_command('somecommand')
+    fake_stream = io.StringIO()
+    with patch('charmcraft.main.COMMAND_GROUPS', [('test-group', 'whatever title', [cmd])]):
+        with patch.object(logsetup.message_handler, 'ended_ok') as ended_ok_mock:
+            with patch.object(logsetup.message_handler._stderr_handler, 'stream', fake_stream):
+                main(['charmcraft', '--quiet', 'somecommand'])
+
+    # get the logfile first line before removing it
+    ended_ok_mock.assert_called_once()
+    logged_to_file = pathlib.Path(logsetup.message_handler._log_filepath).read_text()
+    file_first_line = logged_to_file.split('\n')[0]
+    logsetup.message_handler.ended_ok()
+
+    # get the terminal first line
+    captured = fake_stream.getvalue()
+    terminal_first_line = captured.split('\n')[0]
+
+    expected = "Starting charmcraft version " + __version__
+    assert expected in file_first_line
+    assert expected not in terminal_first_line
+
+
+def test_initmsg_verbose():
+    """In verbose mode, the init msg goes both to disk and terminal."""
+    cmd = create_command('somecommand')
+    fake_stream = io.StringIO()
+    with patch('charmcraft.main.COMMAND_GROUPS', [('test-group', 'whatever title', [cmd])]):
+        with patch.object(logsetup.message_handler, 'ended_ok') as ended_ok_mock:
+            with patch.object(logsetup.message_handler._stderr_handler, 'stream', fake_stream):
+                main(['charmcraft', '--verbose', 'somecommand'])
+
+    # get the logfile first line before removing it
+    ended_ok_mock.assert_called_once()
+    logged_to_file = pathlib.Path(logsetup.message_handler._log_filepath).read_text()
+    file_first_line = logged_to_file.split('\n')[0]
+    logsetup.message_handler.ended_ok()
+
+    # get the terminal first line
+    captured = fake_stream.getvalue()
+    terminal_first_line = captured.split('\n')[0]
+
+    expected = "Starting charmcraft version " + __version__
+    assert expected in file_first_line
+    assert expected in terminal_first_line
+
+
+def test_initmsg_debug(monkeypatch):
+    """When in DEBUG, the init msg goes both to disk and terminal."""
+    monkeypatch.setenv('DEBUG', '1')
+
+    cmd = create_command('somecommand')
+    fake_stream = io.StringIO()
+    with patch('charmcraft.main.COMMAND_GROUPS', [('test-group', 'whatever title', [cmd])]):
+        with patch.object(logsetup.message_handler, 'ended_ok') as ended_ok_mock:
+            with patch.object(logsetup.message_handler._stderr_handler, 'stream', fake_stream):
+                main(['charmcraft', 'somecommand'])
+
+    # get the logfile first line before removing it
+    ended_ok_mock.assert_called_once()
+    logged_to_file = pathlib.Path(logsetup.message_handler._log_filepath).read_text()
+    file_first_line = logged_to_file.split('\n')[0]
+    logsetup.message_handler.ended_ok()
+
+    # get the terminal first line
+    captured = fake_stream.getvalue()
+    terminal_first_line = captured.split('\n')[0]
+
+    expected = "Starting charmcraft version " + __version__
+    assert expected in file_first_line
+    assert expected in terminal_first_line

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -356,7 +356,7 @@ def test_initmsg_default():
                 main(['charmcraft', 'somecommand'])
 
     # get the logfile first line before removing it
-    ended_ok_mock.assert_called_once()
+    ended_ok_mock.assert_called_once_with()
     logged_to_file = pathlib.Path(logsetup.message_handler._log_filepath).read_text()
     file_first_line = logged_to_file.split('\n')[0]
     logsetup.message_handler.ended_ok()
@@ -380,7 +380,7 @@ def test_initmsg_quiet():
                 main(['charmcraft', '--quiet', 'somecommand'])
 
     # get the logfile first line before removing it
-    ended_ok_mock.assert_called_once()
+    ended_ok_mock.assert_called_once_with()
     logged_to_file = pathlib.Path(logsetup.message_handler._log_filepath).read_text()
     file_first_line = logged_to_file.split('\n')[0]
     logsetup.message_handler.ended_ok()
@@ -404,7 +404,7 @@ def test_initmsg_verbose():
                 main(['charmcraft', '--verbose', 'somecommand'])
 
     # get the logfile first line before removing it
-    ended_ok_mock.assert_called_once()
+    ended_ok_mock.assert_called_once_with()
     logged_to_file = pathlib.Path(logsetup.message_handler._log_filepath).read_text()
     file_first_line = logged_to_file.split('\n')[0]
     logsetup.message_handler.ended_ok()
@@ -430,7 +430,7 @@ def test_initmsg_debug(monkeypatch):
                 main(['charmcraft', 'somecommand'])
 
     # get the logfile first line before removing it
-    ended_ok_mock.assert_called_once()
+    ended_ok_mock.assert_called_once_with()
     logged_to_file = pathlib.Path(logsetup.message_handler._log_filepath).read_text()
     file_first_line = logged_to_file.split('\n')[0]
     logsetup.message_handler.ended_ok()


### PR DESCRIPTION
Moved out the the version logging from Dispatcher's init to the
MessageHandler, which will always send it to the file (first thing after
configuring that part of the logging) and to the terminal when the mode
goes verbose.

This is part of #48, but not of all it. It's what was important,
though, other two messages remain un-shown because of initialization
order, but those two messages will go away (or at least change heavily)
when the bootstrap refactor is done (see #139).
