### PR TITLE
snap: strict -> classic confinement for Charmcraft snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -50,7 +50,7 @@ architectures:
 
 apps:
   charmcraft:
-    command: bin/charmcraft
+    command: bin/python3 $SNAP/bin/charmcraft
     completer: completion.bash
     plugs:
       - home            # so it can acess files under the user's home
@@ -59,7 +59,7 @@ apps:
       - desktop         # so the right default browser can be used
     environment:
       # help python pick up useful things from the base snap
-      PYTHONPATH: /usr/lib/python3/dist-packages:$SNAP/lib
+      PYTHONPATH: /snap/core20/current/usr/lib/python3/dist-packages:$SNAP/lib
       # have the cache outside of the version dirs (avoids keeping N copies)
       XDG_CACHE_HOME: $SNAP_USER_COMMON/cache
       # same for config
@@ -71,10 +71,27 @@ apps:
       GIT_EXEC_PATH: $SNAP/git/git-core
 
 grade: stable
-confinement: strict
+confinement: classic
 
 parts:
+  # Classic core20 snaps require staged python.
+  python3:
+    plugin: nil
+    stage-packages:
+      - libpython3-stdlib
+      - libpython3.8-minimal
+      - libpython3.8-stdlib
+      - python3.8-minimal
+      - python3-distutils
+      - python3-minimal
+      - python3-pkg-resources
+      - python3-pip
+      - python3-setuptools
+      - python3-venv
+      - python3-wheel
+
   charmcraft:
+    after: [python3]
     source: .
     plugin: python
     build-packages:
@@ -93,6 +110,8 @@ parts:
       snapcraftctl build
       # why is this needed?
       cp -v completion.bash ../install
+      # python3 fixup symlink (snapcraft bug)
+      ln -sf ../usr/bin/python3.8 $SNAPCRAFT_PART_INSTALL/bin/python3
     organize:
       # move things around so they're tidier
       usr/lib/git-core: git/git-core


### PR DESCRIPTION
Classic snaps on core20 require python3.  Add this collection
of stage packages as its own part to separate stage filtering
used in the charmcraft part.

There is an apparent bug in Snacpraft where it will set the
bin/python3 to an invalid symlink in this scenario.  Hardcode
the correct symlink until we have a fix in place for Snapcraft.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>