### PR TITLE
Exercise command parsers.

### DIFF
--- a/charmcraft/commands/init.py
+++ b/charmcraft/commands/init.py
@@ -80,7 +80,7 @@ class InitCommand(BaseCommand):
             help="A comma-separated list of supported platform series;"
             " defaults to 'kubernetes'")
         parser.add_argument(
-            "-f", "--force", type="store_true",
+            "-f", "--force", action="store_true",
             help="Initialize even if the directory is not empty (will not overwrite files)")
 
     def run(self, args):

--- a/charmcraft/main.py
+++ b/charmcraft/main.py
@@ -52,6 +52,7 @@ class HelpCommand(BaseCommand):
         Unlike other commands, this one receives an extra parameter with all commands,
         to validate if the help requested is on a valid one, or even parse its data.
         """
+        retcode = 0
         if parsed_args.command_to_help is None or parsed_args.command_to_help == self.name:
             # help on no command in particular, get general text
             help_text = get_general_help(detailed=parsed_args.all)
@@ -59,13 +60,14 @@ class HelpCommand(BaseCommand):
             # asked help on a command that doesn't exist
             msg = "no such command {!r}".format(parsed_args.command_to_help)
             help_text = helptexts.get_usage_message('charmcraft', msg)
+            retcode = 1
         else:
             cmd_class, group = all_commands[parsed_args.command_to_help]
             cmd = cmd_class(group)
             parser = CustomArgumentParser(prog=cmd.name)
             cmd.fill_parser(parser)
             help_text = get_command_help(parser, cmd)
-        raise CommandError(help_text, argsparsing=True)
+        raise CommandError(help_text, argsparsing=True, retcode=retcode)
 
 
 # Collect commands in different groups, for easier human consumption. Note that this is not

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -369,6 +369,7 @@ def test_tool_exec_command_incorrect(sysargv):
     error = cm.value
     assert error.argsparsing
     assert str(error) == expected
+    assert error.retcode == 1
 
 
 @pytest.mark.parametrize('help_option', ['-h', '--help'])
@@ -394,6 +395,7 @@ def test_tool_exec_command_dash_help_simple(help_option):
     # check the result of the full help builder is what is shown
     assert error.argsparsing
     assert str(error) == "test help"
+    assert error.retcode == 0
 
 
 @pytest.mark.parametrize('help_option', ['-h', '--help'])
@@ -419,6 +421,7 @@ def test_tool_exec_command_dash_help_reverse(help_option):
     # check the result of the full help builder is what is shown
     assert error.argsparsing
     assert str(error) == "test help"
+    assert error.retcode == 0
 
 
 @pytest.mark.parametrize('help_option', ['-h', '--help'])
@@ -448,6 +451,7 @@ def test_tool_exec_command_dash_help_missing_params(help_option):
     # check the result of the full help builder is what is shown
     assert error.argsparsing
     assert str(error) == "test help"
+    assert error.retcode == 0
 
 
 def test_tool_exec_command_wrong_option():
@@ -467,6 +471,7 @@ def test_tool_exec_command_wrong_option():
     error = cm.value
     assert error.argsparsing
     assert str(error) == expected
+    assert error.retcode == 1
 
 
 def test_tool_exec_command_bad_option_type():
@@ -491,6 +496,7 @@ def test_tool_exec_command_bad_option_type():
     error = cm.value
     assert error.argsparsing
     assert str(error) == expected
+    assert error.retcode == 1
 
 
 def test_tool_exec_help_command_on_command_ok():
@@ -512,6 +518,7 @@ def test_tool_exec_help_command_on_command_ok():
     # check the result of the full help builder is what is shown
     assert error.argsparsing
     assert str(error) == "test help"
+    assert error.retcode == 0
 
 
 def test_tool_exec_help_command_on_command_complex():
@@ -552,6 +559,7 @@ def test_tool_exec_help_command_on_command_complex():
     # check the result of the full help builder is what is shown
     assert error.argsparsing
     assert str(error) == "test help"
+    assert error.retcode == 0
 
 
 def test_tool_exec_help_command_on_command_wrong():
@@ -570,6 +578,7 @@ def test_tool_exec_help_command_on_command_wrong():
     # check the result of the full help builder is what is shown
     assert error.argsparsing
     assert str(error) == "test help"
+    assert error.retcode == 1
 
 
 def test_tool_exec_help_command_all():
@@ -590,3 +599,4 @@ def test_tool_exec_help_command_all():
     # check the result of the full help builder is what is shown
     assert error.argsparsing
     assert str(error) == "test help"
+    assert error.retcode == 0


### PR DESCRIPTION
Before this change, asking for help would always return with error.
This made testing actually asking for help hard, so we didn't, so we
never exercised the actual command parser, so a bug snuck in. This
changes things so that help returns with error only when actually in
error, and adds a test that asks for help over all commands, meaning
we exercise all the parsers, so we would actually catch this bug.

Fixes: #210