### PR TITLE
Update charm library template for correct command to publish or update libraries

### DIFF
--- a/charmcraft/templates/charmlibs/new_library.py.j2
+++ b/charmcraft/templates/charmlibs/new_library.py.j2
@@ -7,7 +7,7 @@ library.
 Complete documentation about creating and documenting libraries can be found 
 in the SDK docs at https://juju.is/docs/sdk/libraries.
 
-See `charmcraft push-lib` and `charmcraft fetch-lib` for details of how to
+See `charmcraft publish-lib` and `charmcraft fetch-lib` for details of how to
 share and consume charm libraries. They serve to enhance collaboration
 between charmers. Use a charmer's libraries for classes that handle
 integration with their charm.
@@ -25,7 +25,7 @@ LIBID = "{{ lib_id }}"
 # Increment this major API version when introducing breaking changes
 LIBAPI = 0
 
-# Increment this PATCH version before using `charmcraft push-lib` or reset
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
 LIBPATCH = 1
 


### PR DESCRIPTION
`charmcraft push-lib` doesn't seem to exist currently, update the template to use the correct command.