### PR TITLE
(charmlibs) List libraries for a given charm

### DIFF
--- a/charmcraft/commands/store/__init__.py
+++ b/charmcraft/commands/store/__init__.py
@@ -853,9 +853,9 @@ class ListLibCommand(BaseCommand):
             charm_name = get_name_from_metadata()
             if charm_name is None:
                 raise CommandError(
-                    "Can't access name in 'metadata.yaml' file. The 'list-lib' command needs to "
-                    "be executed in a valid project's directory, or indicate the charm name with "
-                    "the --charm-name option.")
+                    "Can't access name in 'metadata.yaml' file. The 'list-lib' command must "
+                    "either be executed from a valid project directory, or specify a charm "
+                    "name using the --charm-name option.")
 
         # get tips from the Store
         store = Store()

--- a/charmcraft/commands/store/__init__.py
+++ b/charmcraft/commands/store/__init__.py
@@ -840,12 +840,15 @@ class ListLibCommand(BaseCommand):
 
     def fill_parser(self, parser):
         """Add own parameters to the general parser."""
-        parser.add_argument('--charm-name', help="The name of the charm")
+        parser.add_argument(
+            'name', nargs='?', help=(
+                "The name of the charm (optional, will get the name from"
+                "metadata.yaml if not given)"))
 
     def run(self, parsed_args):
         """Run the command."""
-        if parsed_args.charm_name:
-            charm_name = parsed_args.charm_name
+        if parsed_args.name:
+            charm_name = parsed_args.name
         else:
             charm_name = get_name_from_metadata()
             if charm_name is None:
@@ -860,7 +863,7 @@ class ListLibCommand(BaseCommand):
         libs_tips = store.get_libraries_tips(to_query)
 
         if not libs_tips:
-            logger.info("Nothing found.")
+            logger.info("No libraries found for charm %s.", charm_name)
             return
 
         headers = ['Library name', 'API', 'Patch']

--- a/charmcraft/commands/store/store.py
+++ b/charmcraft/commands/store/store.py
@@ -212,23 +212,29 @@ class Store:
         return result
 
     def get_libraries_tips(self, libraries):
-        """Get the tip details for several libraries at once."""
+        """Get the tip details for several libraries at once.
+
+        Each requested library can be specified in different ways: using the library id
+        or the charm and library names (both will pinpoint the library), but in the later
+        case the library name is optional (so all libraries for that charm will be
+        returned). Also, for all those cases, an API version can be specified.
+        """
         endpoint = '/v1/charm/libraries/bulk'
         payload = []
         for lib in libraries:
             if 'lib_id' in lib:
-                d = {
+                item = {
                     'library-id': lib['lib_id'],
                 }
             else:
-                d = {
+                item = {
                     'charm-name': lib['charm_name'],
                 }
                 if 'lib_name' in lib:
-                    d['library-name'] = lib['lib_name']
+                    item['library-name'] = lib['lib_name']
             if 'api' in lib:
-                d['api'] = lib['api']
-            payload.append(d)
+                item['api'] = lib['api']
+            payload.append(item)
         response = self._client.post(endpoint, payload)
         libraries = response['libraries']
         result = {(item['library-id'], item['api']): _build_library(item) for item in libraries}

--- a/charmcraft/commands/store/store.py
+++ b/charmcraft/commands/store/store.py
@@ -210,3 +210,26 @@ class Store:
         response = self._client.post(endpoint, payload)
         result = _build_library(response)
         return result
+
+    def get_libraries_tips(self, libraries):
+        """Get the tip details for several libraries at once."""
+        endpoint = '/v1/charm/libraries/bulk'
+        payload = []
+        for lib in libraries:
+            if 'lib_id' in lib:
+                d = {
+                    'library-id': lib['lib_id'],
+                }
+            else:
+                d = {
+                    'charm-name': lib['charm_name'],
+                }
+                if 'lib_name' in lib:
+                    d['library-name'] = lib['lib_name']
+            if 'api' in lib:
+                d['api'] = lib['api']
+            payload.append(d)
+        response = self._client.post(endpoint, payload)
+        libraries = response['libraries']
+        result = {(item['library-id'], item['api']): _build_library(item) for item in libraries}
+        return result

--- a/charmcraft/main.py
+++ b/charmcraft/main.py
@@ -89,7 +89,7 @@ COMMAND_GROUPS = [
         # release process, and show status
         store.ReleaseCommand, store.StatusCommand,
         # libraries support
-        store.CreateLibCommand, store.PublishLibCommand,
+        store.CreateLibCommand, store.PublishLibCommand, store.ListLibCommand,
     ]),
 ]
 

--- a/tests/commands/test_store_api.py
+++ b/tests/commands/test_store_api.py
@@ -22,7 +22,7 @@ from unittest.mock import patch, call, MagicMock
 import pytest
 from dateutil import parser
 
-from charmcraft.commands.store.store import Store
+from charmcraft.commands.store.store import Store, Library
 
 
 @pytest.fixture
@@ -518,3 +518,153 @@ def test_create_library_revision(client_mock):
     assert result_lib.lib_name == test_lib_name
     assert result_lib.charm_name == test_charm_name
     assert result_lib.patch == test_patch
+
+
+def test_get_tips_simple(client_mock):
+    """Get info for a lib, simple case with successful result."""
+    test_charm_name = 'test-charm-name'
+    test_lib_name = 'test-lib-name'
+    test_lib_id = 'test-lib-id'
+    test_api = 'test-api-version'
+    test_patch = 'test-patch-version'
+    test_content = 'test content with quite a lot of funny Python code :p'
+    test_hash = '1234'
+
+    store = Store()
+    client_mock.post.return_value = {'libraries': [{
+        'api': test_api,
+        'content': test_content,
+        'hash': test_hash,
+        'library-id': test_lib_id,
+        'library-name': test_lib_name,
+        'charm-name': test_charm_name,
+        'patch': test_patch,
+    }]}
+
+    query_info = [
+        {'lib_id': test_lib_id},
+    ]
+    result = store.get_libraries_tips(query_info)
+
+    payload = [
+        {'library-id': test_lib_id},
+    ]
+    assert client_mock.mock_calls == [
+        call.post('/v1/charm/libraries/bulk', payload),
+    ]
+    expected = {
+        (test_lib_id, test_api): Library(
+            api=test_api, content=test_content, content_hash=test_hash, lib_id=test_lib_id,
+            lib_name=test_lib_name, charm_name=test_charm_name, patch=test_patch),
+    }
+    assert result == expected
+
+
+def test_get_tips_empty(client_mock):
+    """Get info for a lib, with an empty response."""
+    test_lib_id = 'test-lib-id'
+
+    store = Store()
+    client_mock.post.return_value = {'libraries': []}
+
+    query_info = [
+        {'lib_id': test_lib_id},
+    ]
+    result = store.get_libraries_tips(query_info)
+
+    payload = [
+        {'library-id': test_lib_id},
+    ]
+    assert client_mock.mock_calls == [
+        call.post('/v1/charm/libraries/bulk', payload),
+    ]
+    assert result == {}
+
+
+def test_get_tips_several(client_mock):
+    """Get info for multiple libs at once."""
+    test_charm_name_1 = 'test-charm-name-1'
+    test_lib_name_1 = 'test-lib-name-1'
+    test_lib_id_1 = 'test-lib-id-1'
+    test_api_1 = 'test-api-version-1'
+    test_patch_1 = 'test-patch-version-1'
+    test_content_1 = 'test content with quite a lot of funny Python code :p'
+    test_hash_1 = '1234'
+
+    test_charm_name_2 = 'test-charm-name-2'
+    test_lib_name_2 = 'test-lib-name-2'
+    test_lib_id_2 = 'test-lib-id-2'
+    test_api_2 = 'test-api-version-2'
+    test_patch_2 = 'test-patch-version-2'
+    test_content_2 = 'more awesome Python code :)'
+    test_hash_2 = '5678'
+
+    store = Store()
+    client_mock.post.return_value = {'libraries': [{
+        'api': test_api_1,
+        'content': test_content_1,
+        'hash': test_hash_1,
+        'library-id': test_lib_id_1,
+        'library-name': test_lib_name_1,
+        'charm-name': test_charm_name_1,
+        'patch': test_patch_1,
+    }, {
+        'api': test_api_2,
+        'content': test_content_2,
+        'hash': test_hash_2,
+        'library-id': test_lib_id_2,
+        'library-name': test_lib_name_2,
+        'charm-name': test_charm_name_2,
+        'patch': test_patch_2,
+    }]}
+
+    query_info = [
+        {'lib_id': test_lib_id_1},
+        {'lib_id': test_lib_id_2},
+    ]
+    result = store.get_libraries_tips(query_info)
+
+    payload = [
+        {'library-id': test_lib_id_1},
+        {'library-id': test_lib_id_2},
+    ]
+    assert client_mock.mock_calls == [
+        call.post('/v1/charm/libraries/bulk', payload),
+    ]
+    expected = {
+        (test_lib_id_1, test_api_1): Library(
+            api=test_api_1, content=test_content_1, content_hash=test_hash_1, lib_id=test_lib_id_1,
+            lib_name=test_lib_name_1, charm_name=test_charm_name_1, patch=test_patch_1),
+        (test_lib_id_2, test_api_2): Library(
+            api=test_api_2, content=test_content_2, content_hash=test_hash_2, lib_id=test_lib_id_2,
+            lib_name=test_lib_name_2, charm_name=test_charm_name_2, patch=test_patch_2),
+    }
+    assert result == expected
+
+
+def test_get_tips_query_combinations(client_mock):
+    """Use all the combinations to specify what's queried."""
+    store = Store()
+    client_mock.post.return_value = {'libraries': []}
+
+    query_info = [
+        {'lib_id': 'test-lib-id-1'},
+        {'lib_id': 'test-lib-id-2', 'api': 2},
+        {'charm_name': 'test-charm-name-3'},
+        {'charm_name': 'test-charm-name-4', 'api': 4},
+        {'charm_name': 'test-charm-name-5', 'lib_name': 'test-lib-name-5'},
+        {'charm_name': 'test-charm-name-6', 'lib_name': 'test-lib-name-6', 'api': 6},
+    ]
+    store.get_libraries_tips(query_info)
+
+    payload = [
+        {'library-id': 'test-lib-id-1'},
+        {'library-id': 'test-lib-id-2', 'api': 2},
+        {'charm-name': 'test-charm-name-3'},
+        {'charm-name': 'test-charm-name-4', 'api': 4},
+        {'charm-name': 'test-charm-name-5', 'library-name': 'test-lib-name-5'},
+        {'charm-name': 'test-charm-name-6', 'library-name': 'test-lib-name-6', 'api': 6},
+    ]
+    assert client_mock.mock_calls == [
+        call.post('/v1/charm/libraries/bulk', payload),
+    ]

--- a/tests/commands/test_store_commands.py
+++ b/tests/commands/test_store_commands.py
@@ -32,6 +32,7 @@ from charmcraft.cmdbase import CommandError
 from charmcraft.commands.store import (
     _get_lib_info,
     CreateLibCommand,
+    ListLibCommand,
     ListNamesCommand,
     ListRevisionsCommand,
     LoginCommand,
@@ -1588,3 +1589,98 @@ def test_getlibinfo_libid_empty(tmp_path, monkeypatch):
         _get_lib_info(lib_path=test_path)
     assert str(err.value) == (
         "Library {} metadata field LIBID must be a non-empty ASCII string.".format(test_path))
+
+
+# -- tests for list libraries command
+
+def test_listlib_simple(caplog, store_mock):
+    """Happy path listing simple case."""
+    caplog.set_level(logging.INFO, logger="charmcraft.commands")
+
+    store_mock.get_libraries_tips.return_value = {
+        ('some-lib-id', 3): Library(
+            lib_id='some-lib-id', content=None, content_hash='abc', api=3, patch=7,
+            lib_name='testlib', charm_name='testcharm'),
+    }
+    args = Namespace(charm_name='testcharm')
+    ListLibCommand('group').run(args)
+
+    assert store_mock.mock_calls == [
+        call.get_libraries_tips([{'charm_name': 'testcharm'}]),
+    ]
+    expected = [
+        "Library name    API    Patch",
+        "testlib         3      7",
+    ]
+    assert expected == [rec.message for rec in caplog.records]
+
+
+def test_listlib_charm_from_metadata(caplog, store_mock):
+    """Happy path listing simple case."""
+    caplog.set_level(logging.INFO, logger="charmcraft.commands")
+
+    store_mock.get_libraries_tips.return_value = {}
+    args = Namespace(charm_name=None)
+    with patch('charmcraft.commands.store.get_name_from_metadata') as mock:
+        mock.return_value = 'testcharm'
+        ListLibCommand('group').run(args)
+
+    assert store_mock.mock_calls == [
+        call.get_libraries_tips([{'charm_name': 'testcharm'}]),
+    ]
+
+
+def test_listlib_name_from_metadata_problem(store_mock):
+    """The metadata wasn't there to get the name."""
+    args = Namespace(charm_name=None)
+    with patch('charmcraft.commands.store.get_name_from_metadata') as mock:
+        mock.return_value = None
+        with pytest.raises(CommandError) as cm:
+            ListLibCommand('group').run(args)
+
+        assert str(cm.value) == (
+            "Can't access name in 'metadata.yaml' file. The 'list-lib' command needs to "
+            "be executed in a valid project's directory, or indicate the charm name with "
+            "the --charm-name option.")
+
+
+def test_listlib_empty(caplog, store_mock):
+    """Nothing found in the store for the specified charm."""
+    caplog.set_level(logging.INFO, logger="charmcraft.commands")
+
+    store_mock.get_libraries_tips.return_value = {}
+    args = Namespace(charm_name='testcharm')
+    ListLibCommand('group').run(args)
+
+    expected = "Nothing found."
+    assert [expected] == [rec.message for rec in caplog.records]
+
+
+def test_listlib_properly_sorted(caplog, store_mock):
+    """Check the sorting of the list."""
+    caplog.set_level(logging.INFO, logger="charmcraft.commands")
+
+    store_mock.get_libraries_tips.return_value = {
+        ('lib-id-2', 3): Library(
+            lib_id='lib-id-1', content=None, content_hash='abc', api=3, patch=7,
+            lib_name='testlib-2', charm_name='testcharm'),
+        ('lib-id-2', 2): Library(
+            lib_id='lib-id-1', content=None, content_hash='abc', api=2, patch=8,
+            lib_name='testlib-2', charm_name='testcharm'),
+        ('lib-id-1', 5): Library(
+            lib_id='lib-id-1', content=None, content_hash='abc', api=5, patch=124,
+            lib_name='testlib-1', charm_name='testcharm'),
+    }
+    args = Namespace(charm_name='testcharm')
+    ListLibCommand('group').run(args)
+
+    assert store_mock.mock_calls == [
+        call.get_libraries_tips([{'charm_name': 'testcharm'}]),
+    ]
+    expected = [
+        "Library name    API    Patch",
+        "testlib-1       5      124",
+        "testlib-2       2      8",
+        "testlib-2       3      7",
+    ]
+    assert expected == [rec.message for rec in caplog.records]

--- a/tests/commands/test_store_commands.py
+++ b/tests/commands/test_store_commands.py
@@ -1639,8 +1639,8 @@ def test_listlib_name_from_metadata_problem(store_mock):
             ListLibCommand('group').run(args)
 
         assert str(cm.value) == (
-            "Can't access name in 'metadata.yaml' file. The 'list-lib' command needs to "
-            "be executed in a valid project's directory, or indicate the charm name with "
+            "Can't access name in 'metadata.yaml' file. The 'list-lib' command must either be "
+            "executed from a valid project directory, or specify a charm name using "
             "the --charm-name option.")
 
 

--- a/tests/commands/test_store_commands.py
+++ b/tests/commands/test_store_commands.py
@@ -1602,7 +1602,7 @@ def test_listlib_simple(caplog, store_mock):
             lib_id='some-lib-id', content=None, content_hash='abc', api=3, patch=7,
             lib_name='testlib', charm_name='testcharm'),
     }
-    args = Namespace(charm_name='testcharm')
+    args = Namespace(name='testcharm')
     ListLibCommand('group').run(args)
 
     assert store_mock.mock_calls == [
@@ -1620,7 +1620,7 @@ def test_listlib_charm_from_metadata(caplog, store_mock):
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
     store_mock.get_libraries_tips.return_value = {}
-    args = Namespace(charm_name=None)
+    args = Namespace(name=None)
     with patch('charmcraft.commands.store.get_name_from_metadata') as mock:
         mock.return_value = 'testcharm'
         ListLibCommand('group').run(args)
@@ -1632,7 +1632,7 @@ def test_listlib_charm_from_metadata(caplog, store_mock):
 
 def test_listlib_name_from_metadata_problem(store_mock):
     """The metadata wasn't there to get the name."""
-    args = Namespace(charm_name=None)
+    args = Namespace(name=None)
     with patch('charmcraft.commands.store.get_name_from_metadata') as mock:
         mock.return_value = None
         with pytest.raises(CommandError) as cm:
@@ -1649,10 +1649,10 @@ def test_listlib_empty(caplog, store_mock):
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
     store_mock.get_libraries_tips.return_value = {}
-    args = Namespace(charm_name='testcharm')
+    args = Namespace(name='testcharm')
     ListLibCommand('group').run(args)
 
-    expected = "Nothing found."
+    expected = "No libraries found for charm testcharm."
     assert [expected] == [rec.message for rec in caplog.records]
 
 
@@ -1671,7 +1671,7 @@ def test_listlib_properly_sorted(caplog, store_mock):
             lib_id='lib-id-1', content=None, content_hash='abc', api=5, patch=124,
             lib_name='testlib-1', charm_name='testcharm'),
     }
-    args = Namespace(charm_name='testcharm')
+    args = Namespace(name='testcharm')
     ListLibCommand('group').run(args)
 
     assert store_mock.mock_calls == [


### PR DESCRIPTION

This adds the command itself, and the supporting method in the store layer.

For ListLibCommand:

- it can run standalone, or with a given charm name

- when standalone, it will try to access metadata.yaml, and if there it will list all libraries for that charm

- if a charm name is indicated, will just list all libraries for that charm

In the store layer:

- a new multi-functional `get_libraries_tips` is added

- it's bulk, and supports all the flexibility in the store for each query:

    - just the library id (will get the tip for that library)

    - just the charm name (will get the tip for all libraries of that charm)

    - charm and library names (alternative identification of a specific library)

    - for any of those cases, `api` is supported (it will give the tip for that API version)

- note that this is current more flexible than needed for ListLibCommand itself, but more of this will be used in the FetchLibCommand (in the next branch)
