### PR TITLE
Handling names for bundles: register (new command) and list (generalized previous one).

### DIFF
--- a/charmcraft/commands/store/__init__.py
+++ b/charmcraft/commands/store/__init__.py
@@ -36,6 +36,10 @@ from .store import Store
 
 logger = logging.getLogger('charmcraft.commands.store')
 
+# entity types
+CHARM = 'charm'
+BUNDLE = 'bundle'
+
 LibData = namedtuple(
     'LibData', 'lib_id api patch content content_hash full_name path lib_name charm_name')
 
@@ -67,7 +71,6 @@ class LoginCommand(BaseCommand):
         from your local system, especially in a shared environment.
 
         See also `charmcraft whoami` to verify that you are logged in.
-
     """)
 
     def run(self, parsed_args):
@@ -91,7 +94,6 @@ class LogoutCommand(BaseCommand):
 
         See also `charmcraft whoami` to verify that you are logged in,
         and `charmcraft login`.
-
     """)
 
     def run(self, parsed_args):
@@ -127,8 +129,8 @@ class WhoamiCommand(BaseCommand):
             logger.info(line)
 
 
-class RegisterNameCommand(BaseCommand):
-    """Register a name in Charmhub."""
+class RegisterCharmNameCommand(BaseCommand):
+    """Register a charm name in Charmhub."""
 
     name = 'register'
     help_msg = "Register a charm name in Charmhub"
@@ -151,7 +153,6 @@ class RegisterNameCommand(BaseCommand):
            https://discourse.charmhub.io/c/charm
 
         Registration will take you through login if needed.
-
     """)
     common = True
 
@@ -162,8 +163,45 @@ class RegisterNameCommand(BaseCommand):
     def run(self, parsed_args):
         """Run the command."""
         store = Store(self.config.charmhub)
-        store.register_name(parsed_args.name)
-        logger.info("You are now the publisher of %r in Charmhub.", parsed_args.name)
+        store.register_name(parsed_args.name, CHARM)
+        logger.info("You are now the publisher of charm %r in Charmhub.", parsed_args.name)
+
+
+class RegisterBundleNameCommand(BaseCommand):
+    """Register a bundle name in the Store."""
+
+    name = 'register-bundle'
+    help_msg = "Register a bundle name in the Store"
+    overview = textwrap.dedent("""
+        Register a bundle name in the Store.
+
+        Claim a name for your bundle in Charmhub. Once you have registered
+        a name, you can upload bundle packages for that name and
+        release them for wider consumption.
+
+        Charmhub operates on the 'principle of least surprise' with regard
+        to naming. A bundle with a well-known name should provide the best
+        system for the service most people associate with that name.  Bundles
+        can be renamed in the Charmhub, but we would nonetheless ask
+        you to use a qualified name, such as `yourname-bundlename` if you are
+        in any doubt about your ability to meet that standard.
+
+        We discuss registrations in Charmhub Discourse:
+
+           https://discourse.charmhub.io/c/charm
+
+        Registration will take you through login if needed.
+    """)
+
+    def fill_parser(self, parser):
+        """Add own parameters to the general parser."""
+        parser.add_argument('name', help="The name to register in Charmhub")
+
+    def run(self, parsed_args):
+        """Run the command."""
+        store = Store(self.config.charmhub)
+        store.register_name(parsed_args.name, BUNDLE)
+        logger.info("You are now the publisher of bundle %r in Charmhub.", parsed_args.name)
 
 
 class ListNamesCommand(BaseCommand):
@@ -183,7 +221,6 @@ class ListNamesCommand(BaseCommand):
         other accounts with permission to collaborate on that specific name.
 
         Listing names will take you through login if needed.
-
     """)
     common = True
 
@@ -227,7 +264,6 @@ class UploadCommand(BaseCommand):
         new charm revision.
 
         Upload will take you through login if needed.
-
     """)
     common = True
 
@@ -303,7 +339,6 @@ class ListRevisionsCommand(BaseCommand):
            1           1          2020-11-15    released
 
         Listing revisions will take you through login if needed.
-
     """)
     common = True
 
@@ -697,14 +732,11 @@ class CreateLibCommand(BaseCommand):
         template Python library.
 
         Creating a charm library will take you through login if needed.
-
     """)
 
     def fill_parser(self, parser):
         """Add own parameters to the general parser."""
-        parser.add_argument(
-            'name', metavar='name',
-            help="The name of the library file (e.g. 'db')")
+        parser.add_argument('name', help="The name of the library file (e.g. 'db')")
 
     def run(self, parsed_args):
         """Run the command."""

--- a/charmcraft/commands/store/__init__.py
+++ b/charmcraft/commands/store/__init__.py
@@ -205,16 +205,16 @@ class RegisterBundleNameCommand(BaseCommand):
 
 
 class ListNamesCommand(BaseCommand):
-    """List the charms registered in Charmhub."""
+    """List the entities registered in Charmhub."""
 
     name = 'names'
-    help_msg = "List your registered charm names in Charmhub"
+    help_msg = "List your registered charm and bundle names in Charmhub"
     overview = textwrap.dedent("""
         An overview of names you have registered to publish in Charmhub.
 
           $ charmcraft names
