### PR TITLE
Pass the config to all commands.

### DIFF
--- a/charmcraft/cmdbase.py
+++ b/charmcraft/cmdbase.py
@@ -56,8 +56,9 @@ class BaseCommand:
     overview = None
     common = False
 
-    def __init__(self, group):
+    def __init__(self, group, config):
         self.group = group
+        self.config = config
 
     def fill_parser(self, parser):
         """Specify command's specific parameters.

--- a/charmcraft/main.py
+++ b/charmcraft/main.py
@@ -66,7 +66,7 @@ class HelpCommand(BaseCommand):
             retcode = 1
         else:
             cmd_class, group = all_commands[parsed_args.command_to_help]
-            cmd = cmd_class(group)
+            cmd = cmd_class(group, None)
             parser = CustomArgumentParser(prog=cmd.name, add_help=False)
             cmd.fill_parser(parser)
             help_text = get_command_help(parser, cmd)
@@ -184,7 +184,7 @@ class Dispatcher:
     def _load_command(self, command_name, cmd_args, charmcraft_config):
         """Load a command."""
         cmd_class, group = self.commands[command_name]
-        cmd = cmd_class(group)
+        cmd = cmd_class(group, charmcraft_config)
 
         # load and parse the command specific options/params
         parser = CustomArgumentParser(prog=cmd.name)

--- a/tests/commands/test_init.py
+++ b/tests/commands/test_init.py
@@ -28,30 +28,29 @@ from charmcraft.utils import S_IXALL
 from tests.test_infra import pep8_test, get_python_filepaths, pep257_test
 
 
-def test_init_pep257(tmp_path):
-    cmd = InitCommand('group')
-    cmd.run(Namespace(path=tmp_path, name='my-charm', author='J Doe', series='k8s', force=False))
+def test_init_pep257(tmp_path, config):
+    cmd = InitCommand('group', config)
+    cmd.run(Namespace(name='my-charm', author='J Doe', series='k8s', force=False))
     paths = get_python_filepaths(roots=[str(tmp_path / "src")], python_paths=[])
     pep257_test(paths)
 
 
-def test_init_pep8(tmp_path, *, author="J Doe"):
-    cmd = InitCommand('group')
-    cmd.run(Namespace(path=tmp_path, name='my-charm', author=author, series='k8s', force=False))
+def test_init_pep8(tmp_path, config, *, author="J Doe"):
+    cmd = InitCommand('group', config)
+    cmd.run(Namespace(name='my-charm', author=author, series='k8s', force=False))
     paths = get_python_filepaths(
         roots=[str(tmp_path / "src"), str(tmp_path / "tests")],
         python_paths=[])
     pep8_test(paths)
 
 
-def test_init_non_ascii_author(tmp_path):
-    test_init_pep8(tmp_path, author="فلانة الفلانية")
+def test_init_non_ascii_author(tmp_path, config):
+    test_init_pep8(tmp_path, config, author="فلانة الفلانية")
 
 
-def test_all_the_files(tmp_path):
-    cmd = InitCommand('group')
-    cmd.run(Namespace(path=tmp_path, name='my-charm', author="ಅಪರಿಚಿತ ವ್ಯಕ್ತಿ", series='k8s',
-                      force=False))
+def test_all_the_files(tmp_path, config):
+    cmd = InitCommand('group', config)
+    cmd.run(Namespace(name='my-charm', author="ಅಪರಿಚಿತ ವ್ಯಕ್ತಿ", series='k8s', force=False))
     assert sorted(str(p.relative_to(tmp_path)) for p in tmp_path.glob("**/*")) == [
         ".flake8",
         ".jujuignore",
@@ -71,13 +70,12 @@ def test_all_the_files(tmp_path):
     ]
 
 
-def test_force(tmp_path):
-    cmd = InitCommand('group')
+def test_force(tmp_path, config):
+    cmd = InitCommand('group', config)
     tmp_file = tmp_path / 'README.md'
     with tmp_file.open('w') as f:
         f.write('This is a nonsense readme')
-    cmd.run(Namespace(path=tmp_path, name='my-charm', author="ಅಪರಿಚಿತ ವ್ಯಕ್ತಿ", series='k8s',
-                      force=True))
+    cmd.run(Namespace(name='my-charm', author="ಅಪರಿಚಿತ ವ್ಯಕ್ತಿ", series='k8s', force=True))
 
     # Check that init ran
     assert (tmp_path / 'LICENSE').exists()
@@ -87,21 +85,20 @@ def test_force(tmp_path):
         assert f.read() == 'This is a nonsense readme'
 
 
-def test_bad_name(tmp_path):
-    cmd = InitCommand('group')
+def test_bad_name(config):
+    cmd = InitCommand('group', config)
     with pytest.raises(CommandError):
-        cmd.run(Namespace(path=tmp_path, name='1234', author="שראלה ישראל", series='k8s',
-                          force=False))
+        cmd.run(Namespace(name='1234', author="שראלה ישראל", series='k8s', force=False))
 
 
-def test_executables(tmp_path):
-    cmd = InitCommand('group')
-    cmd.run(Namespace(path=tmp_path, name='my-charm', author="홍길동", series='k8s', force=False))
+def test_executables(tmp_path, config):
+    cmd = InitCommand('group', config)
+    cmd.run(Namespace(name='my-charm', author="홍길동", series='k8s', force=False))
     assert (tmp_path / "run_tests").stat().st_mode & S_IXALL == S_IXALL
     assert (tmp_path / "src/charm.py").stat().st_mode & S_IXALL == S_IXALL
 
 
-def test_tests(tmp_path):
+def test_tests(tmp_path, config):
     # fix the PYTHONPATH and PATH so the tests in the initted environment use our own
     # virtualenv libs and bins (if any), as they need them, but we're not creating a
     # venv for the local tests (note that for CI doesn't use a venv)
@@ -116,26 +113,24 @@ def test_tests(tmp_path):
             bin_path = path[:path.index('env/lib/python')] + 'env/bin'
             env['PATH'] = bin_path + ':' + env['PATH']
 
-    cmd = InitCommand('group')
-    cmd.run(Namespace(path=tmp_path, name='my-charm', author="だれだれ", series='k8s',
-                      force=False))
+    cmd = InitCommand('group', config)
+    cmd.run(Namespace(name='my-charm', author="だれだれ", series='k8s', force=False))
     subprocess.run(["./run_tests"], cwd=str(tmp_path), check=True, env=env)
 
 
-def test_series_defaults(tmp_path):
-    cmd = InitCommand('group')
+def test_series_defaults(tmp_path, config):
+    cmd = InitCommand('group', config)
     # series default comes from the parsing itself
-    cmd.run(Namespace(path=tmp_path, name='my-charm', author="fred", series='k8s', force=False))
+    cmd.run(Namespace(name='my-charm', author="fred", series='k8s', force=False))
 
     with (tmp_path / "metadata.yaml").open("rt", encoding="utf8") as f:
         metadata = yaml.safe_load(f)
     assert metadata.get("series") == ['k8s']
 
 
-def test_manual_overrides_defaults(tmp_path):
-    cmd = InitCommand('group')
-    cmd.run(Namespace(path=tmp_path, name='my-charm', author="fred", series='xenial,precise',
-                      force=False))
+def test_manual_overrides_defaults(tmp_path, config):
+    cmd = InitCommand('group', config)
+    cmd.run(Namespace(name='my-charm', author="fred", series='xenial,precise', force=False))
 
     with (tmp_path / "metadata.yaml").open("rt", encoding="utf8") as f:
         metadata = yaml.safe_load(f)

--- a/tests/commands/test_store_commands.py
+++ b/tests/commands/test_store_commands.py
@@ -137,12 +137,12 @@ def test_get_name_from_metadata_bad_content_no_name(tmp_path, monkeypatch):
 # -- tests for auth commands
 
 
-def test_login(caplog, store_mock):
+def test_login(caplog, store_mock, config):
     """Simple login case."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
     store_mock.whoami.return_value = User(name='John Doe', username='jdoe', userid='-1')
 
