### PR TITLE
Set unit status in default charm

### DIFF
--- a/charmcraft/templates/init/src/charm.py.j2
+++ b/charmcraft/templates/init/src/charm.py.j2
@@ -15,6 +15,7 @@ import logging
 from ops.charm import CharmBase
 from ops.main import main
 from ops.framework import StoredState
+from ops.model import ActiveStatus
 
 logger = logging.getLogger(__name__)
 
@@ -26,9 +27,14 @@ class {{ class_name }}(CharmBase):
 
     def __init__(self, *args):
         super().__init__(*args)
+        self.framework.observe(self.on.install, self._on_install)
         self.framework.observe(self.on.config_changed, self._on_config_changed)
         self.framework.observe(self.on.fortune_action, self._on_fortune_action)
         self._stored.set_default(things=[])
+
+    def _on_install(self, _):
+        # Perform any install steps and report status
+        self.unit.status = ActiveStatus("Active and running")
 
     def _on_config_changed(self, _):
         # Note: you need to uncomment the example in the config.yaml file for this to work (ensure


### PR DESCRIPTION
This addresses https://github.com/canonical/charmcraft/issues/267 by adding a call to set the status in the init template for the charm.