### PR TITLE
snap: explicitly use requirements.txt for dependencies

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -77,6 +77,8 @@ parts:
   charmcraft:
     source: .
     plugin: python
+    requirements:
+      - requirements.txt
     build-packages:
       - libffi-dev
     stage-packages:


### PR DESCRIPTION
Signed-off-by: Chris Patterson <chris.patterson@canonical.com>