### PR TITLE
improve the user-agent string sent to servers

### DIFF
--- a/charmcraft/commands/store/client.py
+++ b/charmcraft/commands/store/client.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Canonical Ltd.
+# Copyright 2020-2021 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
 
 import logging
 import os
+import platform
 import webbrowser
 from http.cookiejar import MozillaCookieJar
 
@@ -46,9 +47,10 @@ STORAGE_BASE_URL = 'https://storage.staging.snapcraftcontent.com'
 
 def build_user_agent():
     """Build the charmcraft's user agent."""
-    # XXX Facundo 2020-06-29: we need to include here at least the platform, maybe
-    # architecture, etc. Related: issue #74.
-    return "charmcraft/{}".format(__version__)
+    return "charmcraft/{} ({}; {}) python/{}".format(__version__,
+                                                     platform.system(),
+                                                     platform.machine(),
+                                                     platform.python_version())
 
 
 def visit_page_with_browser(visit_url):

--- a/charmcraft/commands/store/client.py
+++ b/charmcraft/commands/store/client.py
@@ -65,8 +65,8 @@ def _get_os_platform(filepath=pathlib.Path("/etc/os-release")):
         except FileNotFoundError:
             logger.debug("Unable to locate 'os-release' file, using default values")
         finally:
-            system = os_release.get("NAME", "Unknown")
-            release = os_release.get("VERSION_ID", "Unknown Version")
+            system = os_release.get("NAME", system)
+            release = os_release.get("VERSION_ID", release)
 
     return "{}/{} ({})".format(system, release, machine)
 

--- a/tests/commands/test_store_client.py
+++ b/tests/commands/test_store_client.py
@@ -98,7 +98,7 @@ def test_get_os_platform_linux(tmp_path):
                     """),
                 file=release_file,
             )
-        os_platform = _get_os_platform(filepath)
+        os_platform = _get_os_platform(str(filepath))
     assert os_platform == "Ubuntu/20.04 (x86_64)"
 
 

--- a/tests/commands/test_store_client.py
+++ b/tests/commands/test_store_client.py
@@ -59,6 +59,7 @@ def test_useragent_linux(monkeypatch):
 
 def test_useragent_windows():
     with patch('charmcraft.commands.store.client.__version__', '1.2.3'), \
+            patch('charmcraft.commands.store.client._is_ci_env', return_value=False), \
             patch('platform.system', return_value='Windows'), \
             patch('platform.release', return_value='10'), \
             patch('platform.machine', return_value='AMD64'), \
@@ -72,13 +73,13 @@ def test_is_ci_env(monkeypatch):
     for var in env_vars:
         monkeypatch.setenv(var, "1")
         assert _is_ci_env()
-        monkeypatch.delenv(var)
-        assert not _is_ci_env()
 
 
 def test_get_os_platform_linux(tmp_path):
     filepath = (tmp_path / "os-release")
-    with patch('platform.machine', return_value='x86_64'), open(filepath, "w") as release_file:
+    # XXX: Delete the string conversion on the filepath when Python 3.5 support is dropped.
+    with patch('platform.machine', return_value='x86_64'), \
+            open(str(filepath), "w") as release_file:
         print(
             dedent("""\
             NAME="Ubuntu"
@@ -96,7 +97,8 @@ def test_get_os_platform_linux(tmp_path):
                 """),
             file=release_file,
         )
-    assert _get_os_platform(filepath) == "Ubuntu/20.04 (x86_64)"
+        os_platform = _get_os_platform(filepath)
+    assert os_platform == "Ubuntu/20.04 (x86_64)"
 
 
 def test_get_os_platform_windows():

--- a/tests/commands/test_store_client.py
+++ b/tests/commands/test_store_client.py
@@ -78,7 +78,8 @@ def test_is_ci_env(monkeypatch):
 def test_get_os_platform_linux(tmp_path):
     filepath = (tmp_path / "os-release")
     # XXX: Delete the string conversion on the filepath when Python 3.5 support is dropped.
-    with patch('platform.machine', return_value='x86_64'):
+    with patch('platform.machine', return_value='x86_64'), \
+            patch('platform.system', return_value='Linux'):
         with open(str(filepath), "w") as release_file:
             print(
                 dedent("""\

