### PR TITLE
Add coverage to unit tests by default in 'charmcraft init'

### DIFF
--- a/charmcraft/templates/init/requirements-dev.txt.j2
+++ b/charmcraft/templates/init/requirements-dev.txt.j2
@@ -1,2 +1,3 @@
 -r requirements.txt
+coverage
 flake8

--- a/charmcraft/templates/init/run_tests.j2
+++ b/charmcraft/templates/init/run_tests.j2
@@ -13,4 +13,5 @@ else
 fi
 
 flake8
-python3 -m unittest -v "$@"
+coverage run --source=src -m unittest -v "$@"
+coverage report -m

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 -r requirements.txt
 
+coverage
 pytest == 5.4.1
 flake8 == 3.7.9
 ops >= 0.8.0


### PR DESCRIPTION
I think it'd be nice to include a coverage report in the default unit test output from what's generated by 'charmcraft init'. This PR adds that.