### PR TITLE
Improved the message for the case of Dockerhub not having v2 manifests.

### DIFF
--- a/charmcraft/commands/store/registry.py
+++ b/charmcraft/commands/store/registry.py
@@ -176,8 +176,8 @@ class OCIRegistry:
             response = self._hit('GET', url, headers=headers)
             result = assert_response_ok(response)
             if result.get('schemaVersion') != 2:
-                raise CommandError(
-                    "Manifest v2 requested but got something else: {}".format(result))
+                logger.debug("Got something else when asking for a v2 manifest: %s", result)
+                raise CommandError("Manifest v2 not found for the indicated reference.")
             logger.debug("Got the v2 manifest ok")
             digest = response.headers['Docker-Content-Digest']
         return (None, digest, response.text)

--- a/charmcraft/commands/store/registry.py
+++ b/charmcraft/commands/store/registry.py
@@ -177,7 +177,7 @@ class OCIRegistry:
             result = assert_response_ok(response)
             if result.get('schemaVersion') != 2:
                 logger.debug("Got something else when asking for a v2 manifest: %s", result)
-                raise CommandError("Manifest v2 not found for the indicated reference.")
+                raise CommandError("Manifest v2 not found for {!r}.".format(reference))
             logger.debug("Got the v2 manifest ok")
             digest = response.headers['Docker-Content-Digest']
         return (None, digest, response.text)

--- a/tests/commands/test_store_registry.py
+++ b/tests/commands/test_store_registry.py
@@ -414,8 +414,9 @@ def test_get_manifest_simple_multiple(responses):
     assert raw_manifest == responses.calls[0].response.text  # exact
 
 
-def test_get_manifest_bad_v2(responses):
+def test_get_manifest_bad_v2(responses, caplog):
     """Couldn't get a v2 manifest."""
+    caplog.set_level(logging.DEBUG, logger="charmcraft")
     ocireg = OCIRegistry("fakereg.com", "test-orga", "test-image")
 
     url = 'https://fakereg.com/v2/test-orga/test-image/manifests/test-reference'
@@ -432,7 +433,9 @@ def test_get_manifest_bad_v2(responses):
     # try it
     with pytest.raises(CommandError) as cm:
         ocireg.get_manifest('test-reference')
-    assert str(cm.value) == "Manifest v2 requested but got something else: {'sadly broken': ':('}"
+    assert str(cm.value) == "Manifest v2 not found for the indicated reference."
+    expected = "Got something else when asking for a v2 manifest: {'sadly broken': ':('}"
+    assert expected in [rec.message for rec in caplog.records]
 
 
 # -- tests for the ImageHandler 'get_destination_url' functionality

--- a/tests/commands/test_store_registry.py
+++ b/tests/commands/test_store_registry.py
@@ -433,7 +433,7 @@ def test_get_manifest_bad_v2(responses, caplog):
     # try it
     with pytest.raises(CommandError) as cm:
         ocireg.get_manifest('test-reference')
-    assert str(cm.value) == "Manifest v2 not found for the indicated reference."
+    assert str(cm.value) == "Manifest v2 not found for 'test-reference'."
     expected = "Got something else when asking for a v2 manifest: {'sadly broken': ':('}"
     assert expected in [rec.message for rec in caplog.records]
 


### PR DESCRIPTION
The previous error was a mess in the CLI; now the info is just logged and the message is nicer.