### PR TITLE
Make the Store client to use the Config (with production default URLs now).

### DIFF
--- a/charmcraft/commands/pack.py
+++ b/charmcraft/commands/pack.py
@@ -79,7 +79,7 @@ class PackCommand(BaseCommand):
 
     def run(self, parsed_args):
         """Run the command."""
-        if self.config is None:
+        if self.config.type is None:
             raise CommandError(
                 "Missing project configuration, please provide a valid charmcraft.yaml.")
 

--- a/charmcraft/commands/store/store.py
+++ b/charmcraft/commands/store/store.py
@@ -78,7 +78,7 @@ class Store:
     """The main interface to the Store's API."""
 
     def __init__(self, charmhub_config):
-        self._client = Client()
+        self._client = Client(charmhub_config.api_url, charmhub_config.storage_url)
 
     def login(self):
         """Login into the store.

--- a/charmcraft/config.py
+++ b/charmcraft/config.py
@@ -95,8 +95,8 @@ def check_relative_paths(value):
 class CharmhubConfig:
     """Configuration for all Charmhub related options."""
 
-    api_url = attr.ib(default='https://api.staging.charmhub.io')
-    storage_url = attr.ib(default='https://storage.staging.snapcraftcontent.com')
+    api_url = attr.ib(default='https://api.charmhub.io')
+    storage_url = attr.ib(default='https://storage.snapcraftcontent.com')
 
     @classmethod
     def from_dict(cls, source):
@@ -130,7 +130,7 @@ class Config:
 
     charmhub = attr.ib(default={}, converter=CharmhubConfig.from_dict)
     parts = attr.ib(default={}, converter=BasicPrime.from_dict)
-    type = attr.ib()
+    type = attr.ib(default=None)
 
     # this item is provided by the code itself, not the user, as convenience for the
     # rest of the code
@@ -167,7 +167,6 @@ CONFIG_SCHEMA = {
             },
         },
     },
-    'required': ['type'],
     'additionalProperties': False,
 }
 
@@ -183,7 +182,10 @@ def load(dirpath):
     # XXX Facundo 2021-01-04: we will make this configuration mandatory in the future, but
     # so far is ok to not have it
     if content is None:
-        return
+        # when the configuration becomes mandatory, we should enforce that 'type' is mandatory
+        # in the schema (so it always have it) and raise an exception here instead of having
+        # an empty config
+        content = {}
 
     # validate the loaded config is ok
     try:

--- a/tests/commands/test_pack.py
+++ b/tests/commands/test_pack.py
@@ -106,9 +106,9 @@ def test_bad_type_in_charmcraft(bundle_yaml, config):
         "Bad config: 'type' field in charmcraft.yaml must be 'bundle' for this command.")
 
 
-def test_missing_configuration():
+def test_missing_configuration(config):
     """The charmcraft.yaml file must be in place for this command."""
-    config = None
+    config.set(type=None)
     with pytest.raises(CommandError) as cm:
         PackCommand('group', config).run(noargs)
     assert str(cm.value) == (

--- a/tests/commands/test_store_api.py
+++ b/tests/commands/test_store_api.py
@@ -27,9 +27,21 @@ from charmcraft.commands.store.store import Store, Library
 
 @pytest.fixture
 def client_mock():
+    """Fixture to provide a mocked client."""
     client_mock = MagicMock()
-    with patch('charmcraft.commands.store.store.Client', lambda: client_mock):
+    with patch('charmcraft.commands.store.store.Client', lambda api, storage: client_mock):
         yield client_mock
+
+
+# -- tests for client usage
+
+def test_client_init(config):
+    """Check that the client is initiated ok even without config."""
+    with patch('charmcraft.commands.store.store.Client') as client_mock:
+        Store(config.charmhub)
+    assert client_mock.mock_calls == [
+        call(config.charmhub.api_url, config.charmhub.storage_url),
+    ]
 
 
 # -- tests for auth

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -70,7 +70,8 @@ def test_load_specific_directory_ok(create_config):
 def test_load_optional_charmcraft_missing(tmp_path):
     """Specify a directory where the file is missing."""
     config = load(tmp_path)
-    assert config is None
+    assert config.type is None
+    assert config.project.dirpath == tmp_path
 
 
 def test_load_specific_directory_resolved(create_config, monkeypatch):
@@ -126,21 +127,6 @@ def test_schema_top_level_no_extra_properties(create_config, check_schema_error)
         whatever: new-stuff
     """)
     check_schema_error("Additional properties are not allowed ('whatever' was unexpected)")
-
-
-def test_schema_type_mandatory(create_config, check_schema_error):
-    """Schema validation, type is mandatory."""
-    create_config("""
-        charmhub:
-            storage_url: https://some.server.com
-    """)
-    if is_py35:
-        check_schema_error(
-            "Bad charmcraft.yaml content; missing fields: type.",
-            "Bad charmcraft.yaml content; the 'type' field must be one of: 'charm', 'bundle'.",
-        )
-    else:
-        check_schema_error("Bad charmcraft.yaml content; missing fields: type.")
 
 
 def test_schema_type_bad_type(create_config, check_schema_error):


### PR DESCRIPTION
Note: I had to change the behaviour when the `charmcraft.yaml` file is missing (so far is optional, in the future will be mandatory): previously in that case the whole config was None, but this way the Store URLs wouldn't get to the Store client, or the project directory wouldn't get to the `init` command.

Now the config object will always be there and useful, but with `type` in None. This is fine because the only ones using `type` are the bundle related commands (only `pack` so far, the next coming in the following days), for which the config is also mandatory. 

So if there is no charmcraft.yaml file at all the  config is created and passed around for all objects just fine and `pack` detects that config.type is None, so it complains that config is mandatory (like before).

In the future (following weeks), when we make the config mandatory, we'll put back that `type` is mandatory in the schema.