-          Name                Visibility    Status
-          sabdfl-hello-world  public        registered
+          Name                Type    Visibility    Status
+          sabdfl-hello-world  charm   public        registered
 
         Visibility and status are shown for each name. `public` items can be
         seen by any user, while `private` items are only for you and the
@@ -229,15 +229,16 @@ class ListNamesCommand(BaseCommand):
         store = Store(self.config.charmhub)
         result = store.list_registered_names()
         if not result:
-            logger.info("No charms registered.")
+            logger.info("No charms or bundles registered.")
             return
 
-        headers = ['Name', 'Visibility', 'Status']
+        headers = ['Name', 'Type', 'Visibility', 'Status']
         data = []
         for item in result:
             visibility = 'private' if item.private else 'public'
             data.append([
                 item.name,
+                item.entity_type,
                 visibility,
                 item.status,
             ])

--- a/charmcraft/commands/store/__init__.py
+++ b/charmcraft/commands/store/__init__.py
@@ -37,8 +37,7 @@ from .store import Store
 logger = logging.getLogger('charmcraft.commands.store')
 
 # entity types
-CHARM = 'charm'
-BUNDLE = 'bundle'
+EntityType = namedtuple("EntityType", "charm bundle")(charm="charm", bundle="bundle")
 
 LibData = namedtuple(
     'LibData', 'lib_id api patch content content_hash full_name path lib_name charm_name')
@@ -148,7 +147,7 @@ class RegisterCharmNameCommand(BaseCommand):
         you to use a qualified name, such as `yourname-charmname` if you are
         in any doubt about your ability to meet that standard.
 
-        We discuss registrations in Charmhub Discourse:
+        We discuss registrations on Charmhub's Discourse:
 
            https://discourse.charmhub.io/c/charm
 
@@ -163,7 +162,7 @@ class RegisterCharmNameCommand(BaseCommand):
     def run(self, parsed_args):
         """Run the command."""
         store = Store(self.config.charmhub)
-        store.register_name(parsed_args.name, CHARM)
+        store.register_name(parsed_args.name, EntityType.charm)
         logger.info("You are now the publisher of charm %r in Charmhub.", parsed_args.name)
 
 
@@ -186,7 +185,7 @@ class RegisterBundleNameCommand(BaseCommand):
         you to use a qualified name, such as `yourname-bundlename` if you are
         in any doubt about your ability to meet that standard.
 
-        We discuss registrations in Charmhub Discourse:
+        We discuss registrations on Charmhub's Discourse:
 
            https://discourse.charmhub.io/c/charm
 
@@ -200,7 +199,7 @@ class RegisterBundleNameCommand(BaseCommand):
     def run(self, parsed_args):
         """Run the command."""
         store = Store(self.config.charmhub)
-        store.register_name(parsed_args.name, BUNDLE)
+        store.register_name(parsed_args.name, EntityType.bundle)
         logger.info("You are now the publisher of bundle %r in Charmhub.", parsed_args.name)
 
 

--- a/charmcraft/commands/store/store.py
+++ b/charmcraft/commands/store/store.py
@@ -28,7 +28,7 @@ logger = logging.getLogger('charmcraft.commands.store')
 
 # helpers to build responses from this layer
 User = namedtuple('User', 'name username userid')
-Charm = namedtuple('Charm', 'name private status')
+Entity = namedtuple('Charm', 'entity_type name private status')
 Uploaded = namedtuple('Uploaded', 'ok status revision')
 # XXX Facundo 2020-07-23: Need to do a massive rename to call `revno` to the "revision as
 # the number" inside the "revision as the structure", this gets super confusing in the code with
@@ -123,7 +123,9 @@ class Store:
         response = self._client.get('/v1/charm')
         result = []
         for item in response['results']:
-            result.append(Charm(name=item['name'], private=item['private'], status=item['status']))
+            result.append(Entity(
+                name=item['name'], private=item['private'], status=item['status'],
+                entity_type=item['type']))
         return result
 
     def upload(self, name, filepath):

--- a/charmcraft/commands/store/store.py
+++ b/charmcraft/commands/store/store.py
@@ -114,9 +114,9 @@ class Store:
         )
         return result
 
-    def register_name(self, name):
+    def register_name(self, name, entity_type):
         """Register the specified name for the authenticated user."""
