### PR TITLE
Add init documentation for a gentle introduction to the charm operator

### DIFF
--- a/charmcraft/templates/init/src/charm.py.j2
+++ b/charmcraft/templates/init/src/charm.py.j2
@@ -4,10 +4,10 @@
 
 """Charm the service.
 
-Refer to [1] for a quick-start guide that will help you develop a new k8s charm
-using the operator framework.
+Refer to the following post for a quick-start guide that will help you 
+develop a new k8s charm using the Operator Framework:
 
-[1] https://discourse.charmhub.io/t/quick-start-guide-to-help-you-write-a-k8s-charm-using-the-operator-framework/4208
+    https://discourse.charmhub.io/t/4208
 """
 
 import logging

--- a/charmcraft/templates/init/src/charm.py.j2
+++ b/charmcraft/templates/init/src/charm.py.j2
@@ -4,7 +4,7 @@
 
 """Charm the service.
 
-Refer to the following post for a quick-start guide that will help you 
+Refer to the following post for a quick-start guide that will help you
 develop a new k8s charm using the Operator Framework:
 
     https://discourse.charmhub.io/t/4208

--- a/charmcraft/templates/init/src/charm.py.j2
+++ b/charmcraft/templates/init/src/charm.py.j2
@@ -2,7 +2,51 @@
 # Copyright {{ year }} {{ author }}
 # See LICENSE file for licensing details.
 
-"""Charm the service."""
+"""Charm the service.
+
+To gently guide you through the recommended way to write and deploy your new charm,
+here are some essential links and instructions to get you up-to-speed.
+
+To ease the development iterations on your computer we suggest you to setup a
+microk8s environment [1], in summary it will be:
+
+snap install juju --classic
+snap install microk8s --classic
+microk8s.enable dns storage
+juju bootstrap microk8s micro
+juju add-model my-charm-model
+
+At this point you have a controller named "micro" in the "microk8s" cloud. This
+cloud is actually your local machine, how neat! In Juju, you interact with the client
+(the juju command on your local machine). It connects to a controller. The controller
+is hosted on a cloud and controls models.
+
+This charm although simple is fully functional. You can build and deploy it on your
+microk8s cloud as following:
+
+charmcraft build
+juju deploy ./{{name}}-charm
+
+It may take a while to have the deployment finished, in the meantime you can check
+the status by:
+
+juju status
+
+From this point you are ready to start discovering how the Operation Framework
+works [2] and some more specifics about config, log, testing among other topics
+[3].
+
+If you are curious on how other existing operators are implemented refer to the
+MongoDB [4], Elasticsearch[5], or Redis[6] for inspiration on other topics such
+as relation management, replication and lifecycle management.
+
+[1] https://juju.is/docs/microk8s-cloud
+[2] https://discourse.charmhub.io/t/documentation-operator-framework/3394
+[3] https://discourse.charmhub.io/t/first-steps-with-the-operator-framework/3006
+[4] https://github.com/canonical/mongodb-operator
+[5] https://github.com/canonical/elasticsearch-operator
+[6] https://github.com/canonical/redis-operator
+"""
 
 import logging
 

--- a/charmcraft/templates/init/src/charm.py.j2
+++ b/charmcraft/templates/init/src/charm.py.j2
@@ -4,11 +4,9 @@
 
 """Charm the service.
 
-To gently guide you through the recommended way to write and deploy your new charm,
-here are some essential links and instructions to get you up-to-speed.
-
-To ease the development iterations on your computer we suggest you to setup a
-microk8s environment [1], in summary it will be:
+This is a quick-start guide to help you write and deploy a new k8s charm using the
+operator framework. To ease the development, we suggest you to setup a microk8s
+environment [1] by running:
 
 snap install juju --classic
 snap install microk8s --classic
@@ -28,24 +26,27 @@ charmcraft build
 juju deploy ./{{name}}-charm
 
 It may take a while to have the deployment finished, in the meantime you can check
-the status by:
+the status by running:
 
 juju status
 
-From this point you are ready to start discovering how the Operation Framework
-works [2] and some more specifics about config, log, testing among other topics
-[3].
+Now you are ready to start discovering how the operator framework works [2] and
+learn some more specifics about config, log, testing among other topics [3].
 
 If you are curious on how other existing operators are implemented refer to the
