### PR TITLE
Mutate - to _ to make importable names

### DIFF
--- a/charmcraft/commands/store/__init__.py
+++ b/charmcraft/commands/store/__init__.py
@@ -719,6 +719,8 @@ def _get_libs_from_tree(charm_name=None):
 
     It only follows/uses the the directories/files for a correct charmlibs
     disk structure.
+
+    This can take charm_name as both importable and normal form.
     """
     local_libs_data = []
 
@@ -726,8 +728,8 @@ def _get_libs_from_tree(charm_name=None):
         base_dir = pathlib.Path('lib') / 'charms'
         charm_dirs = sorted(base_dir.iterdir()) if base_dir.is_dir() else []
     else:
-        charm_name = create_importable_name(charm_name)
-        base_dir = pathlib.Path('lib') / 'charms' / charm_name
+        importable_charm_name = create_importable_name(charm_name)
+        base_dir = pathlib.Path('lib') / 'charms' / importable_charm_name
         charm_dirs = [base_dir] if base_dir.is_dir() else []
 
     for charm_dir in charm_dirs:

--- a/charmcraft/commands/store/__init__.py
+++ b/charmcraft/commands/store/__init__.py
@@ -881,7 +881,7 @@ class PublishLibCommand(BaseCommand):
 
         for lib_data in to_publish:
             store.create_library_revision(
-                charm_name, lib_data.lib_id, lib_data.api, lib_data.patch,
+                lib_data.charm_name, lib_data.lib_id, lib_data.api, lib_data.patch,
                 lib_data.content, lib_data.content_hash)
             logger.info(
                 "Library %s sent to the store with version %d.%d",

--- a/tests/commands/test_store_commands.py
+++ b/tests/commands/test_store_commands.py
@@ -1105,6 +1105,34 @@ def test_createlib_name_from_metadata_problem(store_mock, config):
             "directory with metadata.yaml.")
 
 
+def test_createlib_name_contains_dash(caplog, store_mock, tmp_path, monkeypatch, config):
+    """'-' is valid in charm names but can't be imported"""
+    caplog.set_level(logging.INFO, logger="charmcraft.commands")
+    monkeypatch.chdir(tmp_path)
+
+    lib_id = 'test-example-lib-id'
+    store_mock.create_library_id.return_value = lib_id
+
+    args = Namespace(name='testlib')
+    with patch('charmcraft.commands.store.get_name_from_metadata') as mock:
+        mock.return_value = 'test-charm'
+        CreateLibCommand('group', config).run(args)
+
+    assert store_mock.mock_calls == [
+        call.create_library_id('test-charm', 'testlib'),
+    ]
+    expected = [
+        "Library charms.test_charm.v0.testlib created with id test-example-lib-id.",
+        "Consider 'git add lib/charms/test_charm/v0/testlib.py'.",
+    ]
+    assert expected == [rec.message for rec in caplog.records]
+    created_lib_file = tmp_path / 'lib' / 'charms' / 'test_charm' / 'v0' / 'testlib.py'
+
+    env = get_templates_environment('charmlibs')
+    expected_newlib_content = env.get_template('new_library.py.j2').render(lib_id=lib_id)
+    assert created_lib_file.read_text() == expected_newlib_content
+
+
 @pytest.mark.parametrize('lib_name', [
     'foo.bar',
     'foo/bar',
@@ -1135,12 +1163,12 @@ def test_createlib_path_already_there(tmp_path, monkeypatch, config):
             CreateLibCommand('group', config).run(args)
 
     assert str(err.value) == (
-        "This library already exists: lib/charms/test-charm-name/v0/testlib.py")
+        "This library already exists: lib/charms/test_charm_name/v0/testlib.py")
 
 
 def test_createlib_path_can_not_write(tmp_path, monkeypatch, store_mock, add_cleanup, config):
     """Disk error when trying to write the new lib (bad permissions, name too long, whatever)."""
-    lib_dir = tmp_path / 'lib' / 'charms' / 'test-charm-name' / 'v0'
+    lib_dir = tmp_path / 'lib' / 'charms' / 'test_charm_name' / 'v0'
     lib_dir.mkdir(parents=True)
     lib_dir.chmod(0o111)
     add_cleanup(lib_dir.chmod, 0o777)
@@ -1188,6 +1216,29 @@ def test_publishlib_simple(caplog, store_mock, tmp_path, monkeypatch, config):
     assert [expected] == [rec.message for rec in caplog.records]
 
 
+def test_publishlib_contains_dash(caplog, store_mock, tmp_path, monkeypatch, config):
+    """Happy path publishing because no revision at all in the Store."""
+    caplog.set_level(logging.INFO, logger="charmcraft.commands")
+    monkeypatch.chdir(tmp_path)
+
+    lib_id = 'test-example-lib-id'
+    content, content_hash = factory.create_lib_filepath(
+        'test-charm', 'testlib', api=0, patch=1, lib_id=lib_id)
+
+    store_mock.get_libraries_tips.return_value = {}
+    args = Namespace(library='charms.test_charm.v0.testlib')
+    with patch('charmcraft.commands.store.get_name_from_metadata') as mock:
+        mock.return_value = 'test-charm'
+        PublishLibCommand('group', config).run(args)
+
+    assert store_mock.mock_calls == [
+        call.get_libraries_tips([{'lib_id': lib_id, 'api': 0}]),
+        call.create_library_revision('test-charm', lib_id, 0, 1, content, content_hash),
+    ]
+    expected = "Library charms.test_charm.v0.testlib sent to the store with version 0.1"
+    assert [expected] == [rec.message for rec in caplog.records]
+
+
 def test_publishlib_all(caplog, store_mock, tmp_path, monkeypatch, config):
     """Publish all the libraries found in disk."""
     caplog.set_level(logging.DEBUG, logger="charmcraft.commands")
@@ -1219,15 +1270,15 @@ def test_publishlib_all(caplog, store_mock, tmp_path, monkeypatch, config):
         call.create_library_revision('testcharm-1', 'lib_id_3', 1, 3, c3, h3),
     ]
     names = [
-        'charms.testcharm-1.v0.testlib-a',
-        'charms.testcharm-1.v0.testlib-b',
-        'charms.testcharm-1.v1.testlib-b',
+        'charms.testcharm_1.v0.testlib-a',
+        'charms.testcharm_1.v0.testlib-b',
+        'charms.testcharm_1.v1.testlib-b',
     ]
     expected = [
-        "Libraries found under lib/charms/testcharm-1: " + str(names),
-        "Library charms.testcharm-1.v0.testlib-a sent to the store with version 0.1",
-        "Library charms.testcharm-1.v0.testlib-b sent to the store with version 0.1",
-        "Library charms.testcharm-1.v1.testlib-b sent to the store with version 1.3",
+        "Libraries found under lib/charms/testcharm_1: " + str(names),
+        "Library charms.testcharm_1.v0.testlib-a sent to the store with version 0.1",
+        "Library charms.testcharm_1.v0.testlib-b sent to the store with version 0.1",
+        "Library charms.testcharm_1.v1.testlib-b sent to the store with version 1.3",
     ]
     records = [rec.message for rec in caplog.records]
     assert all(e in records for e in expected)