-        self._client.post('/v1/charm', {'name': name})
+        self._client.post('/v1/charm', {'name': name, 'type': entity_type})
 
     def list_registered_names(self):
         """Return names registered by the authenticated user."""

--- a/charmcraft/main.py
+++ b/charmcraft/main.py
@@ -89,7 +89,7 @@ COMMAND_GROUPS = [
         # auth
         store.LoginCommand, store.LogoutCommand, store.WhoamiCommand,
         # name handling
-        store.RegisterNameCommand, store.ListNamesCommand,
+        store.RegisterCharmNameCommand, store.RegisterBundleNameCommand, store.ListNamesCommand,
         # pushing files and checking revisions
         store.UploadCommand, store.ListRevisionsCommand,
         # release process, and show status

--- a/completion.bash
+++ b/completion.bash
@@ -31,6 +31,7 @@ _charmcraft()
         pack 
         publish-lib 
         register 
+        register-bundle
         release 
         revisions 
         status 

--- a/tests/commands/test_store_api.py
+++ b/tests/commands/test_store_api.py
@@ -90,10 +90,10 @@ def test_whoami(client_mock, config):
 def test_register_name(client_mock, config):
     """Simple register case."""
     store = Store(config.charmhub)
-    result = store.register_name('testname')
+    result = store.register_name('testname', 'stuff')
 
     assert client_mock.mock_calls == [
-        call.post('/v1/charm', {'name': 'testname'}),
+        call.post('/v1/charm', {'name': 'testname', 'type': 'stuff'}),
     ]
     assert result is None
 

--- a/tests/commands/test_store_api.py
+++ b/tests/commands/test_store_api.py
@@ -118,8 +118,8 @@ def test_list_registered_names_multiple(client_mock, config):
     store = Store(config.charmhub)
 
     auth_response = {'results': [
-        {'name': 'name1', 'private': False, 'status': 'status1'},
-        {'name': 'name2', 'private': True, 'status': 'status2'},
+        {'name': 'name1', 'type': 'charm', 'private': False, 'status': 'status1'},
+        {'name': 'name2', 'type': 'bundle', 'private': True, 'status': 'status2'},
     ]}
     client_mock.get.return_value = auth_response
 
@@ -130,9 +130,11 @@ def test_list_registered_names_multiple(client_mock, config):
     ]
     item1, item2 = result
     assert item1.name == 'name1'
+    assert item1.entity_type == 'charm'
     assert not item1.private
     assert item1.status == 'status1'
     assert item2.name == 'name2'
+    assert item2.entity_type == 'bundle'
     assert item2.private
     assert item2.status == 'status2'
 

--- a/tests/commands/test_store_commands.py
+++ b/tests/commands/test_store_commands.py
@@ -52,7 +52,7 @@ from charmcraft.commands.store import (
 )
 from charmcraft.commands.store.store import (
     Channel,
-    Charm,
+    Entity,
     Error,
     Library,
     Release,
@@ -236,7 +236,7 @@ def test_list_registered_empty(caplog, store_mock, config):
     assert store_mock.mock_calls == [
         call.list_registered_names(),
     ]
-    expected = "No charms registered."
+    expected = "No charms or bundles registered."
     assert [expected] == [rec.message for rec in caplog.records]
 
 
@@ -245,7 +245,7 @@ def test_list_registered_one_private(caplog, store_mock, config):
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
     store_response = [
-        Charm(name='charm', private=True, status='status'),
+        Entity(entity_type='charm', name='charm', private=True, status='status'),
     ]
     store_mock.list_registered_names.return_value = store_response
 
@@ -255,8 +255,8 @@ def test_list_registered_one_private(caplog, store_mock, config):
         call.list_registered_names(),
     ]
     expected = [
-        "Name    Visibility    Status",
-        "charm   private       status",
+        "Name    Type    Visibility    Status",
+        "charm   charm   private       status",
     ]
     assert expected == [rec.message for rec in caplog.records]
 
@@ -266,7 +266,7 @@ def test_list_registered_one_public(caplog, store_mock, config):
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
     store_response = [
-        Charm(name='charm', private=False, status='status'),
+        Entity(entity_type='charm', name='charm', private=False, status='status'),
     ]
     store_mock.list_registered_names.return_value = store_response
 
@@ -276,8 +276,8 @@ def test_list_registered_one_public(caplog, store_mock, config):
         call.list_registered_names(),
     ]
     expected = [
-        "Name    Visibility    Status",
-        "charm   public        status",
+        "Name    Type    Visibility    Status",
+        "charm   charm   public        status",
     ]
     assert expected == [rec.message for rec in caplog.records]
 
