### PR TITLE
Specify the resource type when uploading one.

### DIFF
--- a/charmcraft/commands/store/__init__.py
+++ b/charmcraft/commands/store/__init__.py
@@ -42,8 +42,9 @@ from .store import Store
 
 logger = logging.getLogger('charmcraft.commands.store')
 
-# entity types
+# some types
 EntityType = namedtuple("EntityType", "charm bundle")(charm="charm", bundle="bundle")
+ResourceType = namedtuple("ResourceType", "file oci_image")(file="file", oci_image="oci-image")
 
 LibData = namedtuple(
     'LibData', 'lib_id api patch content content_hash full_name path lib_name charm_name')
@@ -1093,7 +1094,7 @@ class ListResourcesCommand(BaseCommand):
 
     def fill_parser(self, parser):
         """Add own parameters to the general parser."""
-        parser.add_argument('charm_name', metavar='resource-name', help="The name of the charm")
+        parser.add_argument('charm_name', metavar='charm-name', help="The name of the charm")
 
     def run(self, parsed_args):
         """Run the command."""
@@ -1153,8 +1154,14 @@ class UploadResourceCommand(BaseCommand):
     def run(self, parsed_args):
         """Run the command."""
         store = Store(self.config.charmhub)
+        resource_filepath = parsed_args.filepath
+        resource_type = ResourceType.file
+        logger.debug("Uploading resource directly from file %s", resource_filepath)
+
         result = store.upload_resource(
-            parsed_args.charm_name, parsed_args.resource_name, parsed_args.filepath)
+            parsed_args.charm_name, parsed_args.resource_name,
+            resource_type, resource_filepath)
+
         if result.ok:
             logger.info(
                 "Revision %s created of resource %r for charm %r",
@@ -1175,7 +1182,7 @@ class ListResourceRevisionsCommand(BaseCommand):
 
         For example:
 
-           $ charmcraft resource-revisions
+           $ charmcraft resource-revisions my-charm my-resource
            Revision    Created at     Size
            1           2020-11-15   183151
 

--- a/charmcraft/commands/store/store.py
+++ b/charmcraft/commands/store/store.py
@@ -155,10 +155,13 @@ class Store:
                 entity_type=item['type']))
         return result
 
-    def _upload(self, endpoint, filepath):
+    def _upload(self, endpoint, filepath, *, extra_fields=None):
         """Upload for all charms, bundles and resources (generic process)."""
         upload_id = self._client.push(filepath)
-        response = self._client.post(endpoint, {'upload-id': upload_id})
+        payload = {'upload-id': upload_id}
+        if extra_fields is not None:
+            payload.update(extra_fields)
+        response = self._client.post(endpoint, payload)
         status_url = response['status-url']
         logger.debug("Upload %s started, got status url %s", upload_id, status_url)
 
@@ -184,10 +187,10 @@ class Store:
         endpoint = '/v1/charm/{}/revisions'.format(name)
         return self._upload(endpoint, filepath)
 
-    def upload_resource(self, charm_name, resource_name, filepath):
+    def upload_resource(self, charm_name, resource_name, resource_type, filepath):
         """Upload the content of filepath to the indicated resource."""
         endpoint = '/v1/charm/{}/resources/{}/revisions'.format(charm_name, resource_name)
-        return self._upload(endpoint, filepath)
+        return self._upload(endpoint, filepath, extra_fields={'type': resource_type})
 
     def list_revisions(self, name):
         """Return charm revisions for the indicated charm."""

--- a/tests/commands/test_store_commands.py
+++ b/tests/commands/test_store_commands.py
@@ -2309,7 +2309,7 @@ def test_uploadresource_call_ok(caplog, store_mock, config, tmp_path):
     UploadResourceCommand('group', config).run(args)
 
     assert store_mock.mock_calls == [
-        call.upload_resource('mycharm', 'myresource', test_resource)
+        call.upload_resource('mycharm', 'myresource', 'file', test_resource)
     ]
     expected = "Revision 7 created of resource 'myresource' for charm 'mycharm'"
     assert [expected] == [rec.message for rec in caplog.records]


### PR DESCRIPTION

This is because the API changed, specifying the type for files is optional (for now), but we will need it soon to indicate oci-image types.

Also fixed/improved two help-related details in other commands.