@@ -1723,6 +1774,35 @@ def test_fetchlib_simple_downloaded(caplog, store_mock, tmp_path, monkeypatch, c
     expected = "Library charms.testcharm.v0.testlib version 0.7 downloaded."
     assert [expected] == [rec.message for rec in caplog.records]
     saved_file = tmp_path / 'lib' / 'charms' / 'testcharm' / 'v0' / 'testlib.py'
+    assert saved_file.read_text() == lib_content
+
+
+def test_fetchlib_simple_dash_in_name(caplog, store_mock, tmp_path, monkeypatch, config):
+    """Happy path fetching the lib for the first time (downloading it)."""
+    caplog.set_level(logging.INFO, logger="charmcraft.commands")
+    monkeypatch.chdir(tmp_path)
+
+    lib_id = 'test-example-lib-id'
+    lib_content = 'some test content with uñicode ;)'
+    store_mock.get_libraries_tips.return_value = {
+        (lib_id, 0): Library(
+            lib_id=lib_id, content=None, content_hash='abc', api=0, patch=7,
+            lib_name='testlib', charm_name='test-charm'),
+    }
+    store_mock.get_library.return_value = Library(
+        lib_id=lib_id, content=lib_content, content_hash='abc', api=0, patch=7,
+        lib_name='testlib', charm_name='test-charm')
+
+    FetchLibCommand('group', config).run(Namespace(library='charms.test_charm.v0.testlib'))
+
+    assert store_mock.mock_calls == [
+        call.get_libraries_tips(
+            [{'charm_name': 'test-charm', 'lib_name': 'testlib', 'api': 0}]),
+        call.get_library('test-charm', lib_id, 0),
+    ]
+    expected = "Library charms.test_charm.v0.testlib version 0.7 downloaded."
+    assert [expected] == [rec.message for rec in caplog.records]
+    saved_file = tmp_path / 'lib' / 'charms' / 'test_charm' / 'v0' / 'testlib.py'
     assert saved_file.read_text() == lib_content
 
 

--- a/tests/factory.py
+++ b/tests/factory.py
@@ -20,7 +20,7 @@ import pathlib
 import textwrap
 
 from charmcraft.cmdbase import BaseCommand
-from charmcraft.commands.store import _get_lib_info
+from charmcraft.commands.store import _get_lib_info, create_importable_name
 
 
 def create_command(name_, help_msg_=None, common_=False, overview_=None):
@@ -44,6 +44,7 @@ def create_command(name_, help_msg_=None, common_=False, overview_=None):
 
 def create_lib_filepath(charm_name, lib_name, api=0, patch=1, lib_id='test-lib-id'):
     """Helper to create the structures on disk for a given lib."""
+    charm_name = create_importable_name(charm_name)
     base_dir = pathlib.Path('lib')
     lib_file = base_dir / 'charms' / charm_name / 'v{}'.format(api) / "{}.py".format(lib_name)
     lib_file.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Using '-' in a name means that the charmlib will have an un-importable path.

Mutate that to '_', and use that in places where we need to. This can be reversed from the filepath as '_' is not valid in a charm name (via https://juju.is/docs/charm-metadata )

Closes #265