@@ -287,9 +287,10 @@ def test_list_registered_several(caplog, store_mock, config):
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
     store_response = [
-        Charm(name='charm1', private=True, status='simple status'),
-        Charm(name='charm2-long-name', private=False, status='other'),
-        Charm(name='charm3', private=True, status='super long status'),
+        Entity(entity_type='charm', name='charm1', private=True, status='simple status'),
+        Entity(entity_type='charm', name='charm2-long-name', private=False, status='other'),
+        Entity(entity_type='charm', name='charm3', private=True, status='super long status'),
+        Entity(entity_type='bundle', name='somebundle', private=False, status='bundle status'),
     ]
     store_mock.list_registered_names.return_value = store_response
 
@@ -299,10 +300,11 @@ def test_list_registered_several(caplog, store_mock, config):
         call.list_registered_names(),
     ]
     expected = [
-        "Name              Visibility    Status",
-        "charm1            private       simple status",
-        "charm2-long-name  public        other",
-        "charm3            private       super long status",
+        "Name              Type    Visibility    Status",
+        "charm1            charm   private       simple status",
+        "charm2-long-name  charm   public        other",
+        "charm3            charm   private       super long status",
+        "somebundle        bundle  public        bundle status",
     ]
     assert expected == [rec.message for rec in caplog.records]
 

--- a/tests/commands/test_store_commands.py
+++ b/tests/commands/test_store_commands.py
@@ -32,9 +32,8 @@ from charmcraft.config import CharmhubConfig
 from charmcraft.cmdbase import CommandError
 from charmcraft.commands.store import (
     _get_lib_info,
-    CHARM,
-    BUNDLE,
     CreateLibCommand,
+    EntityType,
     FetchLibCommand,
     ListLibCommand,
     ListNamesCommand,
@@ -204,7 +203,7 @@ def test_register_charm_name(caplog, store_mock, config):
     RegisterCharmNameCommand('group', config).run(args)
 
     assert store_mock.mock_calls == [
-        call.register_name('testname', CHARM),
+        call.register_name('testname', EntityType.charm),
     ]
     expected = "You are now the publisher of charm 'testname' in Charmhub."
     assert [expected] == [rec.message for rec in caplog.records]
@@ -218,7 +217,7 @@ def test_register_bundle_name(caplog, store_mock, config):
     RegisterBundleNameCommand('group', config).run(args)
 
     assert store_mock.mock_calls == [
-        call.register_name('testname', BUNDLE),
+        call.register_name('testname', EntityType.bundle),
     ]
     expected = "You are now the publisher of bundle 'testname' in Charmhub."
     assert [expected] == [rec.message for rec in caplog.records]

--- a/tests/commands/test_store_commands.py
+++ b/tests/commands/test_store_commands.py
@@ -32,6 +32,8 @@ from charmcraft.config import CharmhubConfig
 from charmcraft.cmdbase import CommandError
 from charmcraft.commands.store import (
     _get_lib_info,
+    CHARM,
+    BUNDLE,
     CreateLibCommand,
     FetchLibCommand,
     ListLibCommand,
@@ -40,7 +42,8 @@ from charmcraft.commands.store import (
     LoginCommand,
     LogoutCommand,
     PublishLibCommand,
-    RegisterNameCommand,
+    RegisterCharmNameCommand,
+    RegisterBundleNameCommand,
     ReleaseCommand,
     StatusCommand,
     UploadCommand,
@@ -193,17 +196,31 @@ def test_whoami(caplog, store_mock, config):
 # -- tests for name-related commands
 
 
-def test_register_name(caplog, store_mock, config):
-    """Simple register_name case."""
+def test_register_charm_name(caplog, store_mock, config):
+    """Simple register_name case for a charm."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
     args = Namespace(name='testname')
-    RegisterNameCommand('group', config).run(args)
+    RegisterCharmNameCommand('group', config).run(args)
 
     assert store_mock.mock_calls == [
-        call.register_name('testname'),
+        call.register_name('testname', CHARM),
     ]
-    expected = "You are now the publisher of 'testname' in Charmhub."
+    expected = "You are now the publisher of charm 'testname' in Charmhub."
+    assert [expected] == [rec.message for rec in caplog.records]
+
+
+def test_register_bundle_name(caplog, store_mock, config):
+    """Simple register_name case for a bundl."""
+    caplog.set_level(logging.INFO, logger="charmcraft.commands")
+
+    args = Namespace(name='testname')
+    RegisterBundleNameCommand('group', config).run(args)
+
+    assert store_mock.mock_calls == [
+        call.register_name('testname', BUNDLE),
+    ]
+    expected = "You are now the publisher of bundle 'testname' in Charmhub."
     assert [expected] == [rec.message for rec in caplog.records]
 
 


### PR DESCRIPTION
Also took the opportunity for a couple of small improvements:

- empty line after commands help text is superfluous (the formatter takes care of that, so I changed those that were inconsistent)

- a `meta` was redundantly used in a argparse option