### PR TITLE
Improvements per ux review

### DIFF
--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -370,8 +370,8 @@ class BuildCommand(BaseCommand):
         """Add own parameters to the general parser."""
         parser.add_argument(
             '-f', '--from', type=pathlib.Path,
-            help="The directory where the charm project is located, from where the build "
-                 "is done; defaults to '.'.")
+            help="The directory where the charm project is located, where the build "
+                 "is done from; defaults to '.'.")
         parser.add_argument(
             '-e', '--entrypoint', type=pathlib.Path,
             help="The executable script or program which is the entry point to all the "

--- a/charmcraft/commands/store/__init__.py
+++ b/charmcraft/commands/store/__init__.py
@@ -114,7 +114,7 @@ class WhoamiCommand(BaseCommand):
 class RegisterNameCommand(BaseCommand):
     """Register a name in the Store."""
     name = 'register'
-    help_msg = "Register a charm in the Store."
+    help_msg = "Register a charm name in the Store."
     overview = textwrap.dedent("""
         Register a charm name in the Store.
 
@@ -308,7 +308,7 @@ class ListRevisionsCommand(BaseCommand):
 class ReleaseCommand(BaseCommand):
     """Release a charm revision to specific channels."""
     name = 'release'
-    help_msg = "Relase a charm revision to one or more channels."
+    help_msg = "Release a charm revision to one or more channels."
     overview = textwrap.dedent("""
         Release a charm revision to the indicated channels (one or many).
 

--- a/charmcraft/commands/store/__init__.py
+++ b/charmcraft/commands/store/__init__.py
@@ -114,9 +114,9 @@ class WhoamiCommand(BaseCommand):
 class RegisterNameCommand(BaseCommand):
     """Register a name in the Store."""
     name = 'register'
-    help_msg = "Register a name in the Store."
+    help_msg = "Register a charm in the Store."
     overview = textwrap.dedent("""
-        Register a name in the Store.
+        Register a charm name in the Store.
 
         This is the first step when developing a charm, and needed only once
         for that charm.
@@ -140,7 +140,7 @@ class RegisterNameCommand(BaseCommand):
 class ListNamesCommand(BaseCommand):
     """List the charms registered in the Store."""
     name = 'names'
-    help_msg = "List the charm names registered the Store."
+    help_msg = "List the charm names registered in the Store."
     overview = textwrap.dedent("""
         List the names registered to the current Store user, together
         with each package's type, visibility and status.
@@ -251,9 +251,9 @@ class UploadCommand(BaseCommand):
 class ListRevisionsCommand(BaseCommand):
     """List existing revisions for a charm."""
     name = 'revisions'
-    help_msg = "List existing revisions for a package in the Store."
+    help_msg = "List existing revisions for a charm in the Store."
     overview = textwrap.dedent("""
-        List existing revisions for a package in the Store, along with the version
+        List existing revisions for a charm in the Store, along with the version
         and status for each, and when they were created.
 
         It will automatically take you through the login process if

--- a/charmcraft/helptexts.py
+++ b/charmcraft/helptexts.py
@@ -27,7 +27,7 @@ TERMINAL_WIDTH = 72
 GENERAL_SUMMARY = """
     Charmcraft provides a streamlined, powerful, opinionated and
     flexible tool to develop, package and manage the lifecycle of
-    Juju charm publication, particularly charms written within
+    Juju charm publication, particularly charms written with
     the Operator Framework.
 """
 # XXX Facundo 2020-09-10: we should add an extra (separated) line to the summary with:

--- a/charmcraft/helptexts.py
+++ b/charmcraft/helptexts.py
@@ -63,16 +63,18 @@ def _build_item(title, text, title_space):
     The title starts in column 4 with an extra ':'. The text starts in
     4 plus the title space; if too wide it's wrapped.
     """
-    text_space = TERMINAL_WIDTH - title_space - 4
+    # wrap the general text to the desired max width (discounting the space for the title,
+    # the first 4 spaces, the two spaces to separate title/text, and the ':'
+    text_space = TERMINAL_WIDTH - title_space - 7
     wrapped_lines = textwrap.wrap(text, text_space)
 
     # first line goes with the title at column 4
-    title += ':'
-    result = ["    {:<{title_space}s}{}".format(title, wrapped_lines[0], title_space=title_space)]
+    first = "    {:>{title_space}s}:  {}".format(title, wrapped_lines[0], title_space=title_space)
+    result = [first]
 
     # the rest (if any) still aligned but without title
     for line in wrapped_lines[1:]:
-        result.append(" " * (title_space + 4) + line)
+        result.append(" " * (title_space + 7) + line)
 
     return result
 
@@ -116,9 +118,6 @@ def get_full_help(command_groups, global_options):
 
     for title, _ in global_options:
         max_title_len = max(len(title), max_title_len)
-
-    # leave two spaces after longest title (also considering the ':')
-    max_title_len += 3
 
     global_lines = ["Global options:"]
     for title, text in global_options:
@@ -179,9 +178,6 @@ def get_detailed_help(command_groups, global_options):
     for title, _ in global_options:
         max_title_len = max(len(title), max_title_len)
 
-    # leave two spaces after longest title (also considering the ':')
-    max_title_len += 3
-
     global_lines = ["Global options:"]
     for title, text in global_options:
         global_lines.extend(_build_item(title, text, max_title_len))
@@ -241,8 +237,8 @@ def get_command_help(command_groups, command, arguments):
 
     textblocks.append("Summary:{}".format(textwrap.indent(command.overview, '    ')))
 
-    # column alignment is dictated by longest options title (plus ':' and two intercolumn spaces)
-    max_title_len = max(len(title) for title, text in options) + 3
+    # column alignment is dictated by longest options title
+    max_title_len = max(len(title) for title, text in options)
 
     # command options
     option_lines = ["Options:"]

--- a/charmcraft/helptexts.py
+++ b/charmcraft/helptexts.py
@@ -27,8 +27,8 @@ TERMINAL_WIDTH = 72
 GENERAL_SUMMARY = """
     Charmcraft provides a streamlined, powerful, opinionated and
     flexible tool to develop, package and manage the lifecycle of
-    Juju charm publication, focused particularly on charms written
-    within the Operator Framework.
+    Juju charm publication, particularly charms written within
+    the Operator Framework.
 """
 # XXX Facundo 2020-09-10: we should add an extra (separated) line to the summary with:
 #   See <url> for additional documentation.
@@ -41,7 +41,7 @@ Usage:
 """
 
 USAGE = """\
-Usage: charmcraft [OPTIONS] COMMAND [ARGS]...
+Usage: charmcraft [options] command [args]...
 Try '{fullcommand} -h' for help.
 
 Error: {error_message}

--- a/charmcraft/helptexts.py
+++ b/charmcraft/helptexts.py
@@ -65,7 +65,8 @@ def _build_item(title, text, title_space):
     """
     # wrap the general text to the desired max width (discounting the space for the title,
     # the first 4 spaces, the two spaces to separate title/text, and the ':'
-    text_space = TERMINAL_WIDTH - title_space - 7
+    not_title_space = 7
+    text_space = TERMINAL_WIDTH - title_space - not_title_space
     wrapped_lines = textwrap.wrap(text, text_space)
 
     # first line goes with the title at column 4
@@ -74,7 +75,7 @@ def _build_item(title, text, title_space):
 
     # the rest (if any) still aligned but without title
     for line in wrapped_lines[1:]:
-        result.append(" " * (title_space + 7) + line)
+        result.append(" " * (title_space + not_title_space) + line)
 
     return result
 

--- a/charmcraft/main.py
+++ b/charmcraft/main.py
@@ -240,7 +240,7 @@ class Dispatcher:
         mutexg = parser.add_mutually_exclusive_group()
         mutexg.add_argument(
             '-v', '--verbose', action='store_true', dest='verbose_' + context,
-            help="More verbose and show debug information.")
+            help="Show debug information and be more verbose.")
         mutexg.add_argument(
             '-q', '--quiet', action='store_true', dest='quiet_' + context,
             help="Only show warnings and errors, not progress.")

--- a/charmcraft/main.py
+++ b/charmcraft/main.py
@@ -240,10 +240,10 @@ class Dispatcher:
         mutexg = parser.add_mutually_exclusive_group()
         mutexg.add_argument(
             '-v', '--verbose', action='store_true', dest='verbose_' + context,
-            help="be more verbose and show debug information")
+            help="More verbose and show debug information.")
         mutexg.add_argument(
             '-q', '--quiet', action='store_true', dest='quiet_' + context,
-            help="only show warnings and errors, not progress")
+            help="Only show warnings and errors, not progress.")
 
     def _build_argument_parser(self, commands_groups):
         """Build the generic argument parser."""

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -61,7 +61,7 @@ def test_get_usage_message():
     """Check the general "usage" text."""
     text = get_usage_message('charmcraft build', 'bad parameter for the build')
     expected = textwrap.dedent("""\
-        Usage: charmcraft [OPTIONS] COMMAND [ARGS]...
+        Usage: charmcraft [options] command [args]...
         Try 'charmcraft build -h' for help.
 
         Error: bad parameter for the build
@@ -107,21 +107,21 @@ def test_default_help_text():
             the whole program.
 
         Global options:
-            -h, --help:        Show this help message and exit.
-            -q, --quiet:       Only show warnings and errors, not progress.
+                  -h, --help:  Show this help message and exit.
+                 -q, --quiet:  Only show warnings and errors, not progress.
 
         Starter commands:
-            cmd1:              Cmd help which is very long but whatever.
-            cmd3:              Extremely super crazy long super crazy long super
+                        cmd1:  Cmd help which is very long but whatever.
+                        cmd3:  Extremely super crazy long super crazy long super
                                crazy long super crazy long super crazy long
                                help.
             cmd6-really-long:  More help.
-            command-2:         Cmd help.
+                   command-2:  Cmd help.
 
         Commands can be classified as follows:
-            group1:            cmd6-really-long, command-2
-            group2:            cmd1, cmd3, cmd4, cmd5
-            group3:            cmd7
+                      group1:  cmd6-really-long, command-2
+                      group2:  cmd1, cmd3, cmd4, cmd5
+                      group3:  cmd7
 
         For more information about a command, run 'charmcraft help <command>'.
         For a summary of all commands, run 'charmcraft help --all'.
@@ -165,25 +165,25 @@ def test_detailed_help_text():
             the whole program.
 
         Global options:
-            -h, --help:        Show this help message and exit.
-            -q, --quiet:       Only show warnings and errors, not progress.
+                  -h, --help:  Show this help message and exit.
+                 -q, --quiet:  Only show warnings and errors, not progress.
 
         Commands can be classified as follows:
 
         Group 1 description:
             cmd6-really-long:  More help.
-            command-2:         Cmd help.
+                   command-2:  Cmd help.
 
         Group 3 help text:
-            cmd7:              More help.
+                        cmd7:  More help.
 
         Group 2 stuff:
-            cmd3:              Extremely super crazy long super crazy long super
+                        cmd3:  Extremely super crazy long super crazy long super
                                crazy long super crazy long super crazy long
                                help.
-            cmd4:              Some help.
-            cmd5:              More help.
-            cmd1:              Cmd help which is very long but whatever.
+                        cmd4:  Some help.
+                        cmd5:  More help.
+                        cmd1:  Cmd help which is very long but whatever.
 
         For more information about a specific command, run 'charmcraft help <command>'.
     """)
@@ -225,10 +225,10 @@ def test_command_help_text_no_parameters():
             Multiline!
 
         Options:
-            -h, --help:   Show this help message and exit.
+             -h, --help:  Show this help message and exit.
             -q, --quiet:  Only show warnings and errors, not progress.
-            --name:       The name of the charm.
-            --revision:   The revision to release (defaults to latest).
+                 --name:  The name of the charm.
+             --revision:  The revision to release (defaults to latest).
 
         See also:
             other-cmd-2
@@ -268,8 +268,8 @@ def test_command_help_text_with_parameters():
             Quite some long text.
 
         Options:
-            -h, --help:      Show this help message and exit.
-            --revision:      The revision to release (defaults to latest).
+                -h, --help:  Show this help message and exit.
+                --revision:  The revision to release (defaults to latest).
             --other-option:  Other option.
 
         See also:
@@ -307,7 +307,7 @@ def test_command_help_text_loneranger():
             Quite some long text.
 
         Options:
-            -h, --help:   Show this help message and exit.
+             -h, --help:  Show this help message and exit.
             -q, --quiet:  Only show warnings and errors, not progress.
 
         For a summary of all commands, run 'charmcraft help --all'.
@@ -357,7 +357,7 @@ def test_tool_exec_command_incorrect(sysargv):
         Dispatcher(sysargv, command_groups)
 
     expected = textwrap.dedent("""\
-        Usage: charmcraft [OPTIONS] COMMAND [ARGS]...
+        Usage: charmcraft [options] command [args]...
         Try 'charmcraft -h' for help.
 
         Error: no such command 'wrongcommand'
@@ -453,7 +453,7 @@ def test_tool_exec_command_wrong_option():
         Dispatcher(['somecommand', '--whatever'], command_groups)
 
     expected = textwrap.dedent("""\
-        Usage: charmcraft [OPTIONS] COMMAND [ARGS]...
+        Usage: charmcraft [options] command [args]...
         Try 'charmcraft somecommand -h' for help.
 
         Error: unrecognized arguments: --whatever
@@ -477,7 +477,7 @@ def test_tool_exec_command_bad_option_type():
         Dispatcher(['somecommand', '--number=foo'], command_groups)
 
     expected = textwrap.dedent("""\
-        Usage: charmcraft [OPTIONS] COMMAND [ARGS]...
+        Usage: charmcraft [options] command [args]...
         Try 'charmcraft somecommand -h' for help.
 
         Error: argument --number: invalid int value: 'foo'


### PR DESCRIPTION
Several small improvements in the help texts all around, plus a big change: now the columns are "aligned to the center".

This is how it now looks the general help, for example:

```
$ fades -r requirements.txt -m charmcraft 
Usage:
    charmcraft [help] <command>

Summary:
    Charmcraft provides a streamlined, powerful, opinionated and
    flexible tool to develop, package and manage the lifecycle of
    Juju charm publication, particularly charms written within
    the Operator Framework.

Global options:
       -h, --help:  Show this help message and exit.
    -v, --verbose:  More verbose and show debug information.
      -q, --quiet:  Only show warnings and errors, not progress.

Starter commands:
            build:  Build the charm.
             help:  Provide help on charmcraft usage.
             init:  Initialize a directory to be a charm project.
            names:  List the charm names registered in the Store.
         register:  Register a charm in the Store.
          release:  Relase a charm revision to one or more channels.
        revisions:  List existing revisions for a charm in the Store.
           status:  List released revisions of a package.
           upload:  Upload a charm file to the Store.
          version:  Show the version.

Commands can be classified as follows:
            basic:  build, help, init, version
            store:  login, logout, names, register, release, revisions,
                    status, upload, whoami

For more information about a command, run 'charmcraft help <command>'.
For a summary of all commands, run 'charmcraft help --all'.
```