### PR TITLE
Fix infrastructure around the concept that the config is not always mandatory.

### DIFF
--- a/charmcraft/cmdbase.py
+++ b/charmcraft/cmdbase.py
@@ -42,6 +42,7 @@ class BaseCommand:
     - name: the identifier in the command line
     - help_msg: a one line help for user documentation
     - common: if it's a common/starter command, which are prioritized in the help
+    - needs_config: will ensure a config is provided when executing the command
 
     It also must/can override some methods for the proper command behaviour (see each
     method's docstring).
@@ -55,6 +56,7 @@ class BaseCommand:
     help_msg = None
     overview = None
     common = False
+    needs_config = False
 
     def __init__(self, group, config):
         self.group = group

--- a/charmcraft/commands/pack.py
+++ b/charmcraft/commands/pack.py
@@ -76,13 +76,10 @@ class PackCommand(BaseCommand):
     name = 'pack'
     help_msg = "Build the bundle"
     overview = _overview
+    needs_config = True
 
     def run(self, parsed_args):
         """Run the command."""
-        if self.config.type is None:
-            raise CommandError(
-                "Missing project configuration, please provide a valid charmcraft.yaml.")
-
         # get the config files
         bundle_filepath = self.config.project.dirpath / 'bundle.yaml'
         bundle_config = load_yaml(bundle_filepath)

--- a/charmcraft/main.py
+++ b/charmcraft/main.py
@@ -280,6 +280,11 @@ class Dispatcher:
         if isinstance(self.command, HelpCommand):
             self.command.run(self.parsed_args, self.commands)
         else:
+            if self.command.needs_config and not self.command.config.project.config_provided:
+                raise CommandError(
+                    "The specified command needs a valid 'charmcraft.yaml' configuration file (in "
+                    "the current directory or where specified with --project-dir option); see "
+                    "the reference: https://discourse.charmhub.io/t/charmcraft-configuration/4138")
             self.command.run(self.parsed_args)
 
 

--- a/tests/commands/test_pack.py
+++ b/tests/commands/test_pack.py
@@ -106,15 +106,6 @@ def test_bad_type_in_charmcraft(bundle_yaml, config):
         "Bad config: 'type' field in charmcraft.yaml must be 'bundle' for this command.")
 
 
-def test_missing_configuration(config):
-    """The charmcraft.yaml file must be in place for this command."""
-    config.set(type=None)
-    with pytest.raises(CommandError) as cm:
-        PackCommand('group', config).run(noargs)
-    assert str(cm.value) == (
-        "Missing project configuration, please provide a valid charmcraft.yaml.")
-
-
 # -- tests for get paths helper
 
 def test_getpaths_mandatory_ok(tmp_path, config):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -55,6 +55,7 @@ def test_load_current_directory(create_config, monkeypatch):
     config = load(None)
     assert config.type == 'charm'
     assert config.project.dirpath == tmp_path
+    assert config.project.config_provided
 
 
 def test_load_specific_directory_ok(create_config):
@@ -72,6 +73,7 @@ def test_load_optional_charmcraft_missing(tmp_path):
     config = load(tmp_path)
     assert config.type is None
     assert config.project.dirpath == tmp_path
+    assert not config.project.config_provided
 
 
 def test_load_specific_directory_resolved(create_config, monkeypatch):
@@ -127,6 +129,15 @@ def test_schema_top_level_no_extra_properties(create_config, check_schema_error)
         whatever: new-stuff
     """)
     check_schema_error("Additional properties are not allowed ('whatever' was unexpected)")
+
+
+def test_schema_type_missing(create_config, check_schema_error):
+    """Schema validation, type is mandatory."""
+    create_config("""
+        charmhub:
+            api_url: 33
+    """)
+    check_schema_error("Bad charmcraft.yaml content; missing fields: type.")
 
 
 def test_schema_type_bad_type(create_config, check_schema_error):


### PR DESCRIPTION
This is because it will be mandatory for the more building-related commands, but not for the more store-related ones.

So, now:

- each command indicates if config is mandatory for it, the infrastructure will check that, so the for the command is safe to assume it's always there (see change in `pack.py`).

- if the config was provided by the user is now an attribute of the Project in config, so the infrastructure (at least) can check it.

- if the config is provided, it's verified with the schema; otherwise everything is bootstrapped by default.

- `type` is back to mandatory if the config is provided.