### PR TITLE
Make use of the self.config alias

### DIFF
--- a/charmcraft/templates/init/src/charm.py.j2
+++ b/charmcraft/templates/init/src/charm.py.j2
@@ -21,7 +21,7 @@ class {{ class_name }}(CharmBase):
         self._stored.set_default(things=[])
 
     def _on_config_changed(self, _):
-        current = self.model.config["thing"]
+        current = self.config["thing"]
         if current not in self._stored.things:
             logger.debug("found a new thing: %r", current)
             self._stored.things.append(current)


### PR DESCRIPTION
This PR changes the template for new charms to make use of the more user-friendly "self.config" alias discussed here:

https://discourse.juju.is/t/first-steps-with-the-operator-framework/3006/20?u=erik-lonroth

It makes the charming experience somewhat more casual-programmer-friendly