--- a/tests/commands/test_store_client.py
+++ b/tests/commands/test_store_client.py
@@ -48,12 +48,12 @@ def test_useragent_linux(monkeypatch):
     monkeypatch.setenv("TRAVIS_TESTING", "1")
     with patch('charmcraft.commands.store.client.__version__', '1.2.3'), \
             patch('charmcraft.commands.store.client._get_os_platform',
-                  return_value="Arch Linux/Unknown Version (x86_64)"), \
+                  return_value="Arch Linux/5.10.10-arch1-1 (x86_64)"), \
             patch('platform.system', return_value='Linux'), \
             patch('platform.machine', return_value='x86_64'), \
             patch('platform.python_version', return_value='3.9.1'):
         ua = build_user_agent()
-    assert ua == "charmcraft/1.2.3 (testing) Arch Linux/Unknown Version (x86_64) python/3.9.1"
+    assert ua == "charmcraft/1.2.3 (testing) Arch Linux/5.10.10-arch1-1 (x86_64) python/3.9.1"
 
 
 def test_useragent_windows(monkeypatch):

--- a/tests/commands/test_store_client.py
+++ b/tests/commands/test_store_client.py
@@ -21,6 +21,7 @@ import logging
 import os
 from http.cookiejar import MozillaCookieJar, Cookie
 from unittest.mock import patch
+from textwrap import dedent
 
 import pytest
 from macaroonbakery import httpbakery
@@ -36,19 +37,74 @@ from charmcraft.commands.store.client import (
     _storage_push,
     build_user_agent,
     visit_page_with_browser,
+    _is_ci_env,
+    _get_os_platform,
 )
 
 
 # --- General tests
 
-def test_useragent():
+def test_useragent_linux(monkeypatch):
     """Construct a user-agent for requests."""
+    monkeypatch.setenv("TRAVIS_TESTING", "1")
     with patch('charmcraft.commands.store.client.__version__', '1.2.3'), \
+            patch('charmcraft.commands.store.client._get_os_platform',
+                  return_value="Arch Linux/Unknown Version (x86_64)"), \
             patch('platform.system', return_value='Linux'), \
             patch('platform.machine', return_value='x86_64'), \
             patch('platform.python_version', return_value='3.9.1'):
         ua = build_user_agent()
-    assert ua == "charmcraft/1.2.3 (Linux; x86_64) python/3.9.1"
+    assert ua == "charmcraft/1.2.3 (testing) Arch Linux/Unknown Version (x86_64) python/3.9.1"
+
+
+def test_useragent_windows():
+    with patch('charmcraft.commands.store.client.__version__', '1.2.3'), \
+            patch('platform.system', return_value='Windows'), \
+            patch('platform.release', return_value='10'), \
+            patch('platform.machine', return_value='AMD64'), \
+            patch('platform.python_version', return_value='3.9.1'):
+        ua = build_user_agent()
+    assert ua == "charmcraft/1.2.3  Windows/10 (AMD64) python/3.9.1"
+
+
+def test_is_ci_env(monkeypatch):
+    env_vars = ["TRAVIS_TESTING", "AUTOPKGTEST_TMP"]
+    for var in env_vars:
+        monkeypatch.setenv(var, "1")
+        assert _is_ci_env()
+        monkeypatch.delenv(var)
+        assert not _is_ci_env()
+
+
+def test_get_os_platform_linux(tmp_path):
+    filepath = (tmp_path / "os-release")
+    with patch('platform.machine', return_value='x86_64'), open(filepath, "w") as release_file:
+        print(
+            dedent("""\
+            NAME="Ubuntu"
+            VERSION="20.04.1 LTS (Focal Fossa)"
+            ID=ubuntu
+            ID_LIKE=debian
+            PRETTY_NAME="Ubuntu 20.04.1 LTS"
+            VERSION_ID="20.04"
+            HOME_URL="https://www.ubuntu.com/"
+            SUPPORT_URL="https://help.ubuntu.com/"
+            BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
+            PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
+            VERSION_CODENAME=focal
+            UBUNTU_CODENAME=focal
+                """),
+            file=release_file,
+        )
+    assert _get_os_platform(filepath) == "Ubuntu/20.04 (x86_64)"
+
+
+def test_get_os_platform_windows():
+    with patch('platform.system', return_value='Windows'), \
+            patch('platform.release', return_value='10'), \
+            patch('platform.machine', return_value='AMD64'):
+        os_platform = _get_os_platform()
+    assert os_platform == "Windows/10 (AMD64)"
 
 
 # --- AuthHolder tests

