### PR TITLE
when failing to create hard link attempt to use shutil.copy2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,14 @@ python:
     - "3.7"
     - "3.8"
 
+addons:
+  apt:
+    packages:
+      - libffi-dev
+  homebrew:
+    packages:
+      - libffi
+
 matrix:
     include:
         - os: osx

--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -15,6 +15,7 @@
 # For further info, check https://github.com/canonical/charmcraft
 
 
+import errno
 import logging
 import os
 import pathlib
@@ -185,6 +186,10 @@ class Builder:
                         os.link(str(abs_path), str(dest_path))
                     except PermissionError:
                         # when not allowed to create hard links
+                        shutil.copy2(str(abs_path), str(dest_path))
+                    except OSError as e:
+                        if e.errno != errno.EXDEV:
+                            raise
                         shutil.copy2(str(abs_path), str(dest_path))
                 else:
                     logger.debug("Ignoring file because of type: '%s'", rel_path)

--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -181,7 +181,11 @@ class Builder:
                     self.create_symlink(abs_path, dest_path)
                 elif abs_path.is_file():
                     dest_path = self.buildpath / rel_path
-                    os.link(str(abs_path), str(dest_path))
+                    try:
+                        os.link(str(abs_path), str(dest_path))
+                    except PermissionError:
+                        # when not allowed to create hard links
+                        shutil.copy2(str(abs_path), str(dest_path))
                 else:
                     logger.debug("Ignoring file because of type: '%s'", rel_path)
 


### PR DESCRIPTION
When using e.g. vagrant build fails because using hard links is not allowed.
Could catching the permission exception and attempting to copy the file instead be a way to manage builds in vagrant?
https://github.com/canonical/charmcraft/issues/151