### PR TITLE
Add lib path to run_tests template

### DIFF
--- a/charmcraft/templates/init/run_tests.j2
+++ b/charmcraft/templates/init/run_tests.j2
@@ -7,9 +7,9 @@ if [ -z "$VIRTUAL_ENV" -a -d venv/ ]; then
 fi
 
 if [ -z "$PYTHONPATH" ]; then
-    export PYTHONPATH=src
+    export PYTHONPATH="lib:src"
 else
-    export PYTHONPATH="src:$PYTHONPATH"
+    export PYTHONPATH="lib:src:$PYTHONPATH"
 fi
 
 flake8


### PR DESCRIPTION
If you added a library to your charm, the tests would not run as it is not in the PYTHONPATH provided by the `run_tests` script.

Add it, so that tests will run.