### PR TITLE
Better manifest in case of strict snap.

### DIFF
--- a/charmcraft/utils.py
+++ b/charmcraft/utils.py
@@ -175,7 +175,7 @@ def get_os_platform(filepath=pathlib.Path("/etc/os-release")):
                 if value[0] == value[-1] and value[0] in ('"', "'"):
                     value = value[1:-1]
                 os_release[key] = value
-            system = os_release.get("NAME", system)
+            system = os_release.get("ID", system)
             release = os_release.get("VERSION_ID", release)
 
     return OSPlatform(system=system, release=release, machine=machine)
@@ -192,13 +192,21 @@ def create_manifest(basedir, started_at):
     # we integrate lifecycle lib in future branches
     architectures = [ARCH_TRANSLATIONS.get(os_platform.machine, os_platform.machine)]
 
+    # XXX Facundo 2021-04-19: these are temporary translations until charmcraft
+    # changes to be a "classic" snap
+    name_translation = {'ubuntu core': 'ubuntu'}
+    channel_translation = {'20': '20.04'}
+    name = os_platform.system.lower()
+    name = name_translation.get(name, name)
+    channel = channel_translation.get(os_platform.release, os_platform.release)
+
     content = {
         'charmcraft-version': __version__,
         'charmcraft-started-at': started_at.isoformat() + "Z",
         'bases': [
             {
-                'name': os_platform.system.lower(),
-                'channel': os_platform.release,
+                'name': name,
+                'channel': channel,
                 'architectures': architectures,
             }
         ],

--- a/charmcraft/utils.py
+++ b/charmcraft/utils.py
@@ -194,7 +194,7 @@ def create_manifest(basedir, started_at):
 
     # XXX Facundo 2021-04-19: these are temporary translations until charmcraft
     # changes to be a "classic" snap
-    name_translation = {'ubuntu core': 'ubuntu'}
+    name_translation = {'ubuntu-core': 'ubuntu'}
     channel_translation = {'20': '20.04'}
     name = os_platform.system.lower()
     name = name_translation.get(name, name)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -235,7 +235,7 @@ def test_get_os_platform_linux(tmp_path):
     with patch('platform.machine', return_value='x86_64'):
         with patch('platform.system', return_value='Linux'):
             os_platform = get_os_platform(filepath)
-    assert os_platform.system == "Ubuntu"
+    assert os_platform.system == "ubuntu"
     assert os_platform.release == "20.04"
     assert os_platform.machine == "x86_64"
 
@@ -259,7 +259,7 @@ def test_get_os_platform_alternative_formats(name, tmp_path):
     filepath = (tmp_path / "os-release")
     filepath.write_text(dedent(
         """
-        NAME={}
+        ID={}
         VERSION_ID="20.04"
         """.format(source)
     ))
@@ -314,6 +314,18 @@ def test_manifest_architecture_translated(tmp_path, monkeypatch):
 
     saved = yaml.safe_load(result_filepath.read_text())
     assert saved['bases'][0]['architectures'] == ['nice_arch']
+
+
+def test_manifest_fields_from_strict_snap(tmp_path, monkeypatch):
+    """Fields found in a strict snap must be translated."""
+    os_platform = OSPlatform(system='Ubuntu Core', release='20', machine='amd64')
+    with patch('charmcraft.utils.get_os_platform', return_value=os_platform):
+        result_filepath = create_manifest(tmp_path, datetime.datetime.now())
+
+    saved = yaml.safe_load(result_filepath.read_text())
+    base = saved['bases'][0]
+    assert base['name'] == 'ubuntu'
+    assert base['channel'] == '20.04'
 
 
 def test_manifest_dont_overwrite(tmp_path):


### PR DESCRIPTION
This is temporary, these new translations will be removed when we get into a classic snap.

Also changed the name to com from the 'id' from os_release file. 