-MongoDB [4], Elasticsearch[5], or Redis[6] for inspiration on other topics such
-as relation management, replication and lifecycle management.
+MongoDB [4] and Elasticsearch[5] operators for inspiration on other topics such
+as relation, replication and lifecycle management.
+
+If still in doubt you can ask questions about the operator framework. There are
+multiple communication channels [6].
 
 [1] https://juju.is/docs/microk8s-cloud
 [2] https://discourse.charmhub.io/t/documentation-operator-framework/3394
 [3] https://discourse.charmhub.io/t/first-steps-with-the-operator-framework/3006
 [4] https://github.com/canonical/mongodb-operator
 [5] https://github.com/canonical/elasticsearch-operator
-[6] https://github.com/canonical/redis-operator
+[6] https://github.com/canonical/operator#talk-to-us
+
 """
 
 import logging

--- a/charmcraft/templates/init/src/charm.py.j2
+++ b/charmcraft/templates/init/src/charm.py.j2
@@ -4,49 +4,10 @@
 
 """Charm the service.
 
-This is a quick-start guide to help you write and deploy a new k8s charm using the
-operator framework. To ease the development, we suggest you to setup a microk8s
-environment [1] by running:
+Refer to [1] for a quick-start guide that will help you develop a new k8s charm
+using the operator framework.
 
-snap install juju --classic
-snap install microk8s --classic
-microk8s.enable dns storage
-juju bootstrap microk8s micro
-juju add-model my-charm-model
-
-At this point you have a controller named "micro" in the "microk8s" cloud. This
-cloud is actually your local machine, how neat! In Juju, you interact with the client
-(the juju command on your local machine). It connects to a controller. The controller
-is hosted on a cloud and controls models.
-
-This charm although simple is fully functional. You can build and deploy it on your
-microk8s cloud as following:
-
-charmcraft build
-juju deploy ./{{name}}-charm
-
-It may take a while to have the deployment finished, in the meantime you can check
-the status by running:
-
-juju status
-
-Now you are ready to start discovering how the operator framework works [2] and
-learn some more specifics about config, log, testing among other topics [3].
-
-If you are curious on how other existing operators are implemented refer to the
-MongoDB [4] and Elasticsearch[5] operators for inspiration on other topics such
-as relation, replication and lifecycle management.
-
-If still in doubt you can ask questions about the operator framework. There are
-multiple communication channels [6].
-
-[1] https://juju.is/docs/microk8s-cloud
-[2] https://discourse.charmhub.io/t/documentation-operator-framework/3394
-[3] https://discourse.charmhub.io/t/first-steps-with-the-operator-framework/3006
-[4] https://github.com/canonical/mongodb-operator
-[5] https://github.com/canonical/elasticsearch-operator
-[6] https://github.com/canonical/operator#talk-to-us
-
+[1] https://discourse.charmhub.io/t/quick-start-guide-to-help-you-write-a-k8s-charm-using-the-operator-framework/4208
 """
 
 import logging


### PR DESCRIPTION
So I have recently worked on creating a new charm [operator for Redis](https://github.com/edumucelli/redis-operator). As someone new to Juju and with some knowledge on K8s I ended up struggling a bit to find where were the documentation, examples and even how to set up my local environment to make things work. Consider it as someone new to the whole context: I even searched for the instructions as someone from the outside, looking on Google for documentation -- which mostly took me to the reactive operator.

@mthaddon took some time today to discuss with me and gather some feedback about how the process was to understand where things were easy and where the main roadblocks were. One thing I have mentioned is that the skeleton command `charmcraft init` was great to give something that was already in the expected format -- thanks for that. However, from there I was mostly lost. It took me around 10 days to get the Redis operator working, but I think that having the right links this can be way faster.

One thing @mthaddon suggested was if the `init` command had some more documentation or pointers where to go, or what to do after you are there.

This PR takes most of my notes and some links I have found during the process that could have been useful for someone starting writing a charm with the operator framework. Things that really helped me were the existing up-to-date charms such as the MongoDB (thanks @balbirthomas) one and the discussion with many people here and there that materialized with some stuff I have did in the Redis one, usage of the, e.g., [resource-oci-image](https://github.com/juju-solutions/resource-oci-image) library (thanks @johnsca) as I would have found nowhere suggesting me to use it.