### PR TITLE
gitignore: ignore .envrc for direnv users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,7 @@ celerybeat.pid
 
 # Environments
 .env
+.envrc
 .venv
 env/
 venv/


### PR DESCRIPTION
Signed-off-by: Chris Patterson <chris.patterson@canonical.com>