### PR TITLE
Mandatory parameters must be between angular brackets in the command's help.

### DIFF
--- a/charmcraft/helptexts.py
+++ b/charmcraft/helptexts.py
@@ -236,7 +236,7 @@ def get_command_help(command_groups, command, arguments):
     textblocks.append(textwrap.dedent("""\
         Usage:
             charmcraft {} [options] {}
-    """.format(command.name, " ".join(parameters))))
+    """.format(command.name, " ".join("<{}>".format(parameter) for parameter in parameters))))
 
     textblocks.append("Summary:{}".format(textwrap.indent(command.overview, '    ')))
 

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -262,7 +262,7 @@ def test_command_help_text_with_parameters(config):
 
     expected = textwrap.dedent("""\
         Usage:
-            charmcraft somecommand [options] name extraparam
+            charmcraft somecommand [options] <name> <extraparam>
 
         Summary:
             Quite some long text.


### PR DESCRIPTION
Closes #228.