### PR TITLE
Final commands changes for Bundles support.

### DIFF
--- a/charmcraft/utils.py
+++ b/charmcraft/utils.py
@@ -69,6 +69,30 @@ def get_templates_environment(templates_dir):
     return env
 
 
+class SingleOptionEnsurer:
+    """Argparse helper to ensure that the option is specified only once, converting it properly.
+
+    Receives a callable to convert the string from command line to the desired object.
+
+    Example of use:
+
+        parser.add_argument('-n', '--number',  type=SingleOptionEnsurer(int), required=True)
+
+    No lower limit is checked, that is verified with required=True in the argparse definition.
+    """
+
+    def __init__(self, converter):
+        self.converter = converter
+        self.count = 0
+
+    def __call__(self, value):
+        """Run by argparse to validate and convert the given argument."""
+        self.count += 1
+        if self.count > 1:
+            raise ValueError("the option can be specified only once")
+        return self.converter(value)
+
+
 def useful_filepath(filepath):
     """Return a valid Path with user name expansion for filepath.
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -21,7 +21,7 @@ import pathlib
 import pytest
 
 from charmcraft.cmdbase import CommandError
-from charmcraft.utils import make_executable, load_yaml, useful_filepath
+from charmcraft.utils import make_executable, SingleOptionEnsurer, load_yaml, useful_filepath
 
 
 def test_make_executable_read_bits(tmp_path):
@@ -96,6 +96,23 @@ def test_load_yaml_file_problem(tmp_path, caplog):
     (logged,) = [rec.message for rec in caplog.records]
     assert "Failed to read/parse config file {}".format(test_file) in logged
     assert "PermissionError" in logged
+
+
+# -- tests for the SingleOptionEnsurer helper class
+
+def test_singleoptionensurer_convert_ok():
+    """Work fine with one call, convert as expected."""
+    soe = SingleOptionEnsurer(int)
+    assert soe('33') == 33
+
+
+def test_singleoptionensurer_too_many():
+    """Raise an error after one ok call."""
+    soe = SingleOptionEnsurer(int)
+    assert soe('33') == 33
+    with pytest.raises(ValueError) as cm:
+        soe('33')
+    assert str(cm.value) == "the option can be specified only once"
 
 
 # -- tests for the useful_filepath helper


### PR DESCRIPTION
Explained changes (UX changes accoording to [this doc](https://docs.google.com/document/d/1dqzoFLEaB_1N_jJJdmsoCxeLUtTZRakveXF8aHx6lFA/)):

- `revisions` and `status`: now `name` is mandatory (no longer guessed from metadata)

- `release` now gets `name` as first mandatory parameter, then `--revision` as a mandatory option (only one allowed!) and `--channel` as mandatory option (multiple allowed).