-    LoginCommand('group').run(noargs)
+    LoginCommand('group', config).run(noargs)
 
     assert store_mock.mock_calls == [
         call.login(),
@@ -151,11 +151,11 @@ def test_login(caplog, store_mock):
     assert ["Logged in as 'jdoe'."] == [rec.message for rec in caplog.records]
 
 
-def test_logout(caplog, store_mock):
+def test_logout(caplog, store_mock, config):
     """Simple logout case."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
-    LogoutCommand('group').run(noargs)
+    LogoutCommand('group', config).run(noargs)
 
     assert store_mock.mock_calls == [
         call.logout(),
@@ -163,14 +163,14 @@ def test_logout(caplog, store_mock):
     assert ["Charmhub token cleared."] == [rec.message for rec in caplog.records]
 
 
-def test_whoami(caplog, store_mock):
+def test_whoami(caplog, store_mock, config):
     """Simple whoami case."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
     store_response = User(name='John Doe', username='jdoe', userid='-1')
     store_mock.whoami.return_value = store_response
 
-    WhoamiCommand('group').run(noargs)
+    WhoamiCommand('group', config).run(noargs)
 
     assert store_mock.mock_calls == [
         call.whoami(),
@@ -186,12 +186,12 @@ def test_whoami(caplog, store_mock):
 # -- tests for name-related commands
 
 
-def test_register_name(caplog, store_mock):
+def test_register_name(caplog, store_mock, config):
     """Simple register_name case."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
     args = Namespace(name='testname')
-    RegisterNameCommand('group').run(args)
+    RegisterNameCommand('group', config).run(args)
 
     assert store_mock.mock_calls == [
         call.register_name('testname'),
@@ -200,14 +200,14 @@ def test_register_name(caplog, store_mock):
     assert [expected] == [rec.message for rec in caplog.records]
 
 
-def test_list_registered_empty(caplog, store_mock):
+def test_list_registered_empty(caplog, store_mock, config):
     """List registered with empty response."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
     store_response = []
     store_mock.list_registered_names.return_value = store_response
 
-    ListNamesCommand('group').run(noargs)
+    ListNamesCommand('group', config).run(noargs)
 
     assert store_mock.mock_calls == [
         call.list_registered_names(),
@@ -216,7 +216,7 @@ def test_list_registered_empty(caplog, store_mock):
     assert [expected] == [rec.message for rec in caplog.records]
 
 
-def test_list_registered_one_private(caplog, store_mock):
+def test_list_registered_one_private(caplog, store_mock, config):
     """List registered with one private item in the response."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
@@ -225,7 +225,7 @@ def test_list_registered_one_private(caplog, store_mock):
     ]
     store_mock.list_registered_names.return_value = store_response
 
-    ListNamesCommand('group').run(noargs)
+    ListNamesCommand('group', config).run(noargs)
 
     assert store_mock.mock_calls == [
         call.list_registered_names(),
@@ -237,7 +237,7 @@ def test_list_registered_one_private(caplog, store_mock):
     assert expected == [rec.message for rec in caplog.records]
 
 
-def test_list_registered_one_public(caplog, store_mock):
+def test_list_registered_one_public(caplog, store_mock, config):
     """List registered with one public item in the response."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
@@ -246,7 +246,7 @@ def test_list_registered_one_public(caplog, store_mock):
     ]
     store_mock.list_registered_names.return_value = store_response
 
-    ListNamesCommand('group').run(noargs)
+    ListNamesCommand('group', config).run(noargs)
 
     assert store_mock.mock_calls == [
         call.list_registered_names(),
@@ -258,7 +258,7 @@ def test_list_registered_one_public(caplog, store_mock):
     assert expected == [rec.message for rec in caplog.records]
 
 
-def test_list_registered_several(caplog, store_mock):
+def test_list_registered_several(caplog, store_mock, config):
     """List registered with several itemsssssssss in the response."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
@@ -269,7 +269,7 @@ def test_list_registered_several(caplog, store_mock):
     ]
     store_mock.list_registered_names.return_value = store_response
 
-    ListNamesCommand('group').run(noargs)
+    ListNamesCommand('group', config).run(noargs)
 
     assert store_mock.mock_calls == [
         call.list_registered_names(),
@@ -286,7 +286,7 @@ def test_list_registered_several(caplog, store_mock):
 # -- tests for upload command
 
 
-def test_upload_call_ok(caplog, store_mock):
+def test_upload_call_ok(caplog, store_mock, config):
     """Simple upload, success result."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
@@ -296,7 +296,7 @@ def test_upload_call_ok(caplog, store_mock):
     args = Namespace(charm_file='whatever-cmd-arg')
     with patch('charmcraft.commands.store.UploadCommand._discover_charm') as mock_discover:
         mock_discover.return_value = ('discovered-name', 'discovered-path')
-        UploadCommand('group').run(args)
+        UploadCommand('group', config).run(args)
 
     # check it called self discover helper with correct args
     mock_discover.assert_called_once_with('whatever-cmd-arg')
@@ -308,7 +308,7 @@ def test_upload_call_ok(caplog, store_mock):
     assert [expected] == [rec.message for rec in caplog.records]
 
 
-def test_upload_call_error(caplog, store_mock):
+def test_upload_call_error(caplog, store_mock, config):
     """Simple upload but with a response indicating an error."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
@@ -318,23 +318,23 @@ def test_upload_call_error(caplog, store_mock):
     args = Namespace(charm_file='whatever-cmd-arg')
     with patch('charmcraft.commands.store.UploadCommand._discover_charm') as mock_discover:
         mock_discover.return_value = ('discovered-name', 'discovered-path')
-        UploadCommand('group').run(args)
+        UploadCommand('group', config).run(args)
 
     expected = "Upload failed with status 400."
     assert [expected] == [rec.message for rec in caplog.records]
 
 
-def test_upload_discover_pathgiven_ok(tmp_path):
+def test_upload_discover_pathgiven_ok(tmp_path, config):
     """Discover charm name/path, indicated path ok."""
     charm_file = tmp_path / 'testfile.charm'
     charm_file.touch()
 
-    name, path = UploadCommand('group')._discover_charm(charm_file)
+    name, path = UploadCommand('group', config)._discover_charm(charm_file)
     assert name == 'testfile'
     assert path == charm_file
 
 
-def test_upload_discover_pathgiven_home_expanded(tmp_path):
+def test_upload_discover_pathgiven_home_expanded(tmp_path, config):
     """Discover charm name/path, home-expand the indicated path."""
     fake_home = tmp_path / 'homedir'
     fake_home.mkdir()
@@ -342,26 +342,27 @@ def test_upload_discover_pathgiven_home_expanded(tmp_path):
     charm_file.touch()
 
     with patch.dict(os.environ, {'HOME': str(fake_home)}):
-        name, path = UploadCommand('group')._discover_charm(pathlib.Path('~/testfile.charm'))
+        cmd = UploadCommand('group', config)
+        name, path = cmd._discover_charm(pathlib.Path('~/testfile.charm'))
     assert name == 'testfile'
     assert path == charm_file
 
 
-def test_upload_discover_pathgiven_missing(tmp_path):
+def test_upload_discover_pathgiven_missing(tmp_path, config):
     """Discover charm name/path, the indicated path is not there."""
     with pytest.raises(CommandError) as cm:
-        UploadCommand('group')._discover_charm(pathlib.Path('not_really_there.charm'))
+        UploadCommand('group', config)._discover_charm(pathlib.Path('not_really_there.charm'))
     assert str(cm.value) == "Cannot access 'not_really_there.charm'."
 
 
-def test_upload_discover_pathgiven_not_a_file(tmp_path):
+def test_upload_discover_pathgiven_not_a_file(tmp_path, config):
     """Discover charm name/path, the indicated path is not a file."""
     with pytest.raises(CommandError) as cm:
-        UploadCommand('group')._discover_charm(tmp_path)
+        UploadCommand('group', config)._discover_charm(tmp_path)
     assert str(cm.value) == "{!r} is not a file.".format(str(tmp_path))
 
 
-def test_upload_discover_default_ok(tmp_path, monkeypatch):
+def test_upload_discover_default_ok(tmp_path, monkeypatch, config):
     """Discover charm name/path, default to get info from metadata, ok."""
     monkeypatch.chdir(tmp_path)
 
@@ -373,26 +374,26 @@ def test_upload_discover_default_ok(tmp_path, monkeypatch):
     with patch('charmcraft.commands.store.get_name_from_metadata') as mock:
         mock.return_value = 'testcharm'
 
-        name, path = UploadCommand('group')._discover_charm(None)
+        name, path = UploadCommand('group', config)._discover_charm(None)
 
     assert name == 'testcharm'
     assert path == charm_file
 
 
-def test_upload_discover_default_no_metadata(tmp_path):
+def test_upload_discover_default_no_metadata(tmp_path, config):
     """Discover charm name/path, no metadata file to get info."""
     with patch('charmcraft.commands.store.get_name_from_metadata') as mock:
         mock.return_value = None
 
         with pytest.raises(CommandError) as cm:
-            UploadCommand('group')._discover_charm(None)
+            UploadCommand('group', config)._discover_charm(None)
 
     assert str(cm.value) == (
         "Cannot find a valid charm name in metadata.yaml to upload. Check you are in a "
         "charm directory with metadata.yaml, or use --charm-file=foo.charm.")
 
 
-def test_upload_discover_default_no_charm_file(tmp_path, monkeypatch):
+def test_upload_discover_default_no_charm_file(tmp_path, monkeypatch, config):
     """Discover charm name/path, the metadata indicates a not accesible."""
     monkeypatch.chdir(tmp_path)
 
@@ -404,7 +405,7 @@ def test_upload_discover_default_no_charm_file(tmp_path, monkeypatch):
         fh.write(metadata_raw)
 
     with pytest.raises(CommandError) as cm:
-        UploadCommand('group')._discover_charm(None)
+        UploadCommand('group', config)._discover_charm(None)
     assert str(cm.value) == (
         "Cannot access charm at {!r}. Try --charm-file=foo.charm"
         .format(str(tmp_path / 'testcharm.charm')))
@@ -413,7 +414,7 @@ def test_upload_discover_default_no_charm_file(tmp_path, monkeypatch):
 # -- tests for list revisions command
 
 
-def test_revisions_simple(caplog, store_mock):
+def test_revisions_simple(caplog, store_mock, config):
     """Happy path of one result from the Store."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
@@ -425,7 +426,7 @@ def test_revisions_simple(caplog, store_mock):
     store_mock.list_revisions.return_value = store_response
 
     args = Namespace(name='testcharm')
-    ListRevisionsCommand('group').run(args)
+    ListRevisionsCommand('group', config).run(args)
 
     assert store_mock.mock_calls == [
         call.list_revisions('testcharm'),
@@ -437,32 +438,32 @@ def test_revisions_simple(caplog, store_mock):
     assert expected == [rec.message for rec in caplog.records]
 
 
-def test_revisions_name_from_metadata_ok(store_mock):
+def test_revisions_name_from_metadata_ok(store_mock, config):
     """The charm name is retrieved succesfully from the metadata."""
     store_mock.list_revisions.return_value = []
     args = Namespace(name=None)
     with patch('charmcraft.commands.store.get_name_from_metadata') as mock:
         mock.return_value = 'test-name'
-        ListRevisionsCommand('group').run(args)
+        ListRevisionsCommand('group', config).run(args)
 
     assert store_mock.mock_calls == [
         call.list_revisions('test-name'),
     ]
 
 
-def test_revisions_name_from_metadata_problem(store_mock):
+def test_revisions_name_from_metadata_problem(store_mock, config):
     """The metadata wasn't there to get the name."""
     args = Namespace(name=None)
     with patch('charmcraft.commands.store.get_name_from_metadata') as mock:
         mock.return_value = None
         with pytest.raises(CommandError) as cm:
-            ListRevisionsCommand('group').run(args)
+            ListRevisionsCommand('group', config).run(args)
         assert str(cm.value) == (
             "Cannot find a valid charm name in metadata.yaml. Check you are in a charm "
             "directory with metadata.yaml, or use --name=foo.")
 
 
-def test_revisions_empty(caplog, store_mock):
+def test_revisions_empty(caplog, store_mock, config):
     """No results from the store."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
@@ -470,7 +471,7 @@ def test_revisions_empty(caplog, store_mock):
     store_mock.list_revisions.return_value = store_response
 
     args = Namespace(name='testcharm')
-    ListRevisionsCommand('group').run(args)
+    ListRevisionsCommand('group', config).run(args)
 
     expected = [
         "No revisions found.",
@@ -478,7 +479,7 @@ def test_revisions_empty(caplog, store_mock):
     assert expected == [rec.message for rec in caplog.records]
 
 
-def test_revisions_ordered_by_revision(caplog, store_mock):
+def test_revisions_ordered_by_revision(caplog, store_mock, config):
     """Results are presented ordered by revision in the table."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
@@ -493,7 +494,7 @@ def test_revisions_ordered_by_revision(caplog, store_mock):
     store_mock.list_revisions.return_value = store_response
 
     args = Namespace(name='testcharm')
-    ListRevisionsCommand('group').run(args)
+    ListRevisionsCommand('group', config).run(args)
 
     expected = [
         "Revision    Version    Created at    Status",
@@ -504,7 +505,7 @@ def test_revisions_ordered_by_revision(caplog, store_mock):
     assert expected == [rec.message for rec in caplog.records]
 
 
-def test_revisions_version_null(caplog, store_mock):
+def test_revisions_version_null(caplog, store_mock, config):
     """Support the case of version being None."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
@@ -516,7 +517,7 @@ def test_revisions_version_null(caplog, store_mock):
     store_mock.list_revisions.return_value = store_response
 
     args = Namespace(name='testcharm')
-    ListRevisionsCommand('group').run(args)
+    ListRevisionsCommand('group', config).run(args)
 
     expected = [
         "Revision    Version    Created at    Status",
@@ -525,7 +526,7 @@ def test_revisions_version_null(caplog, store_mock):
     assert expected == [rec.message for rec in caplog.records]
 
 
-def test_revisions_errors_simple(caplog, store_mock):
+def test_revisions_errors_simple(caplog, store_mock, config):
     """Support having one case with a simple error."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
@@ -537,7 +538,7 @@ def test_revisions_errors_simple(caplog, store_mock):
     store_mock.list_revisions.return_value = store_response
 
     args = Namespace(name='testcharm')
-    ListRevisionsCommand('group').run(args)
+    ListRevisionsCommand('group', config).run(args)
 
     expected = [
         "Revision    Version    Created at    Status",
@@ -546,7 +547,7 @@ def test_revisions_errors_simple(caplog, store_mock):
     assert expected == [rec.message for rec in caplog.records]
 
 
-def test_revisions_errors_multiple(caplog, store_mock):
+def test_revisions_errors_multiple(caplog, store_mock, config):
     """Support having one case with multiple errors."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
@@ -561,7 +562,7 @@ def test_revisions_errors_multiple(caplog, store_mock):
     store_mock.list_revisions.return_value = store_response
 
     args = Namespace(name='testcharm')
-    ListRevisionsCommand('group').run(args)
+    ListRevisionsCommand('group', config).run(args)
 
     expected = [
         "Revision    Version    Created at    Status",
@@ -573,13 +574,13 @@ def test_revisions_errors_multiple(caplog, store_mock):
 # -- tests for the release command
 
 
-def test_release_simple_ok(caplog, store_mock):
+def test_release_simple_ok(caplog, store_mock, config):
     """Simple case of releasing a revision ok."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
     channels = ['somechannel']
     args = Namespace(name='testcharm', revision=7, channels=channels)
-    ReleaseCommand('group').run(args)
+    ReleaseCommand('group', config).run(args)
 
     assert store_mock.mock_calls == [
         call.release('testcharm', 7, channels),
@@ -589,25 +590,25 @@ def test_release_simple_ok(caplog, store_mock):
     assert [expected] == [rec.message for rec in caplog.records]
 
 
-def test_release_simple_multiple_channels(caplog, store_mock):
+def test_release_simple_multiple_channels(caplog, store_mock, config):
     """Releasing to multiple channels."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
     args = Namespace(name='testcharm', revision=7, channels=['channel1', 'channel2', 'channel3'])
-    ReleaseCommand('group').run(args)
+    ReleaseCommand('group', config).run(args)
 
     expected = "Revision 7 of charm 'testcharm' released to channel1, channel2, channel3"
     assert [expected] == [rec.message for rec in caplog.records]
 
 
-def test_release_name_guessing_ok(caplog, store_mock):
+def test_release_name_guessing_ok(caplog, store_mock, config):
     """Release after guessing the charm's name correctly."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
     args = Namespace(name=None, revision=7, channels=['somechannel'])
     with patch('charmcraft.commands.store.get_name_from_metadata') as mock:
         mock.return_value = 'guessed-name'
-        ReleaseCommand('group').run(args)
+        ReleaseCommand('group', config).run(args)
 
     assert store_mock.mock_calls == [
         call.release('guessed-name', 7, ['somechannel']),
@@ -616,14 +617,14 @@ def test_release_name_guessing_ok(caplog, store_mock):
     assert [expected] == [rec.message for rec in caplog.records]
 
 
-def test_release_name_guessing_bad():
+def test_release_name_guessing_bad(config):
     """The charm name couldn't be guessed."""
     with patch('charmcraft.commands.store.get_name_from_metadata') as mock:
         mock.return_value = None
 
         args = Namespace(name=None, revision=7, channels=['somechannel'])
         with pytest.raises(CommandError) as cm:
-            ReleaseCommand('group').run(args)
+            ReleaseCommand('group', config).run(args)
 
         assert str(cm.value) == (
             "Cannot find a valid charm name in metadata.yaml. Check you are in a charm "
@@ -650,7 +651,7 @@ def _build_revision(revno, version):
         status='accepted', errors=[])
 
 
-def test_status_simple_ok(caplog, store_mock):
+def test_status_simple_ok(caplog, store_mock, config):
     """Simple happy case of getting a status."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
@@ -669,7 +670,7 @@ def test_status_simple_ok(caplog, store_mock):
     store_mock.list_releases.return_value = (channel_map, channels, revisions)
 
     args = Namespace(name='testcharm')
-    StatusCommand('group').run(args)
+    StatusCommand('group', config).run(args)
 
     assert store_mock.mock_calls == [
         call.list_releases('testcharm'),
@@ -685,19 +686,19 @@ def test_status_simple_ok(caplog, store_mock):
     assert expected == [rec.message for rec in caplog.records]
 
 
-def test_status_empty(caplog, store_mock):
+def test_status_empty(caplog, store_mock, config):
     """Empty response from the store."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
     store_mock.list_releases.return_value = [], [], []
     args = Namespace(name='testcharm')
-    StatusCommand('group').run(args)
+    StatusCommand('group', config).run(args)
 
     expected = "Nothing has been released yet."
     assert [expected] == [rec.message for rec in caplog.records]
 
 
-def test_status_name_guessing_ok(caplog, store_mock):
+def test_status_name_guessing_ok(caplog, store_mock, config):
     """Get the status after guessing the charm's name correctly."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
     store_mock.list_releases.return_value = [], [], []
@@ -705,28 +706,28 @@ def test_status_name_guessing_ok(caplog, store_mock):
     args = Namespace(name=None)
     with patch('charmcraft.commands.store.get_name_from_metadata') as mock:
         mock.return_value = 'guessed-name'
-        StatusCommand('group').run(args)
+        StatusCommand('group', config).run(args)
 
     assert store_mock.mock_calls == [
         call.list_releases('guessed-name'),
     ]
 
 
-def test_status_name_guessing_bad():
+def test_status_name_guessing_bad(config):
     """The charm name couldn't be guessed."""
     with patch('charmcraft.commands.store.get_name_from_metadata') as mock:
         mock.return_value = None
 
         args = Namespace(name=None)
         with pytest.raises(CommandError) as cm:
-            StatusCommand('group').run(args)
+            StatusCommand('group', config).run(args)
 
         assert str(cm.value) == (
             "Cannot find a valid charm name in metadata.yaml. Check you are in a charm "
             "directory with metadata.yaml, or use --name=foo.")
 
 
-def test_status_channels_not_released_with_fallback(caplog, store_mock):
+def test_status_channels_not_released_with_fallback(caplog, store_mock, config):
     """Support gaps in channel releases, having fallbacks."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
@@ -742,7 +743,7 @@ def test_status_channels_not_released_with_fallback(caplog, store_mock):
     store_mock.list_releases.return_value = (channel_map, channels, revisions)
 
     args = Namespace(name='testcharm')
-    StatusCommand('group').run(args)
+    StatusCommand('group', config).run(args)
 
     assert store_mock.mock_calls == [
         call.list_releases('testcharm'),
@@ -758,7 +759,7 @@ def test_status_channels_not_released_with_fallback(caplog, store_mock):
     assert expected == [rec.message for rec in caplog.records]
 
 
-def test_status_channels_not_released_without_fallback(caplog, store_mock):
+def test_status_channels_not_released_without_fallback(caplog, store_mock, config):
     """Support gaps in channel releases, nothing released in more stable ones."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
@@ -774,7 +775,7 @@ def test_status_channels_not_released_without_fallback(caplog, store_mock):
     store_mock.list_releases.return_value = (channel_map, channels, revisions)
 
     args = Namespace(name='testcharm')
-    StatusCommand('group').run(args)
+    StatusCommand('group', config).run(args)
 
     assert store_mock.mock_calls == [
         call.list_releases('testcharm'),
@@ -790,7 +791,7 @@ def test_status_channels_not_released_without_fallback(caplog, store_mock):
     assert expected == [rec.message for rec in caplog.records]
 
 
-def test_status_multiple_tracks(caplog, store_mock):
+def test_status_multiple_tracks(caplog, store_mock, config):
     """Support multiple tracks."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
@@ -808,7 +809,7 @@ def test_status_multiple_tracks(caplog, store_mock):
     store_mock.list_releases.return_value = (channel_map, channels, revisions)
 
     args = Namespace(name='testcharm')
-    StatusCommand('group').run(args)
+    StatusCommand('group', config).run(args)
 
     assert store_mock.mock_calls == [
         call.list_releases('testcharm'),
@@ -828,7 +829,7 @@ def test_status_multiple_tracks(caplog, store_mock):
     assert expected == [rec.message for rec in caplog.records]
 
 
-def test_status_tracks_order(caplog, store_mock):
+def test_status_tracks_order(caplog, store_mock, config):
     """Respect the track ordering from the store."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
@@ -852,7 +853,7 @@ def test_status_tracks_order(caplog, store_mock):
     store_mock.list_releases.return_value = (channel_map, channels, revisions)
 
     args = Namespace(name='testcharm')
-    StatusCommand('group').run(args)
+    StatusCommand('group', config).run(args)
 
     assert store_mock.mock_calls == [
         call.list_releases('testcharm'),
@@ -880,7 +881,7 @@ def test_status_tracks_order(caplog, store_mock):
     assert expected == [rec.message for rec in caplog.records]
 
 
-def test_status_with_one_branch(caplog, store_mock):
+def test_status_with_one_branch(caplog, store_mock, config):
     """Support having one branch."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
@@ -901,7 +902,7 @@ def test_status_with_one_branch(caplog, store_mock):
     store_mock.list_releases.return_value = (channel_map, channels, revisions)
 
     args = Namespace(name='testcharm')
-    StatusCommand('group').run(args)
+    StatusCommand('group', config).run(args)
 
     assert store_mock.mock_calls == [
         call.list_releases('testcharm'),
@@ -918,7 +919,7 @@ def test_status_with_one_branch(caplog, store_mock):
     assert expected == [rec.message for rec in caplog.records]
 
 
-def test_status_with_multiple_branches(caplog, store_mock):
+def test_status_with_multiple_branches(caplog, store_mock, config):
     """Support having multiple branches."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
@@ -945,7 +946,7 @@ def test_status_with_multiple_branches(caplog, store_mock):
     store_mock.list_releases.return_value = (channel_map, channels, revisions)
 
     args = Namespace(name='testcharm')
-    StatusCommand('group').run(args)
+    StatusCommand('group', config).run(args)
 
     assert store_mock.mock_calls == [
         call.list_releases('testcharm'),
@@ -965,7 +966,7 @@ def test_status_with_multiple_branches(caplog, store_mock):
 
 # -- tests for create library command
 
-def test_createlib_simple(caplog, store_mock, tmp_path, monkeypatch):
+def test_createlib_simple(caplog, store_mock, tmp_path, monkeypatch, config):
     """Happy path with result from the Store."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
     monkeypatch.chdir(tmp_path)
@@ -976,7 +977,7 @@ def test_createlib_simple(caplog, store_mock, tmp_path, monkeypatch):
     args = Namespace(name='testlib')
     with patch('charmcraft.commands.store.get_name_from_metadata') as mock:
         mock.return_value = 'testcharm'
-        CreateLibCommand('group').run(args)
+        CreateLibCommand('group', config).run(args)
 
     assert store_mock.mock_calls == [
         call.create_library_id('testcharm', 'testlib'),
@@ -993,13 +994,13 @@ def test_createlib_simple(caplog, store_mock, tmp_path, monkeypatch):
     assert created_lib_file.read_text() == expected_newlib_content
 
 
-def test_createlib_name_from_metadata_problem(store_mock):
+def test_createlib_name_from_metadata_problem(store_mock, config):
     """The metadata wasn't there to get the name."""
     args = Namespace(name='testlib')
     with patch('charmcraft.commands.store.get_name_from_metadata') as mock:
         mock.return_value = None
         with pytest.raises(CommandError) as cm:
-            CreateLibCommand('group').run(args)
+            CreateLibCommand('group', config).run(args)
         assert str(cm.value) == (
             "Cannot find a valid charm name in metadata.yaml. Check you are in a charm "
             "directory with metadata.yaml.")
@@ -1013,17 +1014,17 @@ def test_createlib_name_from_metadata_problem(store_mock):
     '_foo',
     '',
 ])
-def test_createlib_invalid_name(lib_name):
+def test_createlib_invalid_name(lib_name, config):
     """Verify that it can not be used with an invalid name."""
     args = Namespace(name=lib_name)
     with pytest.raises(CommandError) as err:
-        CreateLibCommand('group').run(args)
+        CreateLibCommand('group', config).run(args)
     assert str(err.value) == (
         "Invalid library name. Must only use lowercase alphanumeric "
         "characters and underscore, starting with alpha.")
 
 
-def test_createlib_path_already_there(tmp_path, monkeypatch):
+def test_createlib_path_already_there(tmp_path, monkeypatch, config):
     """The intended-to-be-created library is already there."""
     monkeypatch.chdir(tmp_path)
 
@@ -1032,13 +1033,13 @@ def test_createlib_path_already_there(tmp_path, monkeypatch):
     with patch('charmcraft.commands.store.get_name_from_metadata') as mock:
         mock.return_value = 'test-charm-name'
         with pytest.raises(CommandError) as err:
-            CreateLibCommand('group').run(args)
+            CreateLibCommand('group', config).run(args)
 
     assert str(err.value) == (
         "This library already exists: lib/charms/test-charm-name/v0/testlib.py")
 
 
-def test_createlib_path_can_not_write(tmp_path, monkeypatch, store_mock, add_cleanup):
+def test_createlib_path_can_not_write(tmp_path, monkeypatch, store_mock, add_cleanup, config):
     """Disk error when trying to write the new lib (bad permissions, name too long, whatever)."""
     lib_dir = tmp_path / 'lib' / 'charms' / 'test-charm-name' / 'v0'
     lib_dir.mkdir(parents=True)
@@ -1052,7 +1053,7 @@ def test_createlib_path_can_not_write(tmp_path, monkeypatch, store_mock, add_cle
     with patch('charmcraft.commands.store.get_name_from_metadata') as mock:
         mock.return_value = 'test-charm-name'
         with pytest.raises(CommandError, match=expected_error):
-            CreateLibCommand('group').run(args)
+            CreateLibCommand('group', config).run(args)
 
 
 def test_createlib_library_template_is_python(caplog, store_mock, tmp_path, monkeypatch):
@@ -1065,7 +1066,7 @@ def test_createlib_library_template_is_python(caplog, store_mock, tmp_path, monk
 # -- tests for publish libraries command
 
 
-def test_publishlib_simple(caplog, store_mock, tmp_path, monkeypatch):
+def test_publishlib_simple(caplog, store_mock, tmp_path, monkeypatch, config):
     """Happy path publishing because no revision at all in the Store."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
     monkeypatch.chdir(tmp_path)
@@ -1078,7 +1079,7 @@ def test_publishlib_simple(caplog, store_mock, tmp_path, monkeypatch):
     args = Namespace(library='charms.testcharm.v0.testlib')
     with patch('charmcraft.commands.store.get_name_from_metadata') as mock:
         mock.return_value = 'testcharm'
-        PublishLibCommand('group').run(args)
+        PublishLibCommand('group', config).run(args)
 
     assert store_mock.mock_calls == [
         call.get_libraries_tips([{'lib_id': lib_id, 'api': 0}]),
@@ -1088,7 +1089,7 @@ def test_publishlib_simple(caplog, store_mock, tmp_path, monkeypatch):
     assert [expected] == [rec.message for rec in caplog.records]
 
 
-def test_publishlib_all(caplog, store_mock, tmp_path, monkeypatch):
+def test_publishlib_all(caplog, store_mock, tmp_path, monkeypatch, config):
     """Publish all the libraries found in disk."""
     caplog.set_level(logging.DEBUG, logger="charmcraft.commands")
     monkeypatch.chdir(tmp_path)
@@ -1106,7 +1107,7 @@ def test_publishlib_all(caplog, store_mock, tmp_path, monkeypatch):
     args = Namespace(library=None)
     with patch('charmcraft.commands.store.get_name_from_metadata') as mock:
         mock.return_value = 'testcharm-1'
-        PublishLibCommand('group').run(args)
+        PublishLibCommand('group', config).run(args)
 
     assert store_mock.mock_calls == [
         call.get_libraries_tips([
@@ -1133,7 +1134,7 @@ def test_publishlib_all(caplog, store_mock, tmp_path, monkeypatch):
     assert all(e in records for e in expected)
 
 
-def test_publishlib_not_found(caplog, store_mock, tmp_path, monkeypatch):
+def test_publishlib_not_found(caplog, store_mock, tmp_path, monkeypatch, config):
     """The indicated library is not found."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
     monkeypatch.chdir(tmp_path)
@@ -1142,13 +1143,13 @@ def test_publishlib_not_found(caplog, store_mock, tmp_path, monkeypatch):
     with patch('charmcraft.commands.store.get_name_from_metadata') as mock:
         mock.return_value = 'testcharm'
         with pytest.raises(CommandError) as cm:
-            PublishLibCommand('group').run(args)
+            PublishLibCommand('group', config).run(args)
 
         assert str(cm.value) == (
             "The specified library was not found at path lib/charms/testcharm/v0/testlib.py.")
 
 
-def test_publishlib_not_from_current_charm(caplog, store_mock, tmp_path, monkeypatch):
+def test_publishlib_not_from_current_charm(caplog, store_mock, tmp_path, monkeypatch, config):
     """The indicated library to publish does not belong to this charm."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
     monkeypatch.chdir(tmp_path)
@@ -1158,26 +1159,26 @@ def test_publishlib_not_from_current_charm(caplog, store_mock, tmp_path, monkeyp
     with patch('charmcraft.commands.store.get_name_from_metadata') as mock:
         mock.return_value = 'charm2'
         with pytest.raises(CommandError) as cm:
-            PublishLibCommand('group').run(args)
+            PublishLibCommand('group', config).run(args)
 
         assert str(cm.value) == (
             "The library charms.testcharm.v0.testlib does not belong to this charm 'charm2'.")
 
 
-def test_publishlib_name_from_metadata_problem(store_mock):
+def test_publishlib_name_from_metadata_problem(store_mock, config):
     """The metadata wasn't there to get the name."""
     args = Namespace(library='charms.testcharm.v0.testlib')
     with patch('charmcraft.commands.store.get_name_from_metadata') as mock:
         mock.return_value = None
         with pytest.raises(CommandError) as cm:
-            PublishLibCommand('group').run(args)
+            PublishLibCommand('group', config).run(args)
 
         assert str(cm.value) == (
             "Can't access name in 'metadata.yaml' file. The 'publish-lib' command needs to "
             "be executed in a valid project's directory.")
 
 
-def test_publishlib_store_is_advanced(caplog, store_mock, tmp_path, monkeypatch):
+def test_publishlib_store_is_advanced(caplog, store_mock, tmp_path, monkeypatch, config):
     """The store has a higher revision number than what we expect."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
     monkeypatch.chdir(tmp_path)
@@ -1193,7 +1194,7 @@ def test_publishlib_store_is_advanced(caplog, store_mock, tmp_path, monkeypatch)
     args = Namespace(library='charms.testcharm.v0.testlib')
     with patch('charmcraft.commands.store.get_name_from_metadata') as mock:
         mock.return_value = 'testcharm'
-        PublishLibCommand('group').run(args)
+        PublishLibCommand('group', config).run(args)
 
     assert store_mock.mock_calls == [
         call.get_libraries_tips([{'lib_id': lib_id, 'api': 0}]),
@@ -1204,7 +1205,7 @@ def test_publishlib_store_is_advanced(caplog, store_mock, tmp_path, monkeypatch)
     assert [expected] == [rec.message for rec in caplog.records]
 
 
-def test_publishlib_store_is_exactly_behind_ok(caplog, store_mock, tmp_path, monkeypatch):
+def test_publishlib_store_is_exactly_behind_ok(caplog, store_mock, tmp_path, monkeypatch, config):
     """The store is exactly one revision less than local lib, ok."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
     monkeypatch.chdir(tmp_path)
@@ -1221,7 +1222,7 @@ def test_publishlib_store_is_exactly_behind_ok(caplog, store_mock, tmp_path, mon
     args = Namespace(library='charms.testcharm.v0.testlib')
     with patch('charmcraft.commands.store.get_name_from_metadata') as mock:
         mock.return_value = 'testcharm'
-        PublishLibCommand('group').run(args)
+        PublishLibCommand('group', config).run(args)
 
     assert store_mock.mock_calls == [
         call.get_libraries_tips([{'lib_id': lib_id, 'api': 0}]),
@@ -1231,7 +1232,8 @@ def test_publishlib_store_is_exactly_behind_ok(caplog, store_mock, tmp_path, mon
     assert [expected] == [rec.message for rec in caplog.records]
 
 
-def test_publishlib_store_is_exactly_behind_same_hash(caplog, store_mock, tmp_path, monkeypatch):
+def test_publishlib_store_is_exactly_behind_same_hash(
+        caplog, store_mock, tmp_path, monkeypatch, config):
     """The store is exactly one revision less than local lib, same hash."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
     monkeypatch.chdir(tmp_path)
@@ -1248,7 +1250,7 @@ def test_publishlib_store_is_exactly_behind_same_hash(caplog, store_mock, tmp_pa
     args = Namespace(library='charms.testcharm.v0.testlib')
     with patch('charmcraft.commands.store.get_name_from_metadata') as mock:
         mock.return_value = 'testcharm'
-        PublishLibCommand('group').run(args)
+        PublishLibCommand('group', config).run(args)
 
     assert store_mock.mock_calls == [
         call.get_libraries_tips([{'lib_id': lib_id, 'api': 0}]),
@@ -1259,7 +1261,7 @@ def test_publishlib_store_is_exactly_behind_same_hash(caplog, store_mock, tmp_pa
     assert [expected] == [rec.message for rec in caplog.records]
 
 
-def test_publishlib_store_is_too_behind(caplog, store_mock, tmp_path, monkeypatch):
+def test_publishlib_store_is_too_behind(caplog, store_mock, tmp_path, monkeypatch, config):
     """The store is way more behind than what we expected (local lib too high!)."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
     monkeypatch.chdir(tmp_path)
@@ -1275,7 +1277,7 @@ def test_publishlib_store_is_too_behind(caplog, store_mock, tmp_path, monkeypatc
     args = Namespace(library='charms.testcharm.v0.testlib')
     with patch('charmcraft.commands.store.get_name_from_metadata') as mock:
         mock.return_value = 'testcharm'
-        PublishLibCommand('group').run(args)
+        PublishLibCommand('group', config).run(args)
 
     assert store_mock.mock_calls == [
         call.get_libraries_tips([{'lib_id': lib_id, 'api': 0}]),
@@ -1286,7 +1288,8 @@ def test_publishlib_store_is_too_behind(caplog, store_mock, tmp_path, monkeypatc
     assert [expected] == [rec.message for rec in caplog.records]
 
 
-def test_publishlib_store_has_same_revision_same_hash(caplog, store_mock, tmp_path, monkeypatch):
+def test_publishlib_store_has_same_revision_same_hash(
+        caplog, store_mock, tmp_path, monkeypatch, config):
     """The store has the same revision we want to publish, with the same hash."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
     monkeypatch.chdir(tmp_path)
@@ -1303,7 +1306,7 @@ def test_publishlib_store_has_same_revision_same_hash(caplog, store_mock, tmp_pa
     args = Namespace(library='charms.testcharm.v0.testlib')
     with patch('charmcraft.commands.store.get_name_from_metadata') as mock:
         mock.return_value = 'testcharm'
-        PublishLibCommand('group').run(args)
+        PublishLibCommand('group', config).run(args)
 
     assert store_mock.mock_calls == [
         call.get_libraries_tips([{'lib_id': lib_id, 'api': 0}]),
@@ -1312,7 +1315,8 @@ def test_publishlib_store_has_same_revision_same_hash(caplog, store_mock, tmp_pa
     assert [expected] == [rec.message for rec in caplog.records]
 
 
-def test_publishlib_store_has_same_revision_other_hash(caplog, store_mock, tmp_path, monkeypatch):
+def test_publishlib_store_has_same_revision_other_hash(
+        caplog, store_mock, tmp_path, monkeypatch, config):
     """The store has the same revision we want to publish, but with a different hash."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
     monkeypatch.chdir(tmp_path)
@@ -1328,7 +1332,7 @@ def test_publishlib_store_has_same_revision_other_hash(caplog, store_mock, tmp_p
     args = Namespace(library='charms.testcharm.v0.testlib')
     with patch('charmcraft.commands.store.get_name_from_metadata') as mock:
         mock.return_value = 'testcharm'
-        PublishLibCommand('group').run(args)
+        PublishLibCommand('group', config).run(args)
 
     assert store_mock.mock_calls == [
         call.get_libraries_tips([{'lib_id': lib_id, 'api': 0}]),
@@ -1594,7 +1598,7 @@ def test_getlibinfo_libid_empty(tmp_path, monkeypatch):
 
 # -- tests for fetch libraries command
 
-def test_fetchlib_simple_downloaded(caplog, store_mock, tmp_path, monkeypatch):
+def test_fetchlib_simple_downloaded(caplog, store_mock, tmp_path, monkeypatch, config):
     """Happy path fetching the lib for the first time (downloading it)."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
     monkeypatch.chdir(tmp_path)
@@ -1610,7 +1614,7 @@ def test_fetchlib_simple_downloaded(caplog, store_mock, tmp_path, monkeypatch):
         lib_id=lib_id, content=lib_content, content_hash='abc', api=0, patch=7,
         lib_name='testlib', charm_name='testcharm')
 
-    FetchLibCommand('group').run(Namespace(library='charms.testcharm.v0.testlib'))
+    FetchLibCommand('group', config).run(Namespace(library='charms.testcharm.v0.testlib'))
 
     assert store_mock.mock_calls == [
         call.get_libraries_tips(
@@ -1623,7 +1627,7 @@ def test_fetchlib_simple_downloaded(caplog, store_mock, tmp_path, monkeypatch):
     assert saved_file.read_text() == lib_content
 
 
-def test_fetchlib_simple_updated(caplog, store_mock, tmp_path, monkeypatch):
+def test_fetchlib_simple_updated(caplog, store_mock, tmp_path, monkeypatch, config):
     """Happy path fetching the lib for Nth time (updating it)."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
     monkeypatch.chdir(tmp_path)
@@ -1642,7 +1646,7 @@ def test_fetchlib_simple_updated(caplog, store_mock, tmp_path, monkeypatch):
         lib_id=lib_id, content=new_lib_content, content_hash='abc', api=0, patch=2,
         lib_name='testlib', charm_name='testcharm')
 
-    FetchLibCommand('group').run(Namespace(library='charms.testcharm.v0.testlib'))
+    FetchLibCommand('group', config).run(Namespace(library='charms.testcharm.v0.testlib'))
 
     assert store_mock.mock_calls == [
         call.get_libraries_tips([{'lib_id': lib_id, 'api': 0}]),
@@ -1654,7 +1658,7 @@ def test_fetchlib_simple_updated(caplog, store_mock, tmp_path, monkeypatch):
     assert saved_file.read_text() == new_lib_content
 
 
-def test_fetchlib_all(caplog, store_mock, tmp_path, monkeypatch):
+def test_fetchlib_all(caplog, store_mock, tmp_path, monkeypatch, config):
     """Update all the libraries found in disk."""
     caplog.set_level(logging.DEBUG, logger="charmcraft.commands")
     monkeypatch.chdir(tmp_path)
@@ -1682,7 +1686,7 @@ def test_fetchlib_all(caplog, store_mock, tmp_path, monkeypatch):
     ]
     store_mock.get_library.side_effect = lambda *a: _store_libs_info.pop(0)
 
-    FetchLibCommand('group').run(Namespace(library=None))
+    FetchLibCommand('group', config).run(Namespace(library=None))
 
     assert store_mock.mock_calls == [
         call.get_libraries_tips([
@@ -1710,12 +1714,12 @@ def test_fetchlib_all(caplog, store_mock, tmp_path, monkeypatch):
     assert saved_file.read_text() == 'new lib content 2'
 
 
-def test_fetchlib_store_not_found(caplog, store_mock):
+def test_fetchlib_store_not_found(caplog, store_mock, config):
     """The indicated library is not found in the store."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
     store_mock.get_libraries_tips.return_value = {}
-    FetchLibCommand('group').run(Namespace(library='charms.testcharm.v0.testlib'))
+    FetchLibCommand('group', config).run(Namespace(library='charms.testcharm.v0.testlib'))
 
     assert store_mock.mock_calls == [
         call.get_libraries_tips(
@@ -1725,7 +1729,7 @@ def test_fetchlib_store_not_found(caplog, store_mock):
     assert [expected] == [rec.message for rec in caplog.records]
 
 
-def test_fetchlib_store_is_old(caplog, store_mock, tmp_path, monkeypatch):
+def test_fetchlib_store_is_old(caplog, store_mock, tmp_path, monkeypatch, config):
     """The store has an older version that what is found locally."""
     caplog.set_level(logging.DEBUG, logger="charmcraft.commands")
     monkeypatch.chdir(tmp_path)
@@ -1738,7 +1742,7 @@ def test_fetchlib_store_is_old(caplog, store_mock, tmp_path, monkeypatch):
             lib_id=lib_id, content=None, content_hash='abc', api=0, patch=6,
             lib_name='testlib', charm_name='testcharm'),
     }
-    FetchLibCommand('group').run(Namespace(library='charms.testcharm.v0.testlib'))
+    FetchLibCommand('group', config).run(Namespace(library='charms.testcharm.v0.testlib'))
 
     assert store_mock.mock_calls == [
         call.get_libraries_tips([{'lib_id': lib_id, 'api': 0}]),
@@ -1747,7 +1751,7 @@ def test_fetchlib_store_is_old(caplog, store_mock, tmp_path, monkeypatch):
     assert expected in [rec.message for rec in caplog.records]
 
 
-def test_fetchlib_store_same_versions_same_hash(caplog, store_mock, tmp_path, monkeypatch):
+def test_fetchlib_store_same_versions_same_hash(caplog, store_mock, tmp_path, monkeypatch, config):
     """The store situation is the same than locally."""
     caplog.set_level(logging.DEBUG, logger="charmcraft.commands")
     monkeypatch.chdir(tmp_path)
@@ -1760,7 +1764,7 @@ def test_fetchlib_store_same_versions_same_hash(caplog, store_mock, tmp_path, mo
             lib_id=lib_id, content=None, content_hash=c_hash, api=0, patch=7,
             lib_name='testlib', charm_name='testcharm'),
     }
-    FetchLibCommand('group').run(Namespace(library='charms.testcharm.v0.testlib'))
+    FetchLibCommand('group', config).run(Namespace(library='charms.testcharm.v0.testlib'))
 
     assert store_mock.mock_calls == [
         call.get_libraries_tips([{'lib_id': lib_id, 'api': 0}]),
@@ -1769,7 +1773,8 @@ def test_fetchlib_store_same_versions_same_hash(caplog, store_mock, tmp_path, mo
     assert expected in [rec.message for rec in caplog.records]
 
 
-def test_fetchlib_store_same_versions_differnt_hash(caplog, store_mock, tmp_path, monkeypatch):
+def test_fetchlib_store_same_versions_different_hash(
+        caplog, store_mock, tmp_path, monkeypatch, config):
     """The store has the lib in the same version, but with different content."""
     caplog.set_level(logging.DEBUG, logger="charmcraft.commands")
     monkeypatch.chdir(tmp_path)
@@ -1782,7 +1787,7 @@ def test_fetchlib_store_same_versions_differnt_hash(caplog, store_mock, tmp_path
             lib_id=lib_id, content=None, content_hash='abc', api=0, patch=7,
             lib_name='testlib', charm_name='testcharm'),
     }
-    FetchLibCommand('group').run(Namespace(library='charms.testcharm.v0.testlib'))
+    FetchLibCommand('group', config).run(Namespace(library='charms.testcharm.v0.testlib'))
 
     assert store_mock.mock_calls == [
         call.get_libraries_tips([{'lib_id': lib_id, 'api': 0}]),
@@ -1793,7 +1798,7 @@ def test_fetchlib_store_same_versions_differnt_hash(caplog, store_mock, tmp_path
 
 # -- tests for list libraries command
 
-def test_listlib_simple(caplog, store_mock):
+def test_listlib_simple(caplog, store_mock, config):
     """Happy path listing simple case."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
@@ -1803,7 +1808,7 @@ def test_listlib_simple(caplog, store_mock):
             lib_name='testlib', charm_name='testcharm'),
     }
     args = Namespace(name='testcharm')
-    ListLibCommand('group').run(args)
+    ListLibCommand('group', config).run(args)
 
     assert store_mock.mock_calls == [
         call.get_libraries_tips([{'charm_name': 'testcharm'}]),
@@ -1815,7 +1820,7 @@ def test_listlib_simple(caplog, store_mock):
     assert expected == [rec.message for rec in caplog.records]
 
 
-def test_listlib_charm_from_metadata(caplog, store_mock):
+def test_listlib_charm_from_metadata(caplog, store_mock, config):
     """Happy path listing simple case."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
@@ -1823,20 +1828,20 @@ def test_listlib_charm_from_metadata(caplog, store_mock):
     args = Namespace(name=None)
     with patch('charmcraft.commands.store.get_name_from_metadata') as mock:
         mock.return_value = 'testcharm'
-        ListLibCommand('group').run(args)
+        ListLibCommand('group', config).run(args)
 
     assert store_mock.mock_calls == [
         call.get_libraries_tips([{'charm_name': 'testcharm'}]),
     ]
 
 
-def test_listlib_name_from_metadata_problem(store_mock):
+def test_listlib_name_from_metadata_problem(store_mock, config):
     """The metadata wasn't there to get the name."""
     args = Namespace(name=None)
     with patch('charmcraft.commands.store.get_name_from_metadata') as mock:
         mock.return_value = None
         with pytest.raises(CommandError) as cm:
-            ListLibCommand('group').run(args)
+            ListLibCommand('group', config).run(args)
 
         assert str(cm.value) == (
             "Can't access name in 'metadata.yaml' file. The 'list-lib' command must either be "
@@ -1844,19 +1849,19 @@ def test_listlib_name_from_metadata_problem(store_mock):
             "the --charm-name option.")
 
 
-def test_listlib_empty(caplog, store_mock):
+def test_listlib_empty(caplog, store_mock, config):
     """Nothing found in the store for the specified charm."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
     store_mock.get_libraries_tips.return_value = {}
     args = Namespace(name='testcharm')
-    ListLibCommand('group').run(args)
+    ListLibCommand('group', config).run(args)
 
     expected = "No libraries found for charm testcharm."
     assert [expected] == [rec.message for rec in caplog.records]
 
 
-def test_listlib_properly_sorted(caplog, store_mock):
+def test_listlib_properly_sorted(caplog, store_mock, config):
     """Check the sorting of the list."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
@@ -1872,7 +1877,7 @@ def test_listlib_properly_sorted(caplog, store_mock):
             lib_name='testlib-1', charm_name='testcharm'),
     }
     args = Namespace(name='testcharm')
-    ListLibCommand('group').run(args)
+    ListLibCommand('group', config).run(args)
 
     assert store_mock.mock_calls == [
         call.get_libraries_tips([{'charm_name': 'testcharm'}]),

--- a/tests/commands/test_version.py
+++ b/tests/commands/test_version.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Canonical Ltd.
+# Copyright 2020-2021 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ from charmcraft.commands.version import VersionCommand
 def test_version_result(caplog):
     """Check it produces the right version."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands.version")
-    cmd = VersionCommand('group')
+    cmd = VersionCommand('group', 'config')
     cmd.run([])
     expected = __version__
     assert [expected] == [rec.message for rec in caplog.records]

--- a/tests/test_cmdbase.py
+++ b/tests/test_cmdbase.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Canonical Ltd.
+# Copyright 2020-2021 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -44,15 +44,17 @@ def test_basecommand_mandatory_attributes(command, attrib):
     assert getattr(command, attrib) is not None
 
 
-def test_basecommand_holds_the_indicated_group():
+def test_basecommand_holds_the_indicated_info():
     """BaseCommand subclasses ."""
     class TestClass(BaseCommand):
         help_msg = 'help message'
         name = 'test'
 
     group = 'test group'
-    tc = TestClass(group)
+    config = 'test config'
+    tc = TestClass(group, config)
     assert tc.group == group
+    assert tc.config == config
 
 
 def test_basecommand_fill_parser_optional():
@@ -61,14 +63,14 @@ def test_basecommand_fill_parser_optional():
         help_msg = 'help message'
         name = 'test'
 
-        def __init__(self, group):
+        def __init__(self, group, config):
             self.done = False
-            super().__init__(group)
+            super().__init__(group, config)
 
         def run(self, parsed_args):
             self.done = True
 
-    tc = TestClass('group')
+    tc = TestClass('group', 'config')
     tc.run([])
     assert tc.done
 
@@ -79,6 +81,6 @@ def test_basecommand_run_mandatory():
         help_msg = 'help message'
         name = 'test'
 
-    tc = TestClass('group')
+    tc = TestClass('group', 'config')
     with pytest.raises(NotImplementedError):
         tc.run([])

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -44,7 +44,7 @@ def test_aesthetic_help_msg(command):
 
 
 @pytest.mark.parametrize('command', all_commands)
-def test_aesthetic_args_options_msg(command):
+def test_aesthetic_args_options_msg(command, config):
     """All the real commands args help messages start with uppercase and dont' end with a dot."""
     class FakeParser:
         """A fake to get the arguments added."""
@@ -54,7 +54,7 @@ def test_aesthetic_args_options_msg(command):
             assert help_msg, "The help message must be present in each option"
             assert help_msg[0].isupper() and help_msg[-1] != '.'
 
-    command('group').fill_parser(FakeParser())
+    command('group', config).fill_parser(FakeParser())
 
 
 def test_get_usage_message():
@@ -190,7 +190,7 @@ def test_detailed_help_text():
     assert text == expected
 
 
-def test_command_help_text_no_parameters():
+def test_command_help_text_no_parameters(config):
     """All different parts for a specific command help that doesn't have parameters."""
     overview = textwrap.dedent("""
         Quite some long text.
@@ -213,7 +213,7 @@ def test_command_help_text_no_parameters():
         ("--revision", "The revision to release (defaults to latest)."),
     ]
 
-    text = get_command_help(command_groups, cmd1('group1'), options)
+    text = get_command_help(command_groups, cmd1('group1', config), options)
 
     expected = textwrap.dedent("""\
         Usage:
@@ -239,7 +239,7 @@ def test_command_help_text_no_parameters():
     assert text == expected
 
 
-def test_command_help_text_with_parameters():
+def test_command_help_text_with_parameters(config):
     """All different parts for a specific command help that has parameters."""
     overview = textwrap.dedent("""
         Quite some long text.
@@ -258,7 +258,7 @@ def test_command_help_text_with_parameters():
         ("--other-option", "Other option."),
     ]
 
-    text = get_command_help(command_groups, cmd1('group1'), options)
+    text = get_command_help(command_groups, cmd1('group1', config), options)
 
     expected = textwrap.dedent("""\
         Usage:
@@ -280,7 +280,7 @@ def test_command_help_text_with_parameters():
     assert text == expected
 
 
-def test_command_help_text_loneranger():
+def test_command_help_text_loneranger(config):
     """All different parts for a specific command that's the only one in its group."""
     overview = textwrap.dedent("""
         Quite some long text.
@@ -297,7 +297,7 @@ def test_command_help_text_loneranger():
         ("-q, --quiet", "Only show warnings and errors, not progress."),
     ]
 
-    text = get_command_help(command_groups, cmd1('group1'), options)
+    text = get_command_help(command_groups, cmd1('group1', config), options)
 
     expected = textwrap.dedent("""\
         Usage:


### PR DESCRIPTION
Now the main module passes the config to all the commands.

The branch is a little too big, but most of the diff are mechanical changes (as most of the commands don't use the config, at least so far).

But there are two commands that are impacted by this change:

- `pack`: which previously loaded/validated the `charmcraft.yaml` file itself, now it just uses the config.

- `init`: which had a parameter to identify the project dir, and now this parameter is global to all the system.