### PR TITLE
Produce the default help text.

### DIFF
--- a/charmcraft/cmdbase.py
+++ b/charmcraft/cmdbase.py
@@ -34,6 +34,7 @@ class BaseCommand:
 
     - name: the identifier in the command line
     - help_msg: a one line help for user documentation
+    - common: if it's a common/starter command, which are prioritized in the help
 
     It also must/can override some methods for the proper command behaviour (see each
     method's docstring).
@@ -46,6 +47,7 @@ class BaseCommand:
     name = None
     help_msg = None
     overview = None
+    common = False
 
     def __init__(self, group):
         self.group = group

--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -355,6 +355,7 @@ class BuildCommand(BaseCommand):
     name = 'build'
     help_msg = "Build the charm."
     overview = _overview
+    common = True
 
     def fill_parser(self, parser):
         """Add own parameters to the general parser."""

--- a/charmcraft/commands/init.py
+++ b/charmcraft/commands/init.py
@@ -58,6 +58,7 @@ class InitCommand(BaseCommand):
     name = "init"
     help_msg = "Initialize a directory to be a charm project."
     overview = _overview
+    common = True
 
     def fill_parser(self, parser):
         parser.add_argument(

--- a/charmcraft/commands/store/__init__.py
+++ b/charmcraft/commands/store/__init__.py
@@ -124,6 +124,7 @@ class RegisterNameCommand(BaseCommand):
         It will automatically take you through the login process if
         your credentials are missing or too old.
     """)
+    common = True
 
     def fill_parser(self, parser):
         """Add own parameters to the general parser."""
@@ -147,6 +148,7 @@ class ListNamesCommand(BaseCommand):
         It will automatically take you through the login process if
         your credentials are missing or too old.
     """)
+    common = True
 
     def run(self, parsed_args):
         """Run the command."""
@@ -186,6 +188,7 @@ class UploadCommand(BaseCommand):
         It will automatically take you through the login process if
         your credentials are missing or too old.
     """)
+    common = True
 
     def _discover_charm(self, charm_filepath):
         """Discover the charm name and file path.
@@ -256,6 +259,7 @@ class ListRevisionsCommand(BaseCommand):
         It will automatically take you through the login process if
         your credentials are missing or too old.
     """)
+    common = True
 
     def fill_parser(self, parser):
         """Add own parameters to the general parser."""
@@ -322,6 +326,7 @@ class ReleaseCommand(BaseCommand):
         It will automatically take you through the login process if
         your credentials are missing or too old.
     """)
+    common = True
 
     def fill_parser(self, parser):
         """Add own parameters to the general parser."""
@@ -376,6 +381,7 @@ class StatusCommand(BaseCommand):
         It will automatically take you through the login process if
         your credentials are missing or too old.
     """)
+    common = True
 
     def fill_parser(self, parser):
         """Add own parameters to the general parser."""

--- a/charmcraft/commands/version.py
+++ b/charmcraft/commands/version.py
@@ -47,6 +47,7 @@ class VersionCommand(BaseCommand):
     name = 'version'
     help_msg = "Show the version."
     overview = _overview
+    common = True
 
     def run(self, parsed_args):
         """Run the command."""

--- a/charmcraft/helptexts.py
+++ b/charmcraft/helptexts.py
@@ -1,0 +1,120 @@
+# Copyright 2020 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For further info, check https://github.com/canonical/charmcraft
+
+"""Provide all help texts."""
+
+import textwrap
+from operator import attrgetter
+
+# max columns used in the terminal
+TERMINAL_WIDTH = 72
+
+# the summary of the whole program, already indented so it represents the real
+# "columns spread", for easier human editing.
+GENERAL_SUMMARY = """
+    Charmcraft provides a streamlined, powerful, opinionated and
+    flexible tool to develop, package and manage the lifecycle of
+    Juju charm publication, focused particularly on charms written
+    within the Operator Framework.
+"""
+# XXX Facundo 2020-09-10: we should add an extra (separated) line to the summary with:
+#   See <url> for additional documentation.
+
+
+def _build_item(title, text, title_space):
+    """Show an item in the help, generically a title and a text aligned.
+
+    The title starts in column 4 with an extra ':'. The text starts in
+    4 plus the title space; if too wide it's wrapped.
+    """
+    text_space = TERMINAL_WIDTH - title_space - 4
+    wrapped_lines = textwrap.wrap(text, text_space)
+
+    # first line goes with the title at column 4
+    title += ':'
+    result = ["    {:<{title_space}s}{}".format(title, wrapped_lines[0], title_space=title_space)]
+
+    # the rest (if any) still aligned but without title
+    for line in wrapped_lines[1:]:
+        result.append(" " * (title_space + 4) + line)
+
+    return result
+
+
+def get_full_help(command_groups, global_options):
+    """Produce the text for the default help.
+
+    It has the following structure:
+
+    - usage
+    - summary
+    - common commands listed and described shortly
+    - all commands grouped, just listed
+    - more help
+    """
+    textblocks = []
+
+    # title
+    textblocks.append(textwrap.dedent("""
+        Usage:
+            charmcraft [help] <command>
+    """))
+
+    # summary
+    textblocks.append("Summary:" + GENERAL_SUMMARY)
+
+    # column alignment is dictated by longest common commands names and groups names
+    max_title_len = 0
+
+    # collect common commands
+    common_commands = []
+    for group, _, commands in command_groups:
+        max_title_len = max(len(group), max_title_len)
+        for cmd in commands:
+            if cmd.common:
+                common_commands.append(cmd)
+                max_title_len = max(len(cmd.name), max_title_len)
+
+    for title, _ in global_options:
+        max_title_len = max(len(title), max_title_len)
+
+    # leave two spaces after longest title (also considering the ':')
+    max_title_len += 3
+
+    global_lines = ["Global options:"]
+    for title, text in global_options:
+        global_lines.extend(_build_item(title, text, max_title_len))
+    textblocks.append("\n".join(global_lines))
+
+    common_lines = ["Starter commands:"]
+    for cmd in sorted(common_commands, key=attrgetter('name')):
+        common_lines.extend(_build_item(cmd.name, cmd.help_msg, max_title_len))
+    textblocks.append("\n".join(common_lines))
+
+    grouped_lines = ["Commands can be classified as follows:"]
+    for group, _, commands in sorted(command_groups):
+        command_names = ", ".join(sorted(cmd.name for cmd in commands))
+        grouped_lines.extend(_build_item(group, command_names, max_title_len))
+    textblocks.append("\n".join(grouped_lines))
+
+    textblocks.append(textwrap.dedent("""
+        For more information about a command, run 'charmcraft help <command>'.
+        For a summary of all commands, run 'charmcraft help --all'.
+    """))
+
+    # join all stripped blocks, leaving ONE empty blank line between
+    text = '\n\n'.join(block.strip() for block in textblocks) + '\n'
+    return text

--- a/tests/factory.py
+++ b/tests/factory.py
@@ -19,7 +19,7 @@
 from charmcraft.cmdbase import BaseCommand
 
 
-def create_command(name_, help_msg_=None):
+def create_command(name_, help_msg_=None, common_=False):
     """Helper to create commands."""
     if help_msg_ is None:
         help_msg_ = "Automatic help generated in the factory for the tests."
@@ -27,6 +27,7 @@ def create_command(name_, help_msg_=None):
     class MyCommand(BaseCommand):
         name = name_
         help_msg = help_msg_
+        common = common_
 
         def run(self, parsed_args):
             pass

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -14,12 +14,20 @@
 #
 # For further info, check https://github.com/canonical/charmcraft
 
+import textwrap
+from unittest.mock import patch
+
 import pytest
 
 from charmcraft.main import COMMAND_GROUPS
 
+from charmcraft.helptexts import (
+    get_full_help,
+)
+from tests.factory import create_command
 
-# -- verifications on different help texts
+
+# -- verifications on different short help texts
 
 all_commands = list.__add__(*[commands for _, _, commands in COMMAND_GROUPS])
 
@@ -43,3 +51,63 @@ def test_aesthetic_args_options_msg(command):
             assert help_msg[0].isupper() and help_msg[-1] == '.'
 
     command('group').fill_parser(FakeParser())
+
+
+# -- bulding of the big help text outputs
+
+def test_default_help_text():
+    """All different parts for the default help."""
+    cmd1 = create_command('cmd1', 'Cmd help which is very long but whatever.', common_=True)
+    cmd2 = create_command('command-2', 'Cmd help.', common_=True)
+    cmd3 = create_command('cmd3', 'Extremely ' + 'super crazy long ' * 5 + ' help.', common_=True)
+    cmd4 = create_command('cmd4', 'Some help.')
+    cmd5 = create_command('cmd5', 'More help.')
+    cmd6 = create_command('cmd6-really-long', 'More help.', common_=True)
+    cmd7 = create_command('cmd7', 'More help.')
+
+    command_groups = [
+        ('group1', 'help text for g1', [cmd6, cmd2]),
+        ('group3', 'help text for g3', [cmd7]),
+        ('group2', 'help text for g2', [cmd3, cmd4, cmd5, cmd1]),
+    ]
+    fake_summary = textwrap.indent(textwrap.dedent("""
+        This is the summary for
+        the whole program.
+    """), "    ")
+    global_options = [
+        ('-h, --help', 'Show this help message and exit.'),
+        ('-q, --quiet', 'Only show warnings and errors, not progress.'),
+    ]
+
+    with patch('charmcraft.helptexts.GENERAL_SUMMARY', fake_summary):
+        text = get_full_help(command_groups, global_options)
+
+    expected = textwrap.dedent("""\
+        Usage:
+            charmcraft [help] <command>
+
+        Summary:
+            This is the summary for
+            the whole program.
+
+        Global options:
+            -h, --help:        Show this help message and exit.
+            -q, --quiet:       Only show warnings and errors, not progress.
+
+        Starter commands:
+            cmd1:              Cmd help which is very long but whatever.
+            cmd3:              Extremely super crazy long super crazy long super
+                               crazy long super crazy long super crazy long
+                               help.
+            cmd6-really-long:  More help.
+            command-2:         Cmd help.
+
+        Commands can be classified as follows:
+            group1:            cmd6-really-long, command-2
+            group2:            cmd1, cmd3, cmd4, cmd5
+            group3:            cmd7
+
+        For more information about a command, run 'charmcraft help <command>'.
+        For a summary of all commands, run 'charmcraft help --all'.
+    """)
+    assert text == expected


### PR DESCRIPTION
For this I had to add a 'common' attribute to commands, to flag those are of "common use" (the "common" term was UX used in the docs).

Not integrated yet, this is part of the [big adjust help process](https://github.com/canonical/charmcraft/pull/153).

This PR includes [this previous one](https://github.com/canonical/charmcraft/pull/154).
