### PR TITLE
Small improvements in preparation for the commands refactor branch.

### DIFF
--- a/charmcraft/main.py
+++ b/charmcraft/main.py
@@ -53,7 +53,8 @@ class HelpCommand(BaseCommand):
 
 # Collect commands in different groups, for easier human consumption. Note that this is not
 # declared in each command because it's much easier to do this separation/grouping in one
-# central place and not distributed in several classes/files.
+# central place and not distributed in several classes/files. Also note that order here is
+# important when lisgint commands and showing help.
 COMMAND_GROUPS = [
     ('basic', "Basic commands", [
         HelpCommand,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -173,7 +173,7 @@ def test_main_ok():
             retcode = main(['charmcraft', 'version'])
 
     assert retcode == 0
-    mh_mock.ended_ok.assert_called_once()
+    mh_mock.ended_ok.assert_called_once_with()
 
 
 def test_main_no_args():
@@ -183,7 +183,7 @@ def test_main_no_args():
             retcode = main()
 
     assert retcode == 1
-    mh_mock.ended_cmderror.assert_called_once()
+    assert mh_mock.ended_cmderror.call_count == 1
 
 
 def test_main_controlled_error():
@@ -218,7 +218,7 @@ def test_main_interrupted():
             retcode = main(['charmcraft', 'version'])
 
     assert retcode == 1
-    mh_mock.ended_interrupt.assert_called_once()
+    assert mh_mock.ended_interrupt.call_count == 1
 
 
 # --- Tests for the bootstrap version message


### PR DESCRIPTION
Specifically:

- improved a comment about `COMMAND_GROUPS`

- changed the `test_dispatcher_command_execution_ok` test to verify what it was verifying, but without needing to have access to the instantiated object

- fixed how the `test_main_ok/no_args/controlled_error/etc` tests were patching the message handler and asserting it was properly called
