### PR TITLE
Two small details before integrating help messages to main.

### DIFF
--- a/charmcraft/cmdbase.py
+++ b/charmcraft/cmdbase.py
@@ -19,11 +19,16 @@ class CommandError(Exception):
     """Base exception for all error commands.
 
     It optionally receives a `retcode` parameter that will be the returned code
-    by the process on exit.
+    by the process on exit, and a `argsparsing` one to indicate that the problem
+    is in the command line usage.
+
+    XXX Facundo 2020-09-21: This will be refactored soon in the branch where all
+    output messages are standarized.
     """
 
-    def __init__(self, message, retcode=1):
+    def __init__(self, message, retcode=1, argsparsing=False):
         self.retcode = retcode
+        self.argsparsing = argsparsing
         super().__init__(message)
 
 

--- a/charmcraft/logsetup.py
+++ b/charmcraft/logsetup.py
@@ -95,9 +95,12 @@ class _MessageHandler:
         os.unlink(self._log_filepath)
 
     def ended_cmderror(self, err):
-        """Report the (expected) problem and logfile location."""
-        msg = "{} (full execution logs in {})".format(err, self._log_filepath)
-        _logger.error(msg)
+        """Report the (expected) problem and (maybe) logfile location."""
+        if err.argsparsing:
+            print(err)
+        else:
+            msg = "{} (full execution logs in {})".format(err, self._log_filepath)
+            _logger.error(msg)
 
     def ended_crash(self, err):
         """Report the internal error and logfile location.

--- a/charmcraft/main.py
+++ b/charmcraft/main.py
@@ -46,6 +46,15 @@ COMMAND_GROUPS = [
 ]
 
 
+def _get_option(args, name):
+    """Get a general option, merging with OR both global and command versions.
+
+    This is done manually because otherwise Argparse would overwrite the
+    command ont into thee global one.
+    """
+    return getattr(args, name + '_global', False) or getattr(args, name + '_command', False)
+
+
 class CustomArgumentParser(argparse.ArgumentParser):
     """ArgumentParser with grouped commands help."""
 
@@ -113,10 +122,9 @@ class Dispatcher:
 
     def _handle_global_params(self):
         """Set up and process global parameters."""
-        args = self.parsed_args
-        if args.verbose_global or getattr(args, 'verbose_command', False):
+        if _get_option(self.parsed_args, 'verbose'):
             message_handler.set_mode(message_handler.VERBOSE)
-        if args.quiet_global or getattr(args, 'quiet_command', False):
+        if _get_option(self.parsed_args, 'quiet'):
             message_handler.set_mode(message_handler.QUIET)
 
     def _load_commands(self, commands_groups):

--- a/charmcraft/main.py
+++ b/charmcraft/main.py
@@ -47,10 +47,10 @@ COMMAND_GROUPS = [
 
 
 def _get_option(args, name):
-    """Get a general option, merging with OR both global and command versions.
+    """Get a general option, doing an OR operation between global and command versions.
 
     This is done manually because otherwise Argparse would overwrite the
-    command ont into thee global one.
+    command one into the global one.
     """
     return getattr(args, name + '_global', False) or getattr(args, name + '_command', False)
 

--- a/tests/test_logsetup.py
+++ b/tests/test_logsetup.py
@@ -148,7 +148,7 @@ def test_ended_verbose_interrupt(caplog, create_message_handler):
     ]
 
 
-def test_ended_commanderror(caplog, create_message_handler):
+def test_ended_commanderror_regular(caplog, create_message_handler):
     """Reports just the message, including the log file (not removed)."""
     caplog.set_level(logging.DEBUG, logger="charmcraft")
 
@@ -166,6 +166,15 @@ def test_ended_commanderror(caplog, create_message_handler):
 
     # also it shown the error to the user
     assert [expected_msg] == [rec.message for rec in caplog.records]
+
+
+def test_ended_commanderror_argparsing(capsys, create_message_handler):
+    """Reports just the message to stdout."""
+    mh = create_message_handler()
+    mh.init(mh.NORMAL)
+    mh.ended_cmderror(CommandError("test controlled error", argsparsing=True))
+    captured = capsys.readouterr()
+    assert captured.out == "test controlled error\n"
 
 
 def test_ended_crash_while_normal(caplog, create_message_handler):


### PR DESCRIPTION
Specifically:

- support "argsparsing" option in CommandError to just present the message to the user (this will be refactored heavily in the short future when we change how all messages are sent to the user, but we need it now to just show the help)

- Added a small helper to check for options in the arguments (which will be more used in the next branch).