--- a/tests/commands/test_store_client.py
+++ b/tests/commands/test_store_client.py
@@ -78,25 +78,25 @@ def test_is_ci_env(monkeypatch):
 def test_get_os_platform_linux(tmp_path):
     filepath = (tmp_path / "os-release")
     # XXX: Delete the string conversion on the filepath when Python 3.5 support is dropped.
-    with patch('platform.machine', return_value='x86_64'), \
-            open(str(filepath), "w") as release_file:
-        print(
-            dedent("""\
-            NAME="Ubuntu"
-            VERSION="20.04.1 LTS (Focal Fossa)"
-            ID=ubuntu
-            ID_LIKE=debian
-            PRETTY_NAME="Ubuntu 20.04.1 LTS"
-            VERSION_ID="20.04"
-            HOME_URL="https://www.ubuntu.com/"
-            SUPPORT_URL="https://help.ubuntu.com/"
-            BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
-            PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
-            VERSION_CODENAME=focal
-            UBUNTU_CODENAME=focal
-                """),
-            file=release_file,
-        )
+    with patch('platform.machine', return_value='x86_64'):
+        with open(str(filepath), "w") as release_file:
+            print(
+                dedent("""\
+                NAME="Ubuntu"
+                VERSION="20.04.1 LTS (Focal Fossa)"
+                ID=ubuntu
+                ID_LIKE=debian
+                PRETTY_NAME="Ubuntu 20.04.1 LTS"
+                VERSION_ID="20.04"
+                HOME_URL="https://www.ubuntu.com/"
+                SUPPORT_URL="https://help.ubuntu.com/"
+                BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
+                PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
+                VERSION_CODENAME=focal
+                UBUNTU_CODENAME=focal
+                    """),
+                file=release_file,
+            )
         os_platform = _get_os_platform(filepath)
     assert os_platform == "Ubuntu/20.04 (x86_64)"
 

--- a/tests/commands/test_store_client.py
+++ b/tests/commands/test_store_client.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Canonical Ltd.
+# Copyright 2020-2021 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -42,9 +42,13 @@ from charmcraft.commands.store.client import (
 # --- General tests
 
 def test_useragent():
-    with patch('charmcraft.commands.store.client.__version__', '1.2.3'):
+    """Construct a user-agent for requests."""
+    with patch('charmcraft.commands.store.client.__version__', '1.2.3'), \
+            patch('platform.system', return_value='Linux'), \
+            patch('platform.machine', return_value='x86_64'), \
+            patch('platform.python_version', return_value='3.9.1'):
         ua = build_user_agent()
-    assert ua == "charmcraft/1.2.3"
+    assert ua == "charmcraft/1.2.3 (Linux; x86_64) python/3.9.1"
 
 
 # --- AuthHolder tests


### PR DESCRIPTION
Extend the current user-agent to include the current system, machine
arch and python version, using conventions from the MDN docs. The
user-agent test has been updated to mock these values though it is a bit
ugly to do so, I don't exactly like the patching of `platform` so there may
be a better/cleaner way to handle that.

Also update copyright dates in files modified.

`459 passed, 8 warnings in 5.12s`

fixes #74

Happy to rework this however is desired!