### PR TITLE
Avoid a duplicated -h/--help option when getting help for a command.

### DIFF
--- a/charmcraft/main.py
+++ b/charmcraft/main.py
@@ -62,7 +62,7 @@ class HelpCommand(BaseCommand):
         else:
             cmd_class, group = all_commands[parsed_args.command_to_help]
             cmd = cmd_class(group)
-            parser = CustomArgumentParser(prog=cmd.name)
+            parser = CustomArgumentParser(prog=cmd.name, add_help=False)
             cmd.fill_parser(parser)
             help_text = get_command_help(parser, cmd)
         raise CommandError(help_text, argsparsing=True)

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -337,7 +337,7 @@ def test_tool_exec_full_help(sysargv):
     # check the given information to the builder
     args = mock.call_args[0]
     assert args[0] == COMMAND_GROUPS
-    assert {x[0] for x in args[1]} == {'-h, --help', '-v, --verbose', '-q, --quiet'}
+    assert sorted(x[0] for x in args[1]) == ['-h, --help', '-q, --quiet', '-v, --verbose']
 
     # check the result of the full help builder is what is shown
     assert error.argsparsing
@@ -389,7 +389,7 @@ def test_tool_exec_command_dash_help_simple(help_option):
     args = mock.call_args[0]
     assert args[0] == COMMAND_GROUPS
     assert args[1].__class__ == cmd
-    assert {x[0] for x in args[2]} == {'-h, --help', '-v, --verbose', '-q, --quiet'}
+    assert sorted(x[0] for x in args[2]) == ['-h, --help', '-q, --quiet', '-v, --verbose']
 
     # check the result of the full help builder is what is shown
     assert error.argsparsing
@@ -414,7 +414,7 @@ def test_tool_exec_command_dash_help_reverse(help_option):
     args = mock.call_args[0]
     assert args[0] == COMMAND_GROUPS
     assert args[1].__class__ == cmd
-    assert {x[0] for x in args[2]} == {'-h, --help', '-v, --verbose', '-q, --quiet'}
+    assert sorted(x[0] for x in args[2]) == ['-h, --help', '-q, --quiet', '-v, --verbose']
 
     # check the result of the full help builder is what is shown
     assert error.argsparsing
@@ -443,7 +443,8 @@ def test_tool_exec_command_dash_help_missing_params(help_option):
     args = mock.call_args[0]
     assert args[0] == COMMAND_GROUPS
     assert args[1].__class__ == cmd
-    assert {x[0] for x in args[2]} == {'-h, --help', '-v, --verbose', '-q, --quiet', 'mandatory'}
+    assert sorted(x[0] for x in args[2]) == [
+        '-h, --help', '-q, --quiet', '-v, --verbose', 'mandatory']
 
     # check the result of the full help builder is what is shown
     assert error.argsparsing
@@ -507,7 +508,7 @@ def test_tool_exec_help_command_on_command_ok():
     args = mock.call_args[0]
     assert args[0] == COMMAND_GROUPS
     assert args[1].__class__ == VersionCommand
-    assert {x[0] for x in args[2]} == {'-h, --help', '-v, --verbose', '-q, --quiet'}
+    assert sorted(x[0] for x in args[2]) == ['-h, --help', '-q, --quiet', '-v, --verbose']
 
     # check the result of the full help builder is what is shown
     assert error.argsparsing
@@ -538,16 +539,16 @@ def test_tool_exec_help_command_on_command_complex():
     args = mock.call_args[0]
     assert args[0] == COMMAND_GROUPS
     assert args[1].__class__ == cmd
-    expected_options = {
+    expected_options = [
+        '--option1',
         '-h, --help',
-        '-v, --verbose',
+        '-o2, --option2',
         '-q, --quiet',
+        '-v, --verbose',
         'param1',
         'param2',
-        '--option1',
-        '-o2, --option2',
-    }
-    assert {x[0] for x in args[2]} == expected_options
+    ]
+    assert sorted(x[0] for x in args[2]) == expected_options
 
     # check the result of the full help builder is what is shown
     assert error.argsparsing
@@ -585,7 +586,7 @@ def test_tool_exec_help_command_all():
     # check the given information to the builder
     args = mock.call_args[0]
     assert args[0] == COMMAND_GROUPS
-    assert {x[0] for x in args[1]} == {'-h, --help', '-v, --verbose', '-q, --quiet'}
+    assert sorted(x[0] for x in args[1]) == ['-h, --help', '-q, --quiet', '-v, --verbose']
 
     # check the result of the full help builder is what is shown
     assert error.argsparsing


### PR DESCRIPTION
This was because we had two `-h/--help` options, one which is the global one (that works for the tool in general and for each command, as with any global option), and other specific for the command added by `ArgumentParser`. The fix is to tell `ArgumentParser` to not automatically add a help option.

Regarding tests, no new one was needed, just improved the current ones to stop hiding duplicates.