### PR TITLE
style: use black for consistent and automated formatting

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -10,3 +10,8 @@ exclude:
     *.egg_info
     dist
     snap
+extend-ignore:
+    # E203 whitespace before ‘:’ (Not PEP8 compliant, Python Black)
+    E203
+    # W503 line break before binary operator (Not PEP8 compliant, Python Black)
+    W503

--- a/charmcraft/commands/init.py
+++ b/charmcraft/commands/init.py
@@ -68,25 +68,31 @@ class InitCommand(BaseCommand):
     def fill_parser(self, parser):
         """Specify command's specific parameters."""
         parser.add_argument(
-            "--name",
-            help="The name of the charm; defaults to the directory name")
+            "--name", help="The name of the charm; defaults to the directory name"
+        )
         parser.add_argument(
             "--author",
-            help="The charm author; defaults to the current user name per GECOS")
+            help="The charm author; defaults to the current user name per GECOS",
+        )
         parser.add_argument(
-            "-f", "--force", action="store_true",
-            help="Initialize even if the directory is not empty (will not overwrite files)")
+            "-f",
+            "--force",
+            action="store_true",
+            help="Initialize even if the directory is not empty (will not overwrite files)",
+        )
 
     def run(self, args):
         """Execute command's actual functionality."""
         if any(self.config.project.dirpath.iterdir()) and not args.force:
             raise CommandError(
-                "{} is not empty (consider using --force to work on nonempty directories)"
-                .format(self.config.project.dirpath))
+                "{} is not empty (consider using --force to work on nonempty directories)".format(
+                    self.config.project.dirpath
+                )
+            )
         logger.debug("Using project directory '%s'", self.config.project.dirpath)
 
         if args.author is None:
-            gecos = pwd.getpwuid(os.getuid()).pw_gecos.split(',', 1)[0]
+            gecos = pwd.getpwuid(os.getuid()).pw_gecos.split(",", 1)[0]
             if not gecos:
                 raise CommandError("Author not given, and nothing in GECOS field")
             logger.debug("Setting author to %r from GECOS field", gecos)
@@ -106,7 +112,7 @@ class InitCommand(BaseCommand):
             "class_name": "".join(re.split(r"\W+", args.name.title())) + "Charm",
         }
 
-        env = get_templates_environment('init')
+        env = get_templates_environment("init")
 
         _todo_rx = re.compile("TODO: (.*)")
         todos = []

--- a/charmcraft/commands/pack.py
+++ b/charmcraft/commands/pack.py
@@ -25,12 +25,12 @@ from charmcraft.utils import load_yaml, create_manifest
 logger = logging.getLogger(__name__)
 
 # the minimum set of files in a bundle
-MANDATORY_FILES = {'bundle.yaml', 'manifest.yaml', 'README.md'}
+MANDATORY_FILES = {"bundle.yaml", "manifest.yaml", "README.md"}
 
 
 def build_zip(zippath, basedir, fpaths):
     """Build the final file."""
-    zipfh = zipfile.ZipFile(zippath, 'w', zipfile.ZIP_DEFLATED)
+    zipfh = zipfile.ZipFile(zippath, "w", zipfile.ZIP_DEFLATED)
     for fpath in fpaths:
         zipfh.write(fpath, fpath.relative_to(basedir))
     zipfh.close()
@@ -72,7 +72,7 @@ class PackCommand(BaseCommand):
     on bundles.
     """
 
-    name = 'pack'
+    name = "pack"
     help_msg = "Build the bundle"
     overview = _overview
     needs_config = True
@@ -80,28 +80,31 @@ class PackCommand(BaseCommand):
     def run(self, parsed_args):
         """Run the command."""
         # get the config files
-        bundle_filepath = self.config.project.dirpath / 'bundle.yaml'
+        bundle_filepath = self.config.project.dirpath / "bundle.yaml"
         bundle_config = load_yaml(bundle_filepath)
         if bundle_config is None:
             raise CommandError(
-                "Missing or invalid main bundle file: '{}'.".format(bundle_filepath))
-        bundle_name = bundle_config.get('name')
+                "Missing or invalid main bundle file: '{}'.".format(bundle_filepath)
+            )
+        bundle_name = bundle_config.get("name")
         if not bundle_name:
             raise CommandError(
                 "Invalid bundle config; missing a 'name' field indicating the bundle's name in "
-                "file '{}'.".format(bundle_filepath))
+                "file '{}'.".format(bundle_filepath)
+            )
 
         # so far 'pack' works for bundles only (later this will operate also on charms)
-        if self.config.type != 'bundle':
+        if self.config.type != "bundle":
             raise CommandError(
-                "Bad config: 'type' field in charmcraft.yaml must be 'bundle' for this command.")
+                "Bad config: 'type' field in charmcraft.yaml must be 'bundle' for this command."
+            )
 
         # pack everything
         project = self.config.project
         manifest_filepath = create_manifest(project.dirpath, project.started_at)
         try:
             paths = get_paths_to_include(self.config)
-            zipname = project.dirpath / (bundle_name + '.zip')
+            zipname = project.dirpath / (bundle_name + ".zip")
             build_zip(zipname, project.dirpath, paths)
         finally:
             manifest_filepath.unlink()

--- a/charmcraft/commands/store/__init__.py
+++ b/charmcraft/commands/store/__init__.py
@@ -43,15 +43,19 @@ from charmcraft.utils import (
 from .store import Store
 from .registry import ImageHandler
 
-logger = logging.getLogger('charmcraft.commands.store')
+logger = logging.getLogger("charmcraft.commands.store")
 
 # some types
 EntityType = namedtuple("EntityType", "charm bundle")(charm="charm", bundle="bundle")
-ResourceType = namedtuple("ResourceType", "file oci_image")(file="file", oci_image="oci-image")
+ResourceType = namedtuple("ResourceType", "file oci_image")(
+    file="file", oci_image="oci-image"
+)
 
 LibData = namedtuple(
-    'LibData', 'lib_id api patch content content_hash full_name path lib_name charm_name')
-OCIImageSpec = namedtuple('OCIImageSpec', 'organization name reference')
+    "LibData",
+    "lib_id api patch content content_hash full_name path lib_name charm_name",
+)
+OCIImageSpec = namedtuple("OCIImageSpec", "organization name reference")
 
 # The token used in the 'init' command (as bytes for easier comparison)
 INIT_TEMPLATE_TOKEN = b"TEMPLATE-TODO"
@@ -60,9 +64,9 @@ INIT_TEMPLATE_TOKEN = b"TEMPLATE-TODO"
 def get_name_from_metadata():
     """Return the name if present and plausible in metadata.yaml."""
     try:
-        with open('metadata.yaml', 'rb') as fh:
+        with open("metadata.yaml", "rb") as fh:
             metadata = yaml.safe_load(fh)
-        charm_name = metadata['name']
+        charm_name = metadata["name"]
     except (yaml.error.YAMLError, OSError, KeyError):
         return
     return charm_name
@@ -70,21 +74,22 @@ def get_name_from_metadata():
 
 def create_importable_name(charm_name):
     """Convert a charm name to something that is importable in python."""
-    return charm_name.replace('-', '_')
+    return charm_name.replace("-", "_")
 
 
 def create_charm_name_from_importable(charm_name):
     """Convert a charm name from the importable form to the real form."""
     # _ is invalid in charm names, so we know it's intended to be '-'
-    return charm_name.replace('_', '-')
+    return charm_name.replace("_", "-")
 
 
 class LoginCommand(BaseCommand):
     """Login to Charmhub."""
 
-    name = 'login'
+    name = "login"
     help_msg = "Login to Charmhub"
-    overview = textwrap.dedent("""
+    overview = textwrap.dedent(
+        """
         Login to Charmhub.
 
         Charmcraft will provide a URL for the Charmhub login. When you have
@@ -95,7 +100,8 @@ class LoginCommand(BaseCommand):
         from your local system, especially in a shared environment.
 
         See also `charmcraft whoami` to verify that you are logged in.
-    """)
+    """
+    )
 
     def run(self, parsed_args):
         """Run the command."""
@@ -107,9 +113,10 @@ class LoginCommand(BaseCommand):
 class LogoutCommand(BaseCommand):
     """Clear Charmhub token."""
 
-    name = 'logout'
+    name = "logout"
     help_msg = "Logout from Charmhub and remove token"
-    overview = textwrap.dedent("""
+    overview = textwrap.dedent(
+        """
         Clear the Charmhub token.
 
         Charmcraft will remove the local token used for Charmhub access.
@@ -118,7 +125,8 @@ class LogoutCommand(BaseCommand):
 
         See also `charmcraft whoami` to verify that you are logged in,
         and `charmcraft login`.
-    """)
+    """
+    )
 
     def run(self, parsed_args):
         """Run the command."""
@@ -130,13 +138,15 @@ class LogoutCommand(BaseCommand):
 class WhoamiCommand(BaseCommand):
     """Show login information."""
 
-    name = 'whoami'
+    name = "whoami"
     help_msg = "Show your Charmhub login status"
-    overview = textwrap.dedent("""
+    overview = textwrap.dedent(
+        """
         Show your Charmhub login status.
 
         See also `charmcraft login` and `charmcraft logout`.
-    """)
+    """
+    )
 
     def run(self, parsed_args):
         """Run the command."""
@@ -144,11 +154,11 @@ class WhoamiCommand(BaseCommand):
         result = store.whoami()
 
         data = [
-            ('name:', result.name),
-            ('username:', result.username),
-            ('id:', result.userid),
+            ("name:", result.name),
+            ("username:", result.username),
+            ("id:", result.userid),
         ]
-        table = tabulate(data, tablefmt='plain')
+        table = tabulate(data, tablefmt="plain")
         for line in table.splitlines():
             logger.info(line)
 
@@ -156,9 +166,10 @@ class WhoamiCommand(BaseCommand):
 class RegisterCharmNameCommand(BaseCommand):
     """Register a charm name in Charmhub."""
 
-    name = 'register'
+    name = "register"
     help_msg = "Register a charm name in Charmhub"
-    overview = textwrap.dedent("""
+    overview = textwrap.dedent(
+        """
         Register a charm name in Charmhub.
 
         Claim a name for your operator in Charmhub. Once you have registered
@@ -177,26 +188,30 @@ class RegisterCharmNameCommand(BaseCommand):
            https://discourse.charmhub.io/c/charm
 
         Registration will take you through login if needed.
-    """)
+    """
+    )
     common = True
 
     def fill_parser(self, parser):
         """Add own parameters to the general parser."""
-        parser.add_argument('name', help="The name to register in Charmhub")
+        parser.add_argument("name", help="The name to register in Charmhub")
 
     def run(self, parsed_args):
         """Run the command."""
         store = Store(self.config.charmhub)
         store.register_name(parsed_args.name, EntityType.charm)
-        logger.info("You are now the publisher of charm %r in Charmhub.", parsed_args.name)
+        logger.info(
+            "You are now the publisher of charm %r in Charmhub.", parsed_args.name
+        )
 
 
 class RegisterBundleNameCommand(BaseCommand):
     """Register a bundle name in the Store."""
 
-    name = 'register-bundle'
+    name = "register-bundle"
     help_msg = "Register a bundle name in the Store"
-    overview = textwrap.dedent("""
+    overview = textwrap.dedent(
+        """
         Register a bundle name in the Store.
 
         Claim a name for your bundle in Charmhub. Once you have registered
@@ -215,25 +230,29 @@ class RegisterBundleNameCommand(BaseCommand):
            https://discourse.charmhub.io/c/charm
 
         Registration will take you through login if needed.
-    """)
+    """
+    )
 
     def fill_parser(self, parser):
         """Add own parameters to the general parser."""
-        parser.add_argument('name', help="The name to register in Charmhub")
+        parser.add_argument("name", help="The name to register in Charmhub")
 
     def run(self, parsed_args):
         """Run the command."""
         store = Store(self.config.charmhub)
         store.register_name(parsed_args.name, EntityType.bundle)
-        logger.info("You are now the publisher of bundle %r in Charmhub.", parsed_args.name)
+        logger.info(
+            "You are now the publisher of bundle %r in Charmhub.", parsed_args.name
+        )
 
 
 class ListNamesCommand(BaseCommand):
     """List the entities registered in Charmhub."""
 
-    name = 'names'
+    name = "names"
     help_msg = "List your registered charm and bundle names in Charmhub"
-    overview = textwrap.dedent("""
+    overview = textwrap.dedent(
+        """
         An overview of names you have registered to publish in Charmhub.
 
           $ charmcraft names
@@ -245,7 +264,8 @@ class ListNamesCommand(BaseCommand):
         other accounts with permission to collaborate on that specific name.
 
         Listing names will take you through login if needed.
-    """)
+    """
+    )
     common = True
 
     def run(self, parsed_args):
@@ -256,18 +276,20 @@ class ListNamesCommand(BaseCommand):
             logger.info("No charms or bundles registered.")
             return
 
-        headers = ['Name', 'Type', 'Visibility', 'Status']
+        headers = ["Name", "Type", "Visibility", "Status"]
         data = []
         for item in result:
-            visibility = 'private' if item.private else 'public'
-            data.append([
-                item.name,
-                item.entity_type,
-                visibility,
-                item.status,
-            ])
+            visibility = "private" if item.private else "public"
+            data.append(
+                [
+                    item.name,
+                    item.entity_type,
+                    visibility,
+                    item.status,
+                ]
+            )
 
-        table = tabulate(data, headers=headers, tablefmt='plain')
+        table = tabulate(data, headers=headers, tablefmt="plain")
         for line in table.splitlines():
             logger.info(line)
 
@@ -281,24 +303,27 @@ def get_name_from_zip(filepath):
 
     # get the name from the given file (trying first if it's a charm, then a bundle,
     # otherwise it's an error)
-    if 'metadata.yaml' in zf.namelist():
+    if "metadata.yaml" in zf.namelist():
         try:
-            name = yaml.safe_load(zf.read('metadata.yaml'))['name']
+            name = yaml.safe_load(zf.read("metadata.yaml"))["name"]
         except Exception:
             raise CommandError(
                 "Bad 'metadata.yaml' file inside charm zip {!r}: must be a valid YAML with "
-                "a 'name' key.".format(str(filepath)))
-    elif 'bundle.yaml' in zf.namelist():
+                "a 'name' key.".format(str(filepath))
+            )
+    elif "bundle.yaml" in zf.namelist():
         try:
-            name = yaml.safe_load(zf.read('bundle.yaml'))['name']
+            name = yaml.safe_load(zf.read("bundle.yaml"))["name"]
         except Exception:
             raise CommandError(
                 "Bad 'bundle.yaml' file inside bundle zip {!r}: must be a valid YAML with "
-                "a 'name' key.".format(str(filepath)))
+                "a 'name' key.".format(str(filepath))
+            )
     else:
         raise CommandError(
             "The indicated zip file {!r} is not a charm ('metadata.yaml' not found) "
-            "nor a bundle ('bundle.yaml' not found).".format(str(filepath)))
+            "nor a bundle ('bundle.yaml' not found).".format(str(filepath))
+        )
 
     return name
 
@@ -306,9 +331,10 @@ def get_name_from_zip(filepath):
 class UploadCommand(BaseCommand):
     """Upload a charm or bundle to Charmhub."""
 
-    name = 'upload'
+    name = "upload"
     help_msg = "Upload a charm or bundle to Charmhub"
-    overview = textwrap.dedent("""
+    overview = textwrap.dedent(
+        """
         Upload a charm or bundle to Charmhub.
 
         Push a charm or bundle to Charmhub where it will be verified.
@@ -320,15 +346,20 @@ class UploadCommand(BaseCommand):
         new charm or bundle revision.
 
         Upload will take you through login if needed.
-    """)
+    """
+    )
     common = True
 
     def fill_parser(self, parser):
         """Add own parameters to the general parser."""
-        parser.add_argument('filepath', type=useful_filepath, help="The charm or bundle to upload")
         parser.add_argument(
-            '--release', action='append',
-            help="The channel(s) to release to (this option can be indicated multiple times)")
+            "filepath", type=useful_filepath, help="The charm or bundle to upload"
+        )
+        parser.add_argument(
+            "--release",
+            action="append",
+            help="The channel(s) to release to (this option can be indicated multiple times)",
+        )
 
     def _validate_template_is_handled(self, filepath):
         """Verify the zip does not have any file with the 'init' template TODO marker.
@@ -349,7 +380,8 @@ class UploadCommand(BaseCommand):
             raise CommandError(
                 "Cannot upload the charm as it include the following files with a leftover "
                 "TEMPLATE-TODO token from when the project was created using the 'init' "
-                "command: {}".format(", ".join(tainted_filenames)))
+                "command: {}".format(", ".join(tainted_filenames))
+            )
 
     def run(self, parsed_args):
         """Run the command."""
@@ -372,9 +404,10 @@ class UploadCommand(BaseCommand):
 class ListRevisionsCommand(BaseCommand):
     """List revisions for a charm or a bundle."""
 
-    name = 'revisions'
+    name = "revisions"
     help_msg = "List revisions for a charm or a bundle in Charmhub"
-    overview = textwrap.dedent("""
+    overview = textwrap.dedent(
+        """
         Show version, date and status for each revision in Charmhub.
 
         For example:
@@ -384,12 +417,13 @@ class ListRevisionsCommand(BaseCommand):
            1           1          2020-11-15    released
 
         Listing revisions will take you through login if needed.
-    """)
+    """
+    )
     common = True
 
     def fill_parser(self, parser):
         """Add own parameters to the general parser."""
-        parser.add_argument('name', help="The name of the charm or bundle")
+        parser.add_argument("name", help="The name of the charm or bundle")
 
     def run(self, parsed_args):
         """Run the command."""
@@ -399,24 +433,26 @@ class ListRevisionsCommand(BaseCommand):
             logger.info("No revisions found.")
             return
 
-        headers = ['Revision', 'Version', 'Created at', 'Status']
+        headers = ["Revision", "Version", "Created at", "Status"]
         data = []
-        for item in sorted(result, key=attrgetter('revision'), reverse=True):
+        for item in sorted(result, key=attrgetter("revision"), reverse=True):
             # use just the status or include error message/code in it (if exist)
             if item.errors:
                 errors = ("{0.message} [{0.code}]".format(e) for e in item.errors)
-                status = "{}: {}".format(item.status, '; '.join(errors))
+                status = "{}: {}".format(item.status, "; ".join(errors))
             else:
                 status = item.status
 
-            data.append([
-                item.revision,
-                item.version,
-                item.created_at.strftime('%Y-%m-%d'),
-                status,
-            ])
+            data.append(
+                [
+                    item.revision,
+                    item.version,
+                    item.created_at.strftime("%Y-%m-%d"),
+                    status,
+                ]
+            )
 
-        table = tabulate(data, headers=headers, tablefmt='plain', numalign='left')
+        table = tabulate(data, headers=headers, tablefmt="plain", numalign="left")
         for line in table.splitlines():
             logger.info(line)
 
@@ -424,9 +460,10 @@ class ListRevisionsCommand(BaseCommand):
 class ReleaseCommand(BaseCommand):
     """Release a charm or bundle revision to specific channels."""
 
-    name = 'release'
+    name = "release"
     help_msg = "Release a charm or bundle revision in one or more channels"
-    overview = textwrap.dedent("""
+    overview = textwrap.dedent(
+        """
         Release a charm or bundle revision in the channel(s) provided.
 
         Charm or bundle revisions are not published for anybody else until you
@@ -462,45 +499,67 @@ class ReleaseCommand(BaseCommand):
                 --channel=beta --resource=thedb:4
 
         Listing revisions will take you through login if needed.
-    """)
+    """
+    )
     common = True
 
     def fill_parser(self, parser):
         """Add own parameters to the general parser."""
-        parser.add_argument('name', help="The name of charm or bundle")
+        parser.add_argument("name", help="The name of charm or bundle")
         parser.add_argument(
-            '-r', '--revision', type=SingleOptionEnsurer(int), required=True,
-            help='The revision to release')
+            "-r",
+            "--revision",
+            type=SingleOptionEnsurer(int),
+            required=True,
+            help="The revision to release",
+        )
         parser.add_argument(
-            '-c', '--channel', action='append', required=True,
-            help="The channel(s) to release to (this option can be indicated multiple times)")
+            "-c",
+            "--channel",
+            action="append",
+            required=True,
+            help="The channel(s) to release to (this option can be indicated multiple times)",
+        )
         parser.add_argument(
-            '--resource', action='append', type=ResourceOption(), default=[],
+            "--resource",
+            action="append",
+            type=ResourceOption(),
+            default=[],
             help=(
                 "The resource(s) to attach to the release, in the <name>:<revision> format "
-                "(this option can be indicated multiple times)"))
+                "(this option can be indicated multiple times)"
+            ),
+        )
 
     def run(self, parsed_args):
         """Run the command."""
         store = Store(self.config.charmhub)
         store.release(
-            parsed_args.name, parsed_args.revision, parsed_args.channel, parsed_args.resource)
+            parsed_args.name,
+            parsed_args.revision,
+            parsed_args.channel,
+            parsed_args.resource,
+        )
 
         msg = "Revision %d of charm %r released to %s"
         args = [parsed_args.revision, parsed_args.name, ", ".join(parsed_args.channel)]
         if parsed_args.resource:
             msg += " (attaching resources: %s)"
-            args.append(", ".join(
-                "{!r} r{}".format(r.name, r.revision) for r in parsed_args.resource))
+            args.append(
+                ", ".join(
+                    "{!r} r{}".format(r.name, r.revision) for r in parsed_args.resource
+                )
+            )
         logger.info(msg, *args)
 
 
 class StatusCommand(BaseCommand):
     """Show channel status for a charm or bundle."""
 
-    name = 'status'
+    name = "status"
     help_msg = "Show channel and released revisions"
-    overview = textwrap.dedent("""
+    overview = textwrap.dedent(
+        """
         Show channels and released revisions in Charmhub.
 
         Charm revisions are not available to users until they are released
@@ -517,19 +576,20 @@ class StatusCommand(BaseCommand):
                    edge       1          1
 
         Showing channels will take you through login if needed.
-    """)
+    """
+    )
     common = True
 
     def fill_parser(self, parser):
         """Add own parameters to the general parser."""
-        parser.add_argument('name', help="The name of the charm or bundle")
+        parser.add_argument("name", help="The name of the charm or bundle")
 
     def _build_resources_repr(self, resources):
         """Build a representation of a list of resources."""
         if resources:
-            result = ', '.join("{} (r{})".format(r.name, r.revision) for r in resources)
+            result = ", ".join("{} (r{})".format(r.name, r.revision) for r in resources)
         else:
-            result = '-'
+            result = "-"
         return result
 
     def run(self, parsed_args):
@@ -554,7 +614,9 @@ class StatusCommand(BaseCommand):
             if channel.track not in all_tracks:
                 all_tracks.append(channel.track)
 
-            nonbranches_list, branches_list = per_track.setdefault(channel.track, ([], []))
+            nonbranches_list, branches_list = per_track.setdefault(
+                channel.track, ([], [])
+            )
             if channel.branch is None:
                 # insert branch right after its fallback
                 for idx, stored in enumerate(nonbranches_list, 1):
@@ -567,12 +629,12 @@ class StatusCommand(BaseCommand):
                 branches_list.append(channel)
                 branch_present = True
 
-        headers = ['Track', 'Channel', 'Version', 'Revision']
+        headers = ["Track", "Channel", "Version", "Revision"]
         resources_present = any(release.resources for release in channel_map)
         if resources_present:
-            headers.append('Resources')
+            headers.append("Resources")
         if branch_present:
-            headers.append('Expires at')
+            headers.append("Expires at")
 
         # show everything, grouped by tracks, with regular channels at first and
         # branches (if any) after those
@@ -588,7 +650,9 @@ class StatusCommand(BaseCommand):
                 # get the release of the channel, fallbacking accordingly
                 release = releases_by_channel.get(channel.name)
                 if release is None:
-                    version = revno = resources = '↑' if release_shown_for_this_track else '-'
+                    version = revno = resources = (
+                        "↑" if release_shown_for_this_track else "-"
+                    )
                 else:
                     release_shown_for_this_track = True
                     revno = release.revision
@@ -602,20 +666,20 @@ class StatusCommand(BaseCommand):
                 data.append(datum)
 
                 # stop showing the track name for the rest of the track
-                shown_track = ''
+                shown_track = ""
 
             for branch in branches:
-                description = '/'.join((branch.risk, branch.branch))
+                description = "/".join((branch.risk, branch.branch))
                 release = releases_by_channel[branch.name]
                 expiration = release.expires_at.isoformat()
                 revision = revisions_by_revno[release.revision]
-                datum = ['', description, revision.version, release.revision]
+                datum = ["", description, revision.version, release.revision]
                 if resources_present:
                     datum.append(self._build_resources_repr(release.resources))
                 datum.append(expiration)
                 data.append(datum)
 
-        table = tabulate(data, headers=headers, tablefmt='plain', numalign='left')
+        table = tabulate(data, headers=headers, tablefmt="plain", numalign="left")
         for line in table.splitlines():
             logger.info(line)
 
@@ -626,7 +690,8 @@ class _BadLibraryPathError(CommandError):
     def __init__(self, path):
         super().__init__(
             "Charm library path {} must conform to lib/charms/<charm>/vN/<libname>.py"
-            "".format(path))
+            "".format(path)
+        )
 
 
 class _BadLibraryNameError(CommandError):
@@ -634,15 +699,17 @@ class _BadLibraryNameError(CommandError):
 
     def __init__(self, name):
         super().__init__(
-            "Charm library name {!r} must conform to charms.<charm>.vN.<libname>"
-            .format(name))
+            "Charm library name {!r} must conform to charms.<charm>.vN.<libname>".format(
+                name
+            )
+        )
 
 
 def _get_positive_int(raw_value):
     """Convert the raw value for api/patch into a positive integer."""
     value = int(raw_value)
     if value < 0:
-        raise ValueError('negative')
+        raise ValueError("negative")
     return value
 
 
@@ -661,82 +728,101 @@ def _get_lib_info(*, full_name=None, lib_path=None):
             libsdir, charmsdir, importable_charm_name, v_api = lib_path.parts[:-1]
         except ValueError:
             raise _BadLibraryPathError(lib_path)
-        if libsdir != 'lib' or charmsdir != 'charms' or lib_path.suffix != '.py':
+        if libsdir != "lib" or charmsdir != "charms" or lib_path.suffix != ".py":
             raise _BadLibraryPathError(lib_path)
-        full_name = '.'.join((charmsdir, importable_charm_name, v_api, lib_path.stem))
+        full_name = ".".join((charmsdir, importable_charm_name, v_api, lib_path.stem))
 
     else:
         # build the path! convert a lib name with dots to the full path, including lib
         # dir and Python extension.
         #    e.g.: charms.mycharm.v4.foo -> lib/charms/mycharm/v4/foo.py
         try:
-            charmsdir, importable_charm_name, v_api, libfile = full_name.split('.')
+            charmsdir, importable_charm_name, v_api, libfile = full_name.split(".")
         except ValueError:
             raise _BadLibraryNameError(full_name)
-        if charmsdir != 'charms':
+        if charmsdir != "charms":
             raise _BadLibraryNameError(full_name)
-        path = pathlib.Path('lib')
-        lib_path = path / charmsdir / importable_charm_name / v_api / (libfile + '.py')
+        path = pathlib.Path("lib")
+        lib_path = path / charmsdir / importable_charm_name / v_api / (libfile + ".py")
 
     # charm names in the path can contain '_' to be importable
     # these should be '-', so change them back
     charm_name = create_charm_name_from_importable(importable_charm_name)
 
-    if v_api[0] != 'v' or not v_api[1:].isdigit():
+    if v_api[0] != "v" or not v_api[1:].isdigit():
         raise CommandError(
-            "The API version in the library path must be 'vN' where N is an integer.")
+            "The API version in the library path must be 'vN' where N is an integer."
+        )
     api_from_path = int(v_api[1:])
 
     lib_name = lib_path.stem
     if not lib_path.exists():
         return LibData(
-            lib_id=None, api=api_from_path, patch=-1, content_hash=None, content=None,
-            full_name=full_name, path=lib_path, lib_name=lib_name, charm_name=charm_name)
+            lib_id=None,
+            api=api_from_path,
+            patch=-1,
+            content_hash=None,
+            content=None,
+            full_name=full_name,
+            path=lib_path,
+            lib_name=lib_name,
+            charm_name=charm_name,
+        )
 
     # parse the file and extract metadata from it, while hashing
-    metadata_fields = (b'LIBAPI', b'LIBPATCH', b'LIBID')
+    metadata_fields = (b"LIBAPI", b"LIBPATCH", b"LIBID")
     metadata = dict.fromkeys(metadata_fields)
     hasher = hashlib.sha256()
-    with lib_path.open('rb') as fh:
+    with lib_path.open("rb") as fh:
         for line in fh:
             if line.startswith(metadata_fields):
                 try:
-                    field, value = [x.strip() for x in line.split(b'=')]
+                    field, value = [x.strip() for x in line.split(b"=")]
                 except ValueError:
-                    raise CommandError("Bad metadata line in {}: {!r}".format(lib_path, line))
+                    raise CommandError(
+                        "Bad metadata line in {}: {!r}".format(lib_path, line)
+                    )
                 metadata[field] = value
             else:
                 hasher.update(line)
 
-    missing = [k.decode('ascii') for k, v in metadata.items() if v is None]
+    missing = [k.decode("ascii") for k, v in metadata.items() if v is None]
     if missing:
         raise CommandError(
-            "Library {} is missing the mandatory metadata fields: {}."
-            .format(lib_path, ', '.join(sorted(missing))))
+            "Library {} is missing the mandatory metadata fields: {}.".format(
+                lib_path, ", ".join(sorted(missing))
+            )
+        )
 
-    bad_api_patch_msg = "Library {} metadata field {} is not zero or a positive integer."
+    bad_api_patch_msg = (
+        "Library {} metadata field {} is not zero or a positive integer."
+    )
     try:
-        libapi = _get_positive_int(metadata[b'LIBAPI'])
+        libapi = _get_positive_int(metadata[b"LIBAPI"])
     except ValueError:
-        raise CommandError(bad_api_patch_msg.format(lib_path, 'LIBAPI'))
+        raise CommandError(bad_api_patch_msg.format(lib_path, "LIBAPI"))
     try:
-        libpatch = _get_positive_int(metadata[b'LIBPATCH'])
+        libpatch = _get_positive_int(metadata[b"LIBPATCH"])
     except ValueError:
-        raise CommandError(bad_api_patch_msg.format(lib_path, 'LIBPATCH'))
+        raise CommandError(bad_api_patch_msg.format(lib_path, "LIBPATCH"))
 
     if libapi == 0 and libpatch == 0:
         raise CommandError(
-            "Library {} metadata fields LIBAPI and LIBPATCH cannot both be zero."
-            .format(lib_path))
+            "Library {} metadata fields LIBAPI and LIBPATCH cannot both be zero.".format(
+                lib_path
+            )
+        )
 
     if libapi != api_from_path:
         raise CommandError(
-            "Library {} metadata field LIBAPI is different from the version in the path."
-            .format(lib_path))
+            "Library {} metadata field LIBAPI is different from the version in the path.".format(
+                lib_path
+            )
+        )
 
     bad_libid_msg = "Library {} metadata field LIBID must be a non-empty ASCII string."
     try:
-        libid = ast.literal_eval(metadata[b'LIBID'].decode('ascii'))
+        libid = ast.literal_eval(metadata[b"LIBID"].decode("ascii"))
     except (ValueError, UnicodeDecodeError):
         raise CommandError(bad_libid_msg.format(lib_path))
     if not libid or not isinstance(libid, str):
@@ -746,8 +832,16 @@ def _get_lib_info(*, full_name=None, lib_path=None):
     content = lib_path.read_text()
 
     return LibData(
-        lib_id=libid, api=libapi, patch=libpatch, content_hash=content_hash, content=content,
-        full_name=full_name, path=lib_path, lib_name=lib_name, charm_name=charm_name)
+        lib_id=libid,
+        api=libapi,
+        patch=libpatch,
+        content_hash=content_hash,
+        content=content,
+        full_name=full_name,
+        path=lib_path,
+        lib_name=lib_name,
+        charm_name=charm_name,
+    )
 
 
 def _get_libs_from_tree(charm_name=None):
@@ -761,17 +855,17 @@ def _get_libs_from_tree(charm_name=None):
     local_libs_data = []
 
     if charm_name is None:
-        base_dir = pathlib.Path('lib') / 'charms'
+        base_dir = pathlib.Path("lib") / "charms"
         charm_dirs = sorted(base_dir.iterdir()) if base_dir.is_dir() else []
     else:
         importable_charm_name = create_importable_name(charm_name)
-        base_dir = pathlib.Path('lib') / 'charms' / importable_charm_name
+        base_dir = pathlib.Path("lib") / "charms" / importable_charm_name
         charm_dirs = [base_dir] if base_dir.is_dir() else []
 
     for charm_dir in charm_dirs:
         for v_dir in sorted(charm_dir.iterdir()):
-            if v_dir.is_dir() and v_dir.name[0] == 'v' and v_dir.name[1:].isdigit():
-                for libfile in sorted(v_dir.glob('*.py')):
+            if v_dir.is_dir() and v_dir.name[0] == "v" and v_dir.name[1:].isdigit():
+                for libfile in sorted(v_dir.glob("*.py")):
                     local_libs_data.append(_get_lib_info(lib_path=libfile))
 
     found_libs = [lib_data.full_name for lib_data in local_libs_data]
@@ -782,9 +876,10 @@ def _get_libs_from_tree(charm_name=None):
 class CreateLibCommand(BaseCommand):
     """Create a charm library."""
 
-    name = 'create-lib'
+    name = "create-lib"
     help_msg = "Create a charm library"
-    overview = textwrap.dedent("""
+    overview = textwrap.dedent(
+        """
         Create a charm library.
 
         Charmcraft manages charm libraries, which are published by charmers
@@ -803,52 +898,60 @@ class CreateLibCommand(BaseCommand):
         template Python library.
 
         Creating a charm library will take you through login if needed.
-    """)
+    """
+    )
 
     def fill_parser(self, parser):
         """Add own parameters to the general parser."""
-        parser.add_argument('name', help="The name of the library file (e.g. 'db')")
+        parser.add_argument("name", help="The name of the library file (e.g. 'db')")
 
     def run(self, parsed_args):
         """Run the command."""
         lib_name = parsed_args.name
-        valid_all_chars = set(string.ascii_lowercase + string.digits + '_')
+        valid_all_chars = set(string.ascii_lowercase + string.digits + "_")
         valid_first_char = string.ascii_lowercase
-        if set(lib_name) - valid_all_chars or not lib_name or lib_name[0] not in valid_first_char:
+        if (
+            set(lib_name) - valid_all_chars
+            or not lib_name
+            or lib_name[0] not in valid_first_char
+        ):
             raise CommandError(
                 "Invalid library name. Must only use lowercase alphanumeric "
-                "characters and underscore, starting with alpha.")
+                "characters and underscore, starting with alpha."
+            )
 
         charm_name = get_name_from_metadata()
         if charm_name is None:
             raise CommandError(
                 "Cannot find a valid charm name in metadata.yaml. Check you are in a charm "
-                "directory with metadata.yaml.")
+                "directory with metadata.yaml."
+            )
 
         # '-' is valid in charm names, but not in a python import
         # mutate the name so the path is a valid import
         importable_charm_name = create_importable_name(charm_name)
 
         # all libraries born with API version 0
-        full_name = 'charms.{}.v0.{}'.format(importable_charm_name, lib_name)
+        full_name = "charms.{}.v0.{}".format(importable_charm_name, lib_name)
         lib_data = _get_lib_info(full_name=full_name)
         lib_path = lib_data.path
         if lib_path.exists():
-            raise CommandError('This library already exists: {}'.format(lib_path))
+            raise CommandError("This library already exists: {}".format(lib_path))
 
         store = Store(self.config.charmhub)
         lib_id = store.create_library_id(charm_name, lib_name)
 
         # create the new library file from the template
-        env = get_templates_environment('charmlibs')
-        template = env.get_template('new_library.py.j2')
+        env = get_templates_environment("charmlibs")
+        template = env.get_template("new_library.py.j2")
         context = dict(lib_id=lib_id)
         try:
             lib_path.parent.mkdir(parents=True, exist_ok=True)
             lib_path.write_text(template.render(context))
         except OSError as exc:
             raise CommandError(
-                "Error writing the library in {}: {!r}.".format(lib_path, exc))
+                "Error writing the library in {}: {!r}.".format(lib_path, exc)
+            )
 
         logger.info("Library %s created with id %s.", full_name, lib_id)
         logger.info("Consider 'git add %s'.", lib_path)
@@ -857,9 +960,10 @@ class CreateLibCommand(BaseCommand):
 class PublishLibCommand(BaseCommand):
     """Publish one or more charm libraries."""
 
-    name = 'publish-lib'
+    name = "publish-lib"
     help_msg = "Publish one or more charm libraries"
-    overview = textwrap.dedent("""
+    overview = textwrap.dedent(
+        """
         Publish charm libraries.
 
         Upload and release in Charmhub the new api/patch version of the
@@ -867,13 +971,16 @@ class PublishLibCommand(BaseCommand):
 
         It will automatically take you through the login process if
         your credentials are missing or too old.
-    """)
+    """
+    )
 
     def fill_parser(self, parser):
         """Add own parameters to the general parser."""
         parser.add_argument(
-            'library', nargs='?',
-            help="Library to publish (e.g. charms.mycharm.v2.foo.); optional, default to all")
+            "library",
+            nargs="?",
+            help="Library to publish (e.g. charms.mycharm.v2.foo.); optional, default to all",
+        )
 
     def run(self, parsed_args):
         """Run the command."""
@@ -881,17 +988,23 @@ class PublishLibCommand(BaseCommand):
         if charm_name is None:
             raise CommandError(
                 "Can't access name in 'metadata.yaml' file. The 'publish-lib' command needs to "
-                "be executed in a valid project's directory.")
+                "be executed in a valid project's directory."
+            )
 
         if parsed_args.library:
             lib_data = _get_lib_info(full_name=parsed_args.library)
             if not lib_data.path.exists():
                 raise CommandError(
-                    "The specified library was not found at path {}.".format(lib_data.path))
+                    "The specified library was not found at path {}.".format(
+                        lib_data.path
+                    )
+                )
             if lib_data.charm_name != charm_name:
                 raise CommandError(
                     "The library {} does not belong to this charm {!r}.".format(
-                        lib_data.full_name, charm_name))
+                        lib_data.full_name, charm_name
+                    )
+                )
             local_libs_data = [lib_data]
         else:
             local_libs_data = _get_libs_from_tree(charm_name)
@@ -914,56 +1027,86 @@ class PublishLibCommand(BaseCommand):
                 # the store is more advanced than local
                 logger.info(
                     "Library %s is out-of-date locally, Charmhub has version %d.%d, please "
-                    "fetch the updates before publishing.", lib_data.full_name, tip.api, tip.patch)
+                    "fetch the updates before publishing.",
+                    lib_data.full_name,
+                    tip.api,
+                    tip.patch,
+                )
             elif tip.patch == lib_data.patch:
                 # the store has same version numbers than local
                 if tip.content_hash == lib_data.content_hash:
-                    logger.info("Library %s is already updated in Charmhub.", lib_data.full_name)
+                    logger.info(
+                        "Library %s is already updated in Charmhub.", lib_data.full_name
+                    )
                 else:
                     # but shouldn't as hash is different!
                     logger.info(
                         "Library %s version %d.%d is the same than in Charmhub but content is "
-                        "different", lib_data.full_name, tip.api, tip.patch)
+                        "different",
+                        lib_data.full_name,
+                        tip.api,
+                        tip.patch,
+                    )
             elif tip.patch + 1 == lib_data.patch:
                 # local is correctly incremented
                 if tip.content_hash == lib_data.content_hash:
                     # but shouldn't as hash is the same!
                     logger.info(
                         "Library %s LIBPATCH number was incorrectly incremented, Charmhub has the "
-                        "same content in version %d.%d.", lib_data.full_name, tip.api, tip.patch)
+                        "same content in version %d.%d.",
+                        lib_data.full_name,
+                        tip.api,
+                        tip.patch,
+                    )
                 else:
                     to_publish.append(lib_data)
             else:
                 logger.info(
                     "Library %s has a wrong LIBPATCH number, it's too high, Charmhub "
-                    "highest version is %d.%d.", lib_data.full_name, tip.api, tip.patch)
+                    "highest version is %d.%d.",
+                    lib_data.full_name,
+                    tip.api,
+                    tip.patch,
+                )
 
         for lib_data in to_publish:
             store.create_library_revision(
-                lib_data.charm_name, lib_data.lib_id, lib_data.api, lib_data.patch,
-                lib_data.content, lib_data.content_hash)
+                lib_data.charm_name,
+                lib_data.lib_id,
+                lib_data.api,
+                lib_data.patch,
+                lib_data.content,
+                lib_data.content_hash,
+            )
             logger.info(
                 "Library %s sent to the store with version %d.%d",
-                lib_data.full_name, lib_data.api, lib_data.patch)
+                lib_data.full_name,
+                lib_data.api,
+                lib_data.patch,
+            )
 
 
 class FetchLibCommand(BaseCommand):
     """Fetch one or more charm libraries."""
 
-    name = 'fetch-lib'
+    name = "fetch-lib"
     help_msg = "Fetch one or more charm libraries"
-    overview = textwrap.dedent("""
+    overview = textwrap.dedent(
+        """
         Fetch charm libraries.
 
         The first time a library is downloaded the command will create the needed
         directories to place it, subsequent fetches will just update the local copy.
-    """)
+    """
+    )
 
     def fill_parser(self, parser):
         """Add own parameters to the general parser."""
         parser.add_argument(
-            'library', nargs='?',
-            help="Library to fetch (e.g. charms.mycharm.v2.foo.); optional, default to all")
+            "library",
+            nargs="?",
+            help="Library to fetch (e.g. charms.mycharm.v2.foo.); optional, default to all",
+        )
 
     def run(self, parsed_args):
         """Run the command."""
@@ -980,7 +1123,7 @@ class FetchLibCommand(BaseCommand):
                 item = dict(charm_name=lib.charm_name, lib_name=lib.lib_name)
             else:
                 item = dict(lib_id=lib.lib_id)
-            item['api'] = lib.api
+            item["api"] = lib.api
             to_query.append(item)
         libs_tips = store.get_libraries_tips(to_query)
 
@@ -991,7 +1134,10 @@ class FetchLibCommand(BaseCommand):
             # fix any missing lib id using the Store info
             if lib_data.lib_id is None:
                 for tip in libs_tips.values():
-                    if lib_data.charm_name == tip.charm_name and lib_data.lib_name == tip.lib_name:
+                    if (
+                        lib_data.charm_name == tip.charm_name
+                        and lib_data.lib_name == tip.lib_name
+                    ):
                         lib_data = lib_data._replace(lib_id=tip.lib_id)
                         break
 
@@ -1007,53 +1153,74 @@ class FetchLibCommand(BaseCommand):
             elif tip.patch < lib_data.patch:
                 # the store has a lower version numbers than local
                 logger.info(
-                    "Library %s has local changes, can not be updated.", lib_data.full_name)
+                    "Library %s has local changes, can not be updated.",
+                    lib_data.full_name,
+                )
             else:
                 # same versions locally and in the store
                 if tip.content_hash == lib_data.content_hash:
                     logger.info(
                         "Library %s was already up to date in version %d.%d.",
-                        lib_data.full_name, tip.api, tip.patch)
+                        lib_data.full_name,
+                        tip.api,
+                        tip.patch,
+                    )
                 else:
                     logger.info(
-                        "Library %s has local changes, can not be updated.", lib_data.full_name)
+                        "Library %s has local changes, can not be updated.",
+                        lib_data.full_name,
+                    )
 
         for lib_data in to_fetch:
-            downloaded = store.get_library(lib_data.charm_name, lib_data.lib_id, lib_data.api)
+            downloaded = store.get_library(
+                lib_data.charm_name, lib_data.lib_id, lib_data.api
+            )
             if lib_data.content is None:
                 # locally new
                 lib_data.path.parent.mkdir(parents=True, exist_ok=True)
                 lib_data.path.write_text(downloaded.content)
                 logger.info(
                     "Library %s version %d.%d downloaded.",
-                    lib_data.full_name, downloaded.api, downloaded.patch)
+                    lib_data.full_name,
+                    downloaded.api,
+                    downloaded.patch,
+                )
             else:
                 # XXX Facundo 2020-12-17: manage the case where the library was renamed
                 # (related GH issue: #214)
                 lib_data.path.write_text(downloaded.content)
                 logger.info(
                     "Library %s updated to version %d.%d.",
-                    lib_data.full_name, downloaded.api, downloaded.patch)
+                    lib_data.full_name,
+                    downloaded.api,
+                    downloaded.patch,
+                )
 
 
 class ListLibCommand(BaseCommand):
     """List all libraries belonging to a charm."""
 
-    name = 'list-lib'
+    name = "list-lib"
     help_msg = "List all libraries from a charm"
-    overview = textwrap.dedent("""
+    overview = textwrap.dedent(
+        """
         List all libraries from a charm.
 
         For each library, it will show the name and the api and patch versions
         for its tip.
-    """)
+    """
+    )
 
     def fill_parser(self, parser):
         """Add own parameters to the general parser."""
         parser.add_argument(
-            'name', nargs='?', help=(
+            "name",
+            nargs="?",
+            help=(
                 "The name of the charm (optional, will get the name from"
-                "metadata.yaml if not given)"))
+                "metadata.yaml if not given)"
+            ),
+        )
 
     def run(self, parsed_args):
         """Run the command."""
@@ -1065,21 +1232,24 @@ class ListLibCommand(BaseCommand):
                 raise CommandError(
                     "Can't access name in 'metadata.yaml' file. The 'list-lib' command must "
                     "either be executed from a valid project directory, or specify a charm "
-                    "name using the --charm-name option.")
+                    "name using the --charm-name option."
+                )
 
         # get tips from the Store
         store = Store(self.config.charmhub)
-        to_query = [{'charm_name': charm_name}]
+        to_query = [{"charm_name": charm_name}]
         libs_tips = store.get_libraries_tips(to_query)
 
         if not libs_tips:
             logger.info("No libraries found for charm %s.", charm_name)
             return
 
-        headers = ['Library name', 'API', 'Patch']
-        data = sorted((item.lib_name, item.api, item.patch) for item in libs_tips.values())
+        headers = ["Library name", "API", "Patch"]
+        data = sorted(
+            (item.lib_name, item.api, item.patch) for item in libs_tips.values()
+        )
 
-        table = tabulate(data, headers=headers, tablefmt='plain', numalign='left')
+        table = tabulate(data, headers=headers, tablefmt="plain", numalign="left")
         for line in table.splitlines():
             logger.info(line)
 
@@ -1087,18 +1257,22 @@ class ListLibCommand(BaseCommand):
 class ListResourcesCommand(BaseCommand):
     """List the resources associated with a given charm in Charmhub."""
 
-    name = 'resources'
+    name = "resources"
     help_msg = "List the resources associated with a given charm in Charmhub"
-    overview = textwrap.dedent("""
+    overview = textwrap.dedent(
+        """
         An overview of the resources associated with a given charm in Charmhub.
 
         Listing resources will take you through login if needed.
 
-    """)
+    """
+    )
 
     def fill_parser(self, parser):
         """Add own parameters to the general parser."""
-        parser.add_argument('charm_name', metavar='charm-name', help="The name of the charm")
+        parser.add_argument(
+            "charm_name", metavar="charm-name", help="The name of the charm"
+        )
 
     def run(self, parsed_args):
         """Run the command."""
@@ -1108,18 +1282,21 @@ class ListResourcesCommand(BaseCommand):
             logger.info("No resources associated to %s.", parsed_args.charm_name)
             return
 
-        headers = ['Charm Rev', 'Resource', 'Type', 'Optional']
+        headers = ["Charm Rev", "Resource", "Type", "Optional"]
         by_revision = {}
         for item in result:
             by_revision.setdefault(item.revision, []).append(item)
         data = []
         for revision, items in sorted(by_revision.items(), reverse=True):
-            initial, *rest = sorted(items, key=attrgetter('name'))
-            data.append((revision, initial.name, initial.resource_type, initial.optional))
+            initial, *rest = sorted(items, key=attrgetter("name"))
+            data.append(
+                (revision, initial.name, initial.resource_type, initial.optional)
+            )
             data.extend(
-                ("", item.name, item.resource_type, item.optional) for item in rest)
+                ("", item.name, item.resource_type, item.optional) for item in rest
+            )
 
-        table = tabulate(data, headers=headers, tablefmt='plain', numalign='left')
+        table = tabulate(data, headers=headers, tablefmt="plain", numalign="left")
         for line in table.splitlines():
             logger.info(line)
 
@@ -1128,30 +1305,33 @@ class _BadOCIImageSpecError(CommandError):
     """Subclass to provide a specific error for a bad OCI Image specification."""
 
     def __init__(self, base_error):
-        super().__init__(base_error + " (the format is [organization/]name[:tag|@digest]).")
+        super().__init__(
+            base_error + " (the format is [organization/]name[:tag|@digest])."
+        )
 
 
 def oci_image_spec(value):
     """Build a full OCI image spec, using defaults for non specified parts."""
     # separate the organization
-    if '/' in value:
-        if value.count('/') > 1:
+    if "/" in value:
+        if value.count("/") > 1:
             raise _BadOCIImageSpecError(
-                "The registry server cannot be specified as part of the image")
-        orga, value = value.split('/')
+                "The registry server cannot be specified as part of the image"
+            )
+        orga, value = value.split("/")
     else:
-        orga = 'library'
+        orga = "library"
 
     # get the digest XOR tag
-    if '@' in value and ':' in value:
+    if "@" in value and ":" in value:
         raise _BadOCIImageSpecError("Cannot specify both tag and digest")
-    if '@' in value:
-        name, reference = value.split('@')
-    elif ':' in value:
-        name, reference = value.split(':')
+    if "@" in value:
+        name, reference = value.split("@")
+    elif ":" in value:
+        name, reference = value.split(":")
     else:
         name = value
-        reference = 'latest'
+        reference = "latest"
 
     if not name:
         raise _BadOCIImageSpecError("The image name is mandatory")
@@ -1161,9 +1341,10 @@ def oci_image_spec(value):
 class UploadResourceCommand(BaseCommand):
     """Upload a resource to Charmhub."""
 
-    name = 'upload-resource'
+    name = "upload-resource"
     help_msg = "Upload a resource to Charmhub"
-    overview = textwrap.dedent("""
+    overview = textwrap.dedent(
+        """
         Upload a resource to Charmhub.
 
         Push a resource content to Charmhub, associating it to the
@@ -1179,24 +1360,31 @@ class UploadResourceCommand(BaseCommand):
         correspondingly.
 
         Upload will take you through login if needed.
-    """)
+    """
+    )
     common = True
 
     def fill_parser(self, parser):
         """Add own parameters to the general parser."""
         parser.add_argument(
-            'charm_name', metavar='charm-name',
-            help="The charm name to associate the resource")
+            "charm_name",
+            metavar="charm-name",
+            help="The charm name to associate the resource",
+        )
         parser.add_argument(
-            'resource_name', metavar='resource-name',
-            help="The resource name")
+            "resource_name", metavar="resource-name", help="The resource name"
+        )
         group = parser.add_mutually_exclusive_group(required=True)
         group.add_argument(
-            '--filepath', type=SingleOptionEnsurer(useful_filepath),
-            help="The file path of the resource content to upload")
+            "--filepath",
+            type=SingleOptionEnsurer(useful_filepath),
+            help="The file path of the resource content to upload",
+        )
         group.add_argument(
-            '--image', type=SingleOptionEnsurer(oci_image_spec),
-            help="The image specification with the [organization/]name[:tag|@digest] form")
+            "--image",
+            type=SingleOptionEnsurer(oci_image_spec),
+            help="The image specification with the [organization/]name[:tag|@digest] form",
+        )
 
     def run(self, parsed_args):
         """Run the command."""
@@ -1208,24 +1396,29 @@ class UploadResourceCommand(BaseCommand):
             resource_type = ResourceType.file
             logger.debug("Uploading resource directly from file %s", resource_filepath)
         elif parsed_args.image:
-            logger.debug("Uploading resource from image %s at Dockerhub", parsed_args.image)
+            logger.debug(
+                "Uploading resource from image %s at Dockerhub", parsed_args.image
+            )
             ih = ImageHandler(parsed_args.image.organization, parsed_args.image.name)
             final_resource_url = ih.get_destination_url(parsed_args.image.reference)
             logger.debug("Resource URL: %s", final_resource_url)
-            resource_type = 'oci-image'
+            resource_type = "oci-image"
 
             # create a JSON pointing to the unique image URL (to be uploaded to Charmhub)
             resource_metadata = {
-                'ImageName': final_resource_url,
+                "ImageName": final_resource_url,
             }
-            _, tname = tempfile.mkstemp(prefix='image-resource', suffix='.json')
+            _, tname = tempfile.mkstemp(prefix="image-resource", suffix=".json")
             resource_filepath = pathlib.Path(tname)
             resource_filepath_is_temp = True
             resource_filepath.write_text(json.dumps(resource_metadata))
 
         result = store.upload_resource(
-            parsed_args.charm_name, parsed_args.resource_name,
-            resource_type, resource_filepath)
+            parsed_args.charm_name,
+            parsed_args.resource_name,
+            resource_type,
+            resource_filepath,
+        )
 
         # clean the filepath if needed
         if resource_filepath_is_temp:
@@ -1234,7 +1427,10 @@ class UploadResourceCommand(BaseCommand):
         if result.ok:
             logger.info(
                 "Revision %s created of resource %r for charm %r",
-                result.revision, parsed_args.resource_name, parsed_args.charm_name)
+                result.revision,
+                parsed_args.resource_name,
+                parsed_args.charm_name,
+            )
         else:
             logger.info("Upload failed with status %r:", result.status)
             for error in result.errors:
@@ -1244,9 +1440,10 @@ class UploadResourceCommand(BaseCommand):
 class ListResourceRevisionsCommand(BaseCommand):
     """List revisions for a resource of a charm."""
 
-    name = 'resource-revisions'
+    name = "resource-revisions"
     help_msg = "List revisions for a resource associated to a charm in Charmhub"
-    overview = textwrap.dedent("""
+    overview = textwrap.dedent(
+        """
         Show size and date for each resource revision in Charmhub.
 
         For example:
@@ -1256,34 +1453,44 @@ class ListResourceRevisionsCommand(BaseCommand):
            1           2020-11-15   183151
 
         Listing revisions will take you through login if needed.
-    """)
+    """
+    )
 
     def fill_parser(self, parser):
         """Add own parameters to the general parser."""
         parser.add_argument(
-            'charm_name', metavar='charm-name',
-            help="The charm name to associate the resource")
+            "charm_name",
+            metavar="charm-name",
+            help="The charm name to associate the resource",
+        )
         parser.add_argument(
-            'resource_name', metavar='resource-name',
-            help="The resource name")
+            "resource_name", metavar="resource-name", help="The resource name"
+        )
 
     def run(self, parsed_args):
         """Run the command."""
         store = Store(self.config.charmhub)
-        result = store.list_resource_revisions(parsed_args.charm_name, parsed_args.resource_name)
+        result = store.list_resource_revisions(
+            parsed_args.charm_name, parsed_args.resource_name
+        )
         if not result:
             logger.info("No revisions found.")
             return
 
-        headers = ['Revision', 'Created at', 'Size']
-        custom_alignment = ['left', None, 'right']
-        result.sort(key=attrgetter('revision'), reverse=True)
-        data = [(
-            item.revision,
-            item.created_at.strftime('%Y-%m-%d'),
-            naturalsize(item.size, gnu=True),
-        ) for item in result]
+        headers = ["Revision", "Created at", "Size"]
+        custom_alignment = ["left", None, "right"]
+        result.sort(key=attrgetter("revision"), reverse=True)
+        data = [
+            (
+                item.revision,
+                item.created_at.strftime("%Y-%m-%d"),
+                naturalsize(item.size, gnu=True),
+            )
+            for item in result
+        ]
 
-        table = tabulate(data, headers=headers, tablefmt='plain', colalign=custom_alignment)
+        table = tabulate(
+            data, headers=headers, tablefmt="plain", colalign=custom_alignment
+        )
         for line in table.splitlines():
             logger.info(line)

--- a/charmcraft/commands/version.py
+++ b/charmcraft/commands/version.py
@@ -46,7 +46,7 @@ Example: 0.3.1+40.g883455b.dirty
 class VersionCommand(BaseCommand):
     """Show the charmcraft version."""
 
-    name = 'version'
+    name = "version"
     help_msg = "Show charmcraft version"
     overview = _overview
     common = True

--- a/charmcraft/helptexts.py
+++ b/charmcraft/helptexts.py
@@ -72,7 +72,9 @@ def _build_item(title, text, title_space):
     wrapped_lines = textwrap.wrap(text, text_space)
 
     # first line goes with the title at column 4
-    first = "    {:>{title_space}s}:  {}".format(title, wrapped_lines[0], title_space=title_space)
+    first = "    {:>{title_space}s}:  {}".format(
+        title, wrapped_lines[0], title_space=title_space
+    )
     result = [first]
 
     # the rest (if any) still aligned but without title
@@ -128,7 +130,7 @@ def get_full_help(command_groups, global_options):
     textblocks.append("\n".join(global_lines))
 
     common_lines = ["Starter commands:"]
-    for cmd in sorted(common_commands, key=attrgetter('name')):
+    for cmd in sorted(common_commands, key=attrgetter("name")):
         common_lines.extend(_build_item(cmd.name, cmd.help_msg, max_title_len))
     textblocks.append("\n".join(common_lines))
 
@@ -138,13 +140,17 @@ def get_full_help(command_groups, global_options):
         grouped_lines.extend(_build_item(group, command_names, max_title_len))
     textblocks.append("\n".join(grouped_lines))
 
-    textblocks.append(textwrap.dedent("""
+    textblocks.append(
+        textwrap.dedent(
+            """
         For more information about a command, run 'charmcraft help <command>'.
         For a summary of all commands, run 'charmcraft help --all'.
-    """))
+    """
+        )
+    )
 
     # join all stripped blocks, leaving ONE empty blank line between
-    text = '\n\n'.join(block.strip() for block in textblocks) + '\n'
+    text = "\n\n".join(block.strip() for block in textblocks) + "\n"
     return text
 
 
@@ -194,12 +200,16 @@ def get_detailed_help(command_groups, global_options):
             group_lines.extend(_build_item(cmd.name, cmd.help_msg, max_title_len))
         textblocks.append("\n".join(group_lines))
 
-    textblocks.append(textwrap.dedent("""
+    textblocks.append(
+        textwrap.dedent(
+            """
         For more information about a specific command, run 'charmcraft help <command>'.
-    """))
+    """
+        )
+    )
 
     # join all stripped blocks, leaving ONE empty blank line between
-    text = '\n\n'.join(block.strip() for block in textblocks) + '\n'
+    text = "\n\n".join(block.strip() for block in textblocks) + "\n"
     return text
 
 
@@ -228,17 +238,24 @@ def get_command_help(command_groups, command, arguments):
     parameters = []
     options = []
     for name, title in arguments:
-        if name[0] == '-':
+        if name[0] == "-":
             options.append((name, title))
         else:
             parameters.append(name)
 
-    textblocks.append(textwrap.dedent("""\
+    textblocks.append(
+        textwrap.dedent(
+            """\
         Usage:
             charmcraft {} [options] {}
-    """.format(command.name, " ".join("<{}>".format(parameter) for parameter in parameters))))
+    """.format(
+                command.name,
+                " ".join("<{}>".format(parameter) for parameter in parameters),
+            )
+        )
+    )
 
-    textblocks.append("Summary:{}".format(textwrap.indent(command.overview, '    ')))
+    textblocks.append("Summary:{}".format(textwrap.indent(command.overview, "    ")))
 
     # column alignment is dictated by longest options title
     max_title_len = max(len(title) for title, text in options)
@@ -255,17 +272,21 @@ def get_command_help(command_groups, command, arguments):
             break
     else:
         raise RuntimeError("Internal inconsistency in commands groups")
-    other_command_names = [c.name for c in command_classes if not isinstance(command, c)]
+    other_command_names = [
+        c.name for c in command_classes if not isinstance(command, c)
+    ]
     if other_command_names:
         see_also_block = ["See also:"]
         see_also_block.extend(("    " + name) for name in sorted(other_command_names))
-        textblocks.append('\n'.join(see_also_block))
+        textblocks.append("\n".join(see_also_block))
 
     # footer
-    textblocks.append("""
+    textblocks.append(
+        """
         For a summary of all commands, run 'charmcraft help --all'.
-    """)
+    """
+    )
 
     # join all stripped blocks, leaving ONE empty blank line between
-    text = '\n\n'.join(block.strip() for block in textblocks) + '\n'
+    text = "\n\n".join(block.strip() for block in textblocks) + "\n"
     return text

--- a/charmcraft/logsetup.py
+++ b/charmcraft/logsetup.py
@@ -25,7 +25,7 @@ from charmcraft import __version__
 FORMATTER_SIMPLE = "%(message)s"
 FORMATTER_DETAILED = "%(asctime)s  %(name)-30s %(levelname)-8s %(message)s"
 
-_logger = logging.getLogger('charmcraft')
+_logger = logging.getLogger("charmcraft")
 _logger.setLevel(logging.DEBUG)
 
 
@@ -40,9 +40,9 @@ class _MessageHandler:
     """
 
     _modes = {
-        'quiet': (logging.WARNING, FORMATTER_SIMPLE),
-        'normal': (logging.INFO, FORMATTER_SIMPLE),
-        'verbose': (logging.DEBUG, FORMATTER_DETAILED),
+        "quiet": (logging.WARNING, FORMATTER_SIMPLE),
+        "normal": (logging.INFO, FORMATTER_SIMPLE),
+        "verbose": (logging.DEBUG, FORMATTER_DETAILED),
     }
 
     def __init__(self):
@@ -69,7 +69,7 @@ class _MessageHandler:
 
     def _set_filehandler(self):
         """Set the file handler to log everything to the temp file."""
-        _, self._log_filepath = tempfile.mkstemp(prefix='charmcraft-log-')
+        _, self._log_filepath = tempfile.mkstemp(prefix="charmcraft-log-")
 
         file_handler = logging.FileHandler(self._log_filepath)
         file_handler.setFormatter(logging.Formatter(FORMATTER_DETAILED))
@@ -77,7 +77,7 @@ class _MessageHandler:
         _logger.addHandler(file_handler)
 
         # a logger for only the file
-        self._file_logger = logging.getLogger('charmcraft.guard')
+        self._file_logger = logging.getLogger("charmcraft.guard")
         self._file_logger.propagate = False
         self._file_logger.addHandler(file_handler)
         self._file_logger.debug("Starting charmcraft version %s", __version__)
@@ -108,14 +108,15 @@ class _MessageHandler:
         Show just the error to the user, but send the whole traceback to the log file.
         """
         msg = "charmcraft internal error! {}: {} (full execution logs in {})".format(
-            err.__class__.__name__, err, self._log_filepath)
+            err.__class__.__name__, err, self._log_filepath
+        )
         if self.mode == self.VERBOSE:
             # both to screen and file!
             _logger.exception(msg)
         else:
             # the error to screen and file, plus the traceback to the file
             _logger.error(msg)
-            self._file_logger.exception('')
+            self._file_logger.exception("")
 
 
 message_handler = _MessageHandler()

--- a/charmcraft/main.py
+++ b/charmcraft/main.py
@@ -36,18 +36,26 @@ class HelpCommand(BaseCommand):
     idea is to lower the barrier as much as possible for the user getting help.
     """
 
-    name = 'help'
+    name = "help"
     help_msg = "Provide help on charmcraft usage"
-    overview = "Produce a general or a detailed charmcraft help, or a specific command one."
+    overview = (
+        "Produce a general or a detailed charmcraft help, or a specific command one."
+    )
     common = True
 
     def fill_parser(self, parser):
         """Add own parameters to the general parser."""
         parser.add_argument(
-            '--all', action='store_true', help="Produce an extensive help of all commands")
+            "--all",
+            action="store_true",
+            help="Produce an extensive help of all commands",
+        )
         parser.add_argument(
-            'command_to_help', nargs='?', metavar='command',
-            help="Produce a detailed help of the specified command")
+            "command_to_help",
+            nargs="?",
+            metavar="command",
+            help="Produce a detailed help of the specified command",
+        )
 
     def run(self, parsed_args, all_commands):
         """Present different help messages to the user.
@@ -56,13 +64,16 @@ class HelpCommand(BaseCommand):
         to validate if the help requested is on a valid one, or even parse its data.
         """
         retcode = 0
-        if parsed_args.command_to_help is None or parsed_args.command_to_help == self.name:
+        if (
+            parsed_args.command_to_help is None
+            or parsed_args.command_to_help == self.name
+        ):
             # help on no command in particular, get general text
             help_text = get_general_help(detailed=parsed_args.all)
         elif parsed_args.command_to_help not in all_commands:
             # asked help on a command that doesn't exist
             msg = "no such command {!r}".format(parsed_args.command_to_help)
-            help_text = helptexts.get_usage_message('charmcraft', msg)
+            help_text = helptexts.get_usage_message("charmcraft", msg)
             retcode = 1
         else:
             cmd_class, group = all_commands[parsed_args.command_to_help]
@@ -78,41 +89,70 @@ class HelpCommand(BaseCommand):
 # central place and not distributed in several classes/files. Also note that order here is
 # important when listing commands and showing help.
 COMMAND_GROUPS = [
-    ('basic', "Basic", [
-        HelpCommand,
-        build.BuildCommand,
-        pack.PackCommand,
-        init.InitCommand,
-        version.VersionCommand,
-    ]),
-    ('store', "Charmhub", [
-        # auth
-        store.LoginCommand, store.LogoutCommand, store.WhoamiCommand,
-        # name handling
-        store.RegisterCharmNameCommand, store.RegisterBundleNameCommand, store.ListNamesCommand,
-        # pushing files and checking revisions
-        store.UploadCommand, store.ListRevisionsCommand,
-        # release process, and show status
-        store.ReleaseCommand, store.StatusCommand,
-        # libraries support
-        store.CreateLibCommand, store.PublishLibCommand, store.ListLibCommand,
-        store.FetchLibCommand,
-        # resources support
-        store.ListResourcesCommand, store.UploadResourceCommand,
-        store.ListResourceRevisionsCommand,
-    ]),
+    (
+        "basic",
+        "Basic",
+        [
+            HelpCommand,
+            build.BuildCommand,
+            pack.PackCommand,
+            init.InitCommand,
+            version.VersionCommand,
+        ],
+    ),
+    (
+        "store",
+        "Charmhub",
+        [
+            # auth
+            store.LoginCommand,
+            store.LogoutCommand,
+            store.WhoamiCommand,
+            # name handling
+            store.RegisterCharmNameCommand,
+            store.RegisterBundleNameCommand,
+            store.ListNamesCommand,
+            # pushing files and checking revisions
+            store.UploadCommand,
+            store.ListRevisionsCommand,
+            # release process, and show status
+            store.ReleaseCommand,
+            store.StatusCommand,
+            # libraries support
+            store.CreateLibCommand,
+            store.PublishLibCommand,
+            store.ListLibCommand,
+            store.FetchLibCommand,
+            # resources support
+            store.ListResourcesCommand,
+            store.UploadResourceCommand,
+            store.ListResourceRevisionsCommand,
+        ],
+    ),
 ]
 
 
 # global options: the name used internally, its type, short and long parameters, and help text
-_Global = namedtuple('Global', 'name type short_option long_option help_message')
+_Global = namedtuple("Global", "name type short_option long_option help_message")
 GLOBAL_ARGS = [
-    _Global('help', 'flag', '-h', '--help', "Show this help message and exit"),
-    _Global('verbose', 'flag', '-v', '--verbose', "Show debug information and be more verbose"),
-    _Global('quiet', 'flag', '-q', '--quiet', "Only show warnings and errors, not progress"),
+    _Global("help", "flag", "-h", "--help", "Show this help message and exit"),
     _Global(
-        'project_dir', 'option', '-p', '--project-dir',
-        "Specify the project's directory (defaults to current)"),
+        "verbose",
+        "flag",
+        "-v",
+        "--verbose",
+        "Show debug information and be more verbose",
+    ),
+    _Global(
+        "quiet", "flag", "-q", "--quiet", "Only show warnings and errors, not progress"
+    ),
+    _Global(
+        "project_dir",
+        "option",
+        "-p",
+        "--project-dir",
+        "Specify the project's directory (defaults to current)",
+    ),
 ]
 
 
@@ -130,7 +170,9 @@ def _get_global_options():
     """Return the global flags ready to present as options in the help messages."""
     options = []
     for arg in GLOBAL_ARGS:
-        options.append(("{}, {}".format(arg.short_option, arg.long_option), arg.help_message))
+        options.append(
+            ("{}, {}".format(arg.short_option, arg.long_option), arg.help_message)
+        )
     return options
 
 
@@ -141,7 +183,7 @@ def get_command_help(parser, command):
     for action in parser._actions:
         # store the different options if present, otherwise it's just the dest
         if action.option_strings:
-            options.append((', '.join(action.option_strings), action.help))
+            options.append((", ".join(action.option_strings), action.help))
         else:
             dest = action.dest if action.metavar is None else action.metavar
             options.append((dest, action.help))
@@ -170,7 +212,8 @@ class Dispatcher:
         self.commands = self._get_commands_info(commands_groups)
         command_name, cmd_args, charmcraft_config = self._pre_parse_args(sysargs)
         self.command, self.parsed_args = self._load_command(
-            command_name, cmd_args, charmcraft_config)
+            command_name, cmd_args, charmcraft_config
+        )
 
     def _get_commands_info(self, commands_groups):
         """Process the commands groups structure for easier programmable access."""
@@ -181,7 +224,9 @@ class Dispatcher:
                     _stored_class, _ = commands[_cmd_class.name]
                     raise RuntimeError(
                         "Multiple commands with same name: {} and {}".format(
-                            _cmd_class.__name__, _stored_class.__name__))
+                            _cmd_class.__name__, _stored_class.__name__
+                        )
+                    )
                 commands[_cmd_class.name] = (_cmd_class, _cmd_group)
         return commands
 
@@ -216,11 +261,11 @@ class Dispatcher:
         for arg in GLOBAL_ARGS:
             arg_per_option[arg.short_option] = arg
             arg_per_option[arg.long_option] = arg
-            if arg.type == 'flag':
+            if arg.type == "flag":
                 default = False
-            elif arg.type == 'option':
+            elif arg.type == "option":
                 default = None
-                options_with_equal.append(arg.long_option + '=')
+                options_with_equal.append(arg.long_option + "=")
             else:
                 raise ValueError("Bad GLOBAL_ARGS structure.")
             global_args[arg.name] = default
@@ -231,16 +276,18 @@ class Dispatcher:
         for sysarg in sysargs:
             if sysarg in arg_per_option:
                 arg = arg_per_option[sysarg]
-                if arg.type == 'flag':
+                if arg.type == "flag":
                     value = True
                 else:
                     try:
                         value = next(sysargs)
                     except StopIteration:
-                        raise CommandError("The 'project-dir' option expects one argument.")
+                        raise CommandError(
+                            "The 'project-dir' option expects one argument."
+                        )
                 global_args[arg.name] = value
             elif sysarg.startswith(options_with_equal):
-                option, value = sysarg.split('=', 1)
+                option, value = sysarg.split("=", 1)
                 if not value:
                     raise CommandError("The 'project-dir' option expects one argument.")
                 arg = arg_per_option[option]
@@ -249,16 +296,20 @@ class Dispatcher:
                 filtered_sysargs.append(sysarg)
 
         # control and use quiet/verbose options
-        if global_args['quiet'] and global_args['verbose']:
-            raise CommandError("The 'verbose' and 'quiet' options are mutually exclusive.")
-        if global_args['quiet']:
+        if global_args["quiet"] and global_args["verbose"]:
+            raise CommandError(
+                "The 'verbose' and 'quiet' options are mutually exclusive."
+            )
+        if global_args["quiet"]:
             message_handler.set_mode(message_handler.QUIET)
-        elif global_args['verbose']:
+        elif global_args["verbose"]:
             message_handler.set_mode(message_handler.VERBOSE)
-        logger.debug("Raw pre-parsed sysargs: args=%s filtered=%s", global_args, filtered_sysargs)
+        logger.debug(
+            "Raw pre-parsed sysargs: args=%s filtered=%s", global_args, filtered_sysargs
+        )
 
         # if help requested, transform the parameters to make that explicit
-        if global_args['help']:
+        if global_args["help"]:
             command = HelpCommand.name
             cmd_args = filtered_sysargs
         elif filtered_sysargs:
@@ -266,7 +317,7 @@ class Dispatcher:
             cmd_args = filtered_sysargs[1:]
             if command not in self.commands:
                 msg = "no such command {!r}".format(command)
-                help_text = helptexts.get_usage_message('charmcraft', msg)
+                help_text = helptexts.get_usage_message("charmcraft", msg)
                 raise CommandError(help_text, argsparsing=True)
         else:
             # no command!
@@ -274,7 +325,7 @@ class Dispatcher:
             raise CommandError(help_text, argsparsing=True)
 
         # load the system's config
-        charmcraft_config = config.load(global_args['project_dir'])
+        charmcraft_config = config.load(global_args["project_dir"])
 
         logger.debug("General parsed sysargs: command=%r args=%s", command, cmd_args)
         return command, cmd_args, charmcraft_config
@@ -284,11 +335,15 @@ class Dispatcher:
         if isinstance(self.command, HelpCommand):
             self.command.run(self.parsed_args, self.commands)
         else:
-            if self.command.needs_config and not self.command.config.project.config_provided:
+            if (
+                self.command.needs_config
+                and not self.command.config.project.config_provided
+            ):
                 raise CommandError(
                     "The specified command needs a valid 'charmcraft.yaml' configuration file (in "
                     "the current directory or where specified with --project-dir option); see "
-                    "the reference: https://discourse.charmhub.io/t/charmcraft-configuration/4138")
+                    "the reference: https://discourse.charmhub.io/t/charmcraft-configuration/4138"
+                )
             self.command.run(self.parsed_args)
 
 
@@ -319,5 +374,5 @@ def main(argv=None):
     return retcode
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main(sys.argv))

--- a/charmcraft/utils.py
+++ b/charmcraft/utils.py
@@ -30,7 +30,7 @@ from jinja2 import Environment, PackageLoader, StrictUndefined
 from charmcraft import __version__
 from charmcraft.cmdbase import CommandError
 
-logger = logging.getLogger('charmcraft.commands')
+logger = logging.getLogger("charmcraft.commands")
 
 OSPlatform = namedtuple("OSPlatform", "system release machine")
 
@@ -41,12 +41,12 @@ S_IRALL = S_IRUSR | S_IRGRP | S_IROTH
 # translations from what the platform module informs to the term deb and
 # snaps actually use
 ARCH_TRANSLATIONS = {
-    'aarch64': 'arm64',
-    'armv7l': 'armhf',
-    'i686': 'i386',
-    'ppc': 'powerpc',
-    'ppc64le': 'ppc64el',
-    'x86_64': 'amd64',
+    "aarch64": "arm64",
+    "armv7l": "armhf",
+    "i686": "i386",
+    "ppc": "powerpc",
+    "ppc64le": "ppc64el",
+    "x86_64": "amd64",
 }
 
 
@@ -66,7 +66,7 @@ def load_yaml(fpath):
         logger.debug("Couldn't find config file %s", fpath)
         return
     try:
-        with fpath.open('rb') as fh:
+        with fpath.open("rb") as fh:
             content = yaml.safe_load(fh)
     except (yaml.error.YAMLError, OSError) as err:
         logger.error("Failed to read/parse config file %s: %r", fpath, err)
@@ -77,11 +77,12 @@ def load_yaml(fpath):
 def get_templates_environment(templates_dir):
     """Create and return a Jinja environment to deal with the templates."""
     env = Environment(
-        loader=PackageLoader('charmcraft', 'templates/{}'.format(templates_dir)),
-        autoescape=False,            # no need to escape things here :-)
+        loader=PackageLoader("charmcraft", "templates/{}".format(templates_dir)),
+        autoescape=False,  # no need to escape things here :-)
         keep_trailing_newline=True,  # they're not text files if they don't end in newline!
-        optimized=False,             # optimization doesn't make sense for one-offs
-        undefined=StrictUndefined)   # fail on undefined
+        optimized=False,  # optimization doesn't make sense for one-offs
+        undefined=StrictUndefined,
+    )  # fail on undefined
     return env
 
 
@@ -125,7 +126,7 @@ class ResourceOption:
 
     def __call__(self, value):
         """Run by argparse to validate and convert the given argument."""
-        parts = [x.strip() for x in value.split(':')]
+        parts = [x.strip() for x in value.split(":")]
         parts = [p for p in parts if p]
         if len(parts) == 2:
             name, revision = parts
@@ -161,7 +162,7 @@ def get_os_platform(filepath=pathlib.Path("/etc/os-release")):
 
     if system == "Linux":
         try:
-            with filepath.open("rt", encoding='utf-8') as fh:
+            with filepath.open("rt", encoding="utf-8") as fh:
                 lines = fh.readlines()
         except FileNotFoundError:
             logger.debug("Unable to locate 'os-release' file, using default values")
@@ -169,7 +170,7 @@ def get_os_platform(filepath=pathlib.Path("/etc/os-release")):
             os_release = {}
             for line in lines:
                 line = line.strip()
-                if not line or line.startswith('#') or '=' not in line:
+                if not line or line.startswith("#") or "=" not in line:
                     continue
                 key, value = line.rstrip().split("=", 1)
                 if value[0] == value[-1] and value[0] in ('"', "'"):
@@ -194,27 +195,27 @@ def create_manifest(basedir, started_at):
 
     # XXX Facundo 2021-04-19: these are temporary translations until charmcraft
     # changes to be a "classic" snap
-    name_translation = {'ubuntu-core': 'ubuntu'}
-    channel_translation = {'20': '20.04'}
+    name_translation = {"ubuntu-core": "ubuntu"}
+    channel_translation = {"20": "20.04"}
     name = os_platform.system.lower()
     name = name_translation.get(name, name)
     channel = channel_translation.get(os_platform.release, os_platform.release)
 
     content = {
-        'charmcraft-version': __version__,
-        'charmcraft-started-at': started_at.isoformat() + "Z",
-        'bases': [
+        "charmcraft-version": __version__,
+        "charmcraft-started-at": started_at.isoformat() + "Z",
+        "bases": [
             {
-                'name': name,
-                'channel': channel,
-                'architectures': architectures,
+                "name": name,
+                "channel": channel,
+                "architectures": architectures,
             }
         ],
-
     }
-    filepath = basedir / 'manifest.yaml'
+    filepath = basedir / "manifest.yaml"
     if filepath.exists():
         raise CommandError(
-            "Cannot write the manifest as there is already a 'manifest.yaml' in disk.")
+            "Cannot write the manifest as there is already a 'manifest.yaml' in disk."
+        )
     filepath.write_text(yaml.dump(content))
     return filepath

--- a/charmcraft/version.py
+++ b/charmcraft/version.py
@@ -17,9 +17,9 @@
 import subprocess
 from pathlib import Path
 
-__all__ = ('version',)
+__all__ = ("version",)
 
-_FALLBACK = '0.10.0'  # this gets bumped after release
+_FALLBACK = "0.10.0"  # this gets bumped after release
 
 
 def _get_version():
@@ -27,24 +27,25 @@ def _get_version():
     version = _FALLBACK + ".dev0+unknown"
 
     p = Path(__file__).parent
-    if (p.parent / '.git').exists():
+    if (p.parent / ".git").exists():
         try:
             proc = subprocess.run(
-                ['git', 'describe', '--tags', '--dirty'],
+                ["git", "describe", "--tags", "--dirty"],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.DEVNULL,
                 cwd=p,
-                check=True)
+                check=True,
+            )
         except Exception:
             pass
         else:
-            version = proc.stdout.strip().decode('utf8')
-            if '-' in version:
+            version = proc.stdout.strip().decode("utf8")
+            if "-" in version:
                 # version will look like <tag>-<#commits>-g<hex>[-dirty]
                 # in terms of PEP 440, the tag we'll make sure is a 'public version identifier';
                 # everything after the first - needs to be a 'local version'
-                public, local = version.split('-', 1)
-                version = public + '+' + local.replace('-', '.')
+                public, local = version.split("-", 1)
+                version = public + "+" + local.replace("-", ".")
                 # version now <tag>+<#commits>.g<hex>[.dirty]
                 # which is PEP440-compliant (as long as <tag> is :-)
     return version

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 appdirs==1.4.4
+black==21.4b0
 attrs==20.3.0
 certifi==2020.12.5
 cffi==1.14.5

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ from setuptools import setup
 import charmcraft
 
 
-with open("README.md", "rt", encoding='utf8') as fh:
+with open("README.md", "rt", encoding="utf8") as fh:
     long_description = fh.read()
 
 install_requires = [
@@ -61,11 +61,15 @@ version_backup = Path("charmcraft/version.py~")
 version_path.rename(version_backup)
 try:
     with version_path.open("wt", encoding="utf8") as fh:
-        fh.write(dedent('''
+        fh.write(
+            dedent(
+                """
             # this is a generated file
 
             version = {!r}
-            ''').format(charmcraft.__version__))
+            """
+            ).format(charmcraft.__version__)
+        )
 
     setup(
         name="charmcraft",
@@ -77,7 +81,7 @@ try:
         long_description_content_type="text/markdown",
         url="https://github.com/canonical/charmcraft",
         license="Apache-2.0",
-        packages=['charmcraft', 'charmcraft.commands', 'charmcraft.commands.store'],
+        packages=["charmcraft", "charmcraft.commands", "charmcraft.commands.store"],
         classifiers=[
             "Environment :: Console",
             "License :: OSI Approved :: Apache Software License",
@@ -85,9 +89,9 @@ try:
             "Programming Language :: Python :: 3",
         ],
         entry_points={
-            'console_scripts': ["charmcraft = charmcraft.main:main"],
+            "console_scripts": ["charmcraft = charmcraft.main:main"],
         },
-        python_requires='>=3',
+        python_requires=">=3",
         install_requires=install_requires,
         extras_require=extras_require,
         include_package_data=True,  # so we get templates in the wheel

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ install_requires = [
 ]
 
 dev_requires = [
+    "black",
     "coverage",
     "flake8",
     "ops>=0.8.0",

--- a/tests/commands/test_build.py
+++ b/tests/commands/test_build.py
@@ -44,10 +44,12 @@ from charmcraft.commands.build import (
 
 # --- Validator tests
 
+
 def test_validator_process_simple():
     """Process the present options and store the result."""
+
     class TestValidator(Validator):
-        _options = ['foo', 'bar']
+        _options = ["foo", "bar"]
 
         def validate_foo(self, arg):
             assert arg == 35
@@ -57,7 +59,7 @@ def test_validator_process_simple():
             assert arg == 45
             return 80
 
-    test_args = namedtuple('T', 'foo bar')(35, 45)
+    test_args = namedtuple("T", "foo bar")(35, 45)
     validator = TestValidator()
     result = validator.process(test_args)
     assert result == dict(foo=70, bar=80)
@@ -65,14 +67,15 @@ def test_validator_process_simple():
 
 def test_validator_process_notpresent():
     """Process an option after not finding the value."""
+
     class TestValidator(Validator):
-        _options = ['foo']
+        _options = ["foo"]
 
         def validate_foo(self, arg):
             assert arg is None
             return 70
 
-    test_args = namedtuple('T', 'bar')(35)
+    test_args = namedtuple("T", "bar")(35)
     validator = TestValidator()
     result = validator.process(test_args)
     assert result == dict(foo=70)
@@ -90,27 +93,27 @@ def test_validator_from_default():
     """'from' param: default value."""
     validator = Validator()
     resp = validator.validate_from(None)
-    assert resp == pathlib.Path('.').absolute()
+    assert resp == pathlib.Path(".").absolute()
 
 
 def test_validator_from_absolutized(tmp_path, monkeypatch):
     """'from' param: check it's made absolute."""
     # change dir to the temp one, where we will have the 'dir1/dir2' tree
-    dir1 = tmp_path / 'dir1'
+    dir1 = tmp_path / "dir1"
     dir1.mkdir()
-    dir2 = dir1 / 'dir2'
+    dir2 = dir1 / "dir2"
     dir2.mkdir()
     monkeypatch.chdir(tmp_path)
 
     validator = Validator()
-    resp = validator.validate_from(pathlib.Path('dir1/dir2'))
+    resp = validator.validate_from(pathlib.Path("dir1/dir2"))
     assert resp == dir2
 
 
 def test_validator_from_expanded():
     """'from' param: expands the user-home prefix."""
     validator = Validator()
-    resp = validator.validate_from(pathlib.Path('~'))
+    resp = validator.validate_from(pathlib.Path("~"))
     assert resp == pathlib.Path.home()
 
 
@@ -119,12 +122,12 @@ def test_validator_from_exist():
     validator = Validator()
     expected_msg = "Charm directory was not found: '/not_really_there'"
     with pytest.raises(CommandError, match=expected_msg):
-        validator.validate_from(pathlib.Path('/not_really_there'))
+        validator.validate_from(pathlib.Path("/not_really_there"))
 
 
 def test_validator_from_isdir(tmp_path):
     """'from' param: checks that the directory is really that."""
-    testfile = tmp_path / 'testfile'
+    testfile = tmp_path / "testfile"
     testfile.touch()
 
     validator = Validator()
@@ -135,7 +138,7 @@ def test_validator_from_isdir(tmp_path):
 
 def test_validator_entrypoint_simple(tmp_path):
     """'entrypoint' param: simple validation."""
-    testfile = tmp_path / 'testfile'
+    testfile = tmp_path / "testfile"
     testfile.touch(mode=0o777)
 
     validator = Validator()
@@ -146,7 +149,7 @@ def test_validator_entrypoint_simple(tmp_path):
 
 def test_validator_entrypoint_default(tmp_path):
     """'entrypoint' param: default value."""
-    default_entrypoint = tmp_path / 'src' / 'charm.py'
+    default_entrypoint = tmp_path / "src" / "charm.py"
     default_entrypoint.parent.mkdir()
     default_entrypoint.touch(mode=0o777)
 
@@ -159,31 +162,31 @@ def test_validator_entrypoint_default(tmp_path):
 def test_validator_entrypoint_absolutized(tmp_path, monkeypatch):
     """'entrypoint' param: check it's made absolute."""
     # change dir to the temp one, where we will have the 'dirX/file.py' stuff
-    dirx = tmp_path / 'dirX'
+    dirx = tmp_path / "dirX"
     dirx.mkdir()
-    testfile = dirx / 'file.py'
+    testfile = dirx / "file.py"
     testfile.touch(mode=0o777)
     monkeypatch.chdir(tmp_path)
 
     validator = Validator()
     validator.basedir = tmp_path
-    resp = validator.validate_entrypoint(pathlib.Path('dirX/file.py'))
+    resp = validator.validate_entrypoint(pathlib.Path("dirX/file.py"))
     assert resp == testfile
 
 
 def test_validator_entrypoint_expanded(tmp_path):
     """'entrypoint' param: expands the user-home prefix."""
-    fake_home = tmp_path / 'homedir'
+    fake_home = tmp_path / "homedir"
     fake_home.mkdir()
 
-    testfile = fake_home / 'testfile'
+    testfile = fake_home / "testfile"
     testfile.touch(mode=0o777)
 
     validator = Validator()
     validator.basedir = tmp_path
 
-    with patch.dict(os.environ, {'HOME': str(fake_home)}):
-        resp = validator.validate_entrypoint(pathlib.Path('~/testfile'))
+    with patch.dict(os.environ, {"HOME": str(fake_home)}):
+        resp = validator.validate_entrypoint(pathlib.Path("~/testfile"))
     assert resp == testfile
 
 
@@ -192,13 +195,13 @@ def test_validator_entrypoint_exist():
     validator = Validator()
     expected_msg = "Charm entry point was not found: '/not_really_there.py'"
     with pytest.raises(CommandError, match=expected_msg):
-        validator.validate_entrypoint(pathlib.Path('/not_really_there.py'))
+        validator.validate_entrypoint(pathlib.Path("/not_really_there.py"))
 
 
 def test_validator_entrypoint_inside_project(tmp_path):
     """'entrypoint' param: checks that it's part of the project."""
-    project_dir = tmp_path / 'test-project'
-    testfile = tmp_path / 'testfile'
+    project_dir = tmp_path / "test-project"
+    testfile = tmp_path / "testfile"
     testfile.touch(mode=0o777)
 
     validator = Validator()
@@ -211,7 +214,7 @@ def test_validator_entrypoint_inside_project(tmp_path):
 
 def test_validator_entrypoint_exec(tmp_path):
     """'entrypoint' param: checks that the file is executable."""
-    testfile = tmp_path / 'testfile'
+    testfile = tmp_path / "testfile"
     testfile.touch(mode=0o444)
 
     validator = Validator()
@@ -223,7 +226,7 @@ def test_validator_entrypoint_exec(tmp_path):
 
 def test_validator_requirement_simple(tmp_path):
     """'requirement' param: simple validation."""
-    testfile = tmp_path / 'testfile'
+    testfile = tmp_path / "testfile"
     testfile.touch()
 
     validator = Validator()
@@ -233,9 +236,9 @@ def test_validator_requirement_simple(tmp_path):
 
 def test_validator_requirement_multiple(tmp_path):
     """'requirement' param: multiple files."""
-    testfile1 = tmp_path / 'testfile1'
+    testfile1 = tmp_path / "testfile1"
     testfile1.touch()
-    testfile2 = tmp_path / 'testfile2'
+    testfile2 = tmp_path / "testfile2"
     testfile2.touch()
 
     validator = Validator()
@@ -245,7 +248,7 @@ def test_validator_requirement_multiple(tmp_path):
 
 def test_validator_requirement_default_present_ok(tmp_path):
     """'requirement' param: default value when a requirements.txt is there and readable."""
-    default_requirement = tmp_path / 'requirements.txt'
+    default_requirement = tmp_path / "requirements.txt"
     default_requirement.touch()
 
     validator = Validator()
@@ -256,7 +259,7 @@ def test_validator_requirement_default_present_ok(tmp_path):
 
 def test_validator_requirement_default_present_not_readable(tmp_path):
     """'requirement' param: default value when a requirements.txt is there but not readable."""
-    default_requirement = tmp_path / 'requirements.txt'
+    default_requirement = tmp_path / "requirements.txt"
     default_requirement.touch(0o230)
 
     validator = Validator()
@@ -276,27 +279,27 @@ def test_validator_requirement_default_missing(tmp_path):
 def test_validator_requirement_absolutized(tmp_path, monkeypatch):
     """'requirement' param: check it's made absolute."""
     # change dir to the temp one, where we will have the reqs file
-    testfile = tmp_path / 'reqs.txt'
+    testfile = tmp_path / "reqs.txt"
     testfile.touch()
     monkeypatch.chdir(tmp_path)
 
     validator = Validator()
-    resp = validator.validate_requirement([pathlib.Path('reqs.txt')])
+    resp = validator.validate_requirement([pathlib.Path("reqs.txt")])
     assert resp == [testfile]
 
 
 def test_validator_requirement_expanded(tmp_path):
     """'requirement' param: expands the user-home prefix."""
-    fake_home = tmp_path / 'homedir'
+    fake_home = tmp_path / "homedir"
     fake_home.mkdir()
 
-    requirement = fake_home / 'requirements.txt'
+    requirement = fake_home / "requirements.txt"
     requirement.touch(0o230)
 
     validator = Validator()
 
-    with patch.dict(os.environ, {'HOME': str(fake_home)}):
-        resp = validator.validate_requirement([pathlib.Path('~/requirements.txt')])
+    with patch.dict(os.environ, {"HOME": str(fake_home)}):
+        resp = validator.validate_requirement([pathlib.Path("~/requirements.txt")])
     assert resp == [requirement]
 
 
@@ -305,16 +308,17 @@ def test_validator_requirement_exist():
     validator = Validator()
     expected_msg = "the requirements file was not found: '/not_really_there.txt'"
     with pytest.raises(CommandError, match=expected_msg):
-        validator.validate_requirement([pathlib.Path('/not_really_there.txt')])
+        validator.validate_requirement([pathlib.Path("/not_really_there.txt")])
 
 
 # --- Polite Executor tests
+
 
 def test_politeexec_base(caplog):
     """Basic execution."""
     caplog.set_level(logging.ERROR, logger="charmcraft")
 
-    cmd = ['echo', 'HELO']
+    cmd = ["echo", "HELO"]
     retcode = polite_exec(cmd)
     assert retcode == 0
     assert not caplog.records
@@ -324,7 +328,7 @@ def test_politeexec_stdout_logged(caplog):
     """The standard output is logged in debug."""
     caplog.set_level(logging.DEBUG, logger="charmcraft")
 
-    cmd = ['echo', 'HELO']
+    cmd = ["echo", "HELO"]
     polite_exec(cmd)
     expected = [
         "Running external command ['echo', 'HELO']",
@@ -337,7 +341,7 @@ def test_politeexec_stderr_logged(caplog):
     """The standard error is logged in debug."""
     caplog.set_level(logging.DEBUG, logger="charmcraft")
 
-    cmd = [sys.executable, '-c', "import sys; print('weird, huh?', file=sys.stderr)"]
+    cmd = [sys.executable, "-c", "import sys; print('weird, huh?', file=sys.stderr)"]
     polite_exec(cmd)
     expected = [
         "Running external command " + str(cmd),
@@ -350,7 +354,7 @@ def test_politeexec_failed(caplog):
     """It's logged in error if cmd fails."""
     caplog.set_level(logging.ERROR, logger="charmcraft")
 
-    cmd = [sys.executable, '-c', "exit(3)"]
+    cmd = [sys.executable, "-c", "exit(3)"]
     retcode = polite_exec(cmd)
     assert retcode == 3
     expected_msg = "Executing {} failed with return code 3".format(cmd)
@@ -360,7 +364,7 @@ def test_politeexec_failed(caplog):
 def test_politeexec_crashed(caplog, tmp_path):
     """It's logged in error if cmd fails."""
     caplog.set_level(logging.ERROR, logger="charmcraft")
-    nonexistent = tmp_path / 'whatever'
+    nonexistent = tmp_path / "whatever"
 
     cmd = [str(nonexistent)]
     retcode = polite_exec(cmd)
@@ -378,51 +382,58 @@ def test_build_basic_complete_structure(tmp_path, monkeypatch, config):
     build_dir.mkdir()
 
     # the metadata (save it and restore to later check)
-    metadata_data = {'name': 'name-from-metadata'}
-    metadata_file = tmp_path / 'metadata.yaml'
-    metadata_raw = yaml.dump(metadata_data).encode('ascii')
-    with metadata_file.open('wb') as fh:
+    metadata_data = {"name": "name-from-metadata"}
+    metadata_file = tmp_path / "metadata.yaml"
+    metadata_raw = yaml.dump(metadata_data).encode("ascii")
+    with metadata_file.open("wb") as fh:
         fh.write(metadata_raw)
 
     # a lib dir
-    lib_dir = tmp_path / 'lib'
+    lib_dir = tmp_path / "lib"
     lib_dir.mkdir()
-    ops_lib_dir = lib_dir / 'ops'
+    ops_lib_dir = lib_dir / "ops"
     ops_lib_dir.mkdir()
-    ops_stuff = ops_lib_dir / 'stuff.txt'
-    with ops_stuff.open('wb') as fh:
-        fh.write(b'ops stuff')
+    ops_stuff = ops_lib_dir / "stuff.txt"
+    with ops_stuff.open("wb") as fh:
+        fh.write(b"ops stuff")
 
     # simple source code
-    src_dir = tmp_path / 'src'
+    src_dir = tmp_path / "src"
     src_dir.mkdir()
-    charm_script = src_dir / 'charm.py'
-    with charm_script.open('wb') as fh:
-        fh.write(b'all the magic')
+    charm_script = src_dir / "charm.py"
+    with charm_script.open("wb") as fh:
+        fh.write(b"all the magic")
 
     monkeypatch.chdir(tmp_path)  # so the zip file is left in the temp dir
-    builder = Builder({
-        'from': tmp_path,
-        'entrypoint': charm_script,
-        'requirement': [],
-    }, config)
+    builder = Builder(
+        {
+            "from": tmp_path,
+            "entrypoint": charm_script,
+            "requirement": [],
+        },
+        config,
+    )
     zipname = builder.run()
 
     # check all is properly inside the zip
     # contents!), and all relative to build dir
     zf = zipfile.ZipFile(zipname)
-    assert zf.read('metadata.yaml') == metadata_raw
-    assert zf.read('src/charm.py') == b"all the magic"
-    dispatch = DISPATCH_CONTENT.format(entrypoint_relative_path='src/charm.py').encode('ascii')
-    assert zf.read('dispatch') == dispatch
-    assert zf.read('hooks/install') == dispatch
-    assert zf.read('hooks/start') == dispatch
-    assert zf.read('hooks/upgrade-charm') == dispatch
-    assert zf.read('lib/ops/stuff.txt') == b"ops stuff"
+    assert zf.read("metadata.yaml") == metadata_raw
+    assert zf.read("src/charm.py") == b"all the magic"
+    dispatch = DISPATCH_CONTENT.format(entrypoint_relative_path="src/charm.py").encode(
+        "ascii"
+    )
+    assert zf.read("dispatch") == dispatch
+    assert zf.read("hooks/install") == dispatch
+    assert zf.read("hooks/start") == dispatch
+    assert zf.read("hooks/upgrade-charm") == dispatch
+    assert zf.read("lib/ops/stuff.txt") == b"ops stuff"
 
     # check the manifest is present and with particular values that depend on given info
-    manifest = yaml.safe_load(zf.read('manifest.yaml'))
-    assert manifest['charmcraft-started-at'] == config.project.started_at.isoformat() + "Z"
+    manifest = yaml.safe_load(zf.read("manifest.yaml"))
+    assert (
+        manifest["charmcraft-started-at"] == config.project.started_at.isoformat() + "Z"
+    )
 
 
 def test_build_generics_simple_files(tmp_path, config):
@@ -432,14 +443,17 @@ def test_build_generics_simple_files(tmp_path, config):
 
     metadata = tmp_path / CHARM_METADATA
     metadata.touch()
-    entrypoint = tmp_path / 'crazycharm.py'
+    entrypoint = tmp_path / "crazycharm.py"
     entrypoint.touch()
 
-    builder = Builder({
-        'from': tmp_path,
-        'entrypoint': entrypoint,
-        'requirement': [],
-    }, config)
+    builder = Builder(
+        {
+            "from": tmp_path,
+            "entrypoint": entrypoint,
+            "requirement": [],
+        },
+        config,
+    )
     linked_entrypoint = builder.handle_generic_paths()
 
     # check files are there, are files, and are really hard links (so no
@@ -448,7 +462,7 @@ def test_build_generics_simple_files(tmp_path, config):
     assert built_metadata.is_file()
     assert built_metadata.stat().st_ino == metadata.stat().st_ino
 
-    built_entrypoint = build_dir / 'crazycharm.py'
+    built_entrypoint = build_dir / "crazycharm.py"
     assert built_entrypoint.is_file()
     assert built_entrypoint.stat().st_ino == entrypoint.stat().st_ino
 
@@ -459,20 +473,23 @@ def test_build_generics_simple_dir(tmp_path, config):
     """Check transferred any directory, with proper permissions."""
     build_dir = tmp_path / BUILD_DIRNAME
     build_dir.mkdir()
-    entrypoint = tmp_path / 'crazycharm.py'
+    entrypoint = tmp_path / "crazycharm.py"
     entrypoint.touch()
 
-    somedir = tmp_path / 'somedir'
+    somedir = tmp_path / "somedir"
     somedir.mkdir(mode=0o700)
 
-    builder = Builder({
-        'from': tmp_path,
-        'entrypoint': entrypoint,
-        'requirement': [],
-    }, config)
+    builder = Builder(
+        {
+            "from": tmp_path,
+            "entrypoint": entrypoint,
+            "requirement": [],
+        },
+        config,
+    )
     builder.handle_generic_paths()
 
-    built_dir = build_dir / 'somedir'
+    built_dir = build_dir / "somedir"
     assert built_dir.is_dir()
     assert built_dir.stat().st_mode & 0xFFF == 0o700
 
@@ -484,25 +501,28 @@ def test_build_generics_ignored_file(tmp_path, caplog, config):
     build_dir.mkdir()
 
     # create two files (and the needed entrypoint)
-    file1 = tmp_path / 'file1.txt'
+    file1 = tmp_path / "file1.txt"
     file1.touch()
-    file2 = tmp_path / 'file2.txt'
+    file2 = tmp_path / "file2.txt"
     file2.touch()
-    entrypoint = tmp_path / 'crazycharm.py'
+    entrypoint = tmp_path / "crazycharm.py"
     entrypoint.touch()
 
-    builder = Builder({
-        'from': tmp_path,
-        'entrypoint': entrypoint,
-        'requirement': [],
-    }, config)
+    builder = Builder(
+        {
+            "from": tmp_path,
+            "entrypoint": entrypoint,
+            "requirement": [],
+        },
+        config,
+    )
 
     # set it up to ignore file 2 and make it work
-    builder.ignore_rules.extend_patterns(['file2.*'])
+    builder.ignore_rules.extend_patterns(["file2.*"])
     builder.handle_generic_paths()
 
-    assert (build_dir / 'file1.txt').exists()
-    assert not (build_dir / 'file2.txt').exists()
+    assert (build_dir / "file1.txt").exists()
+    assert not (build_dir / "file2.txt").exists()
 
     expected = "Ignoring file because of rules: 'file2.txt'"
     assert expected in [rec.message for rec in caplog.records]
@@ -515,25 +535,28 @@ def test_build_generics_ignored_dir(tmp_path, caplog, config):
     build_dir.mkdir()
 
     # create two files (and the needed entrypoint)
-    dir1 = tmp_path / 'dir1'
+    dir1 = tmp_path / "dir1"
     dir1.mkdir()
-    dir2 = tmp_path / 'dir2'
+    dir2 = tmp_path / "dir2"
     dir2.mkdir()
-    entrypoint = tmp_path / 'crazycharm.py'
+    entrypoint = tmp_path / "crazycharm.py"
     entrypoint.touch()
 
-    builder = Builder({
-        'from': tmp_path,
-        'entrypoint': entrypoint,
-        'requirement': [],
-    }, config)
+    builder = Builder(
+        {
+            "from": tmp_path,
+            "entrypoint": entrypoint,
+            "requirement": [],
+        },
+        config,
+    )
 
     # set it up to ignore dir 2 and make it work
-    builder.ignore_rules.extend_patterns(['dir2'])
+    builder.ignore_rules.extend_patterns(["dir2"])
     builder.handle_generic_paths()
 
-    assert (build_dir / 'dir1').exists()
-    assert not (build_dir / 'dir2').exists()
+    assert (build_dir / "dir1").exists()
+    assert not (build_dir / "dir2").exists()
 
     expected = "Ignoring directory because of rules: 'dir2'"
     assert expected in [rec.message for rec in caplog.records]
@@ -556,55 +579,60 @@ def _test_build_generics_tree(tmp_path, caplog, config, *, expect_hardlinks):
     #    ├─ dir4  (ignored!)
     #    │   └─ file4.txt
     #    └─ dir5
-    entrypoint = tmp_path / 'crazycharm.py'
+    entrypoint = tmp_path / "crazycharm.py"
     entrypoint.touch()
-    file1 = tmp_path / 'file1.txt'
+    file1 = tmp_path / "file1.txt"
     file1.touch()
-    dir1 = tmp_path / 'dir1'
+    dir1 = tmp_path / "dir1"
     dir1.mkdir()
-    dir3 = dir1 / 'dir3'
+    dir3 = dir1 / "dir3"
     dir3.mkdir()
-    dir2 = tmp_path / 'dir2'
+    dir2 = tmp_path / "dir2"
     dir2.mkdir()
-    file2 = dir2 / 'file2.txt'
+    file2 = dir2 / "file2.txt"
     file2.touch()
-    file3 = dir2 / 'file3.txt'
+    file3 = dir2 / "file3.txt"
     file3.touch()
-    dir4 = dir2 / 'dir4'
+    dir4 = dir2 / "dir4"
     dir4.mkdir()
-    file4 = dir4 / 'file4.txt'
+    file4 = dir4 / "file4.txt"
     file4.touch()
-    dir5 = dir2 / 'dir5'
+    dir5 = dir2 / "dir5"
     dir5.mkdir()
 
-    builder = Builder({
-        'from': tmp_path,
-        'entrypoint': entrypoint,
-        'requirement': [],
-    }, config)
+    builder = Builder(
+        {
+            "from": tmp_path,
+            "entrypoint": entrypoint,
+            "requirement": [],
+        },
+        config,
+    )
 
     # set it up to ignore some stuff and make it work
-    builder.ignore_rules.extend_patterns([
-        'dir1/dir3',
-        'dir2/file3.txt',
-        'dir2/dir4',
-    ])
+    builder.ignore_rules.extend_patterns(
+        [
+            "dir1/dir3",
+            "dir2/file3.txt",
+            "dir2/dir4",
+        ]
+    )
     builder.handle_generic_paths()
 
-    assert (build_dir / 'crazycharm.py').exists()
-    assert (build_dir / 'file1.txt').exists()
-    assert (build_dir / 'dir1').exists()
-    assert not (build_dir / 'dir1' / 'dir3').exists()
-    assert (build_dir / 'dir2').exists()
-    assert (build_dir / 'dir2' / 'file2.txt').exists()
-    assert not (build_dir / 'dir2' / 'file3.txt').exists()
-    assert not (build_dir / 'dir2' / 'dir4').exists()
-    assert (build_dir / 'dir2' / 'dir5').exists()
+    assert (build_dir / "crazycharm.py").exists()
+    assert (build_dir / "file1.txt").exists()
+    assert (build_dir / "dir1").exists()
+    assert not (build_dir / "dir1" / "dir3").exists()
+    assert (build_dir / "dir2").exists()
+    assert (build_dir / "dir2" / "file2.txt").exists()
+    assert not (build_dir / "dir2" / "file3.txt").exists()
+    assert not (build_dir / "dir2" / "dir4").exists()
+    assert (build_dir / "dir2" / "dir5").exists()
 
     for (p1, p2) in [
-        (build_dir / 'crazycharm.py', entrypoint),
-        (build_dir / 'file1.txt', file1),
-        (build_dir / 'dir2' / 'file2.txt', file2),
+        (build_dir / "crazycharm.py", entrypoint),
+        (build_dir / "file1.txt", file1),
+        (build_dir / "dir2" / "file2.txt", file2),
     ]:
         if expect_hardlinks:
             # they're hard links
@@ -627,14 +655,14 @@ def test_build_generics_tree(tmp_path, caplog, config):
 
 def test_build_generics_tree_vagrant(tmp_path, caplog, config):
     """Manages ok a deep tree, including internal ignores, when hardlinks aren't allowed."""
-    with patch('os.link') as mock_link:
+    with patch("os.link") as mock_link:
         mock_link.side_effect = PermissionError("No you don't.")
         _test_build_generics_tree(tmp_path, caplog, config, expect_hardlinks=False)
 
 
 def test_build_generics_tree_xdev(tmp_path, caplog, config):
     """Manages ok a deep tree, including internal ignores, when hardlinks can't be done."""
-    with patch('os.link') as mock_link:
+    with patch("os.link") as mock_link:
         mock_link.side_effect = OSError(errno.EXDEV, os.strerror(errno.EXDEV))
         _test_build_generics_tree(tmp_path, caplog, config, expect_hardlinks=False)
 
@@ -644,23 +672,26 @@ def test_build_generics_symlink_file(tmp_path, config):
     build_dir = tmp_path / BUILD_DIRNAME
     build_dir.mkdir()
 
-    entrypoint = tmp_path / 'crazycharm.py'
+    entrypoint = tmp_path / "crazycharm.py"
     entrypoint.touch()
-    the_symlink = tmp_path / 'somehook.py'
+    the_symlink = tmp_path / "somehook.py"
     the_symlink.symlink_to(entrypoint)
 
-    builder = Builder({
-        'from': tmp_path,
-        'entrypoint': entrypoint,
-        'requirement': [],
-    }, config)
+    builder = Builder(
+        {
+            "from": tmp_path,
+            "entrypoint": entrypoint,
+            "requirement": [],
+        },
+        config,
+    )
     builder.handle_generic_paths()
 
-    built_symlink = build_dir / 'somehook.py'
+    built_symlink = build_dir / "somehook.py"
     assert built_symlink.is_symlink()
-    assert built_symlink.resolve() == build_dir / 'crazycharm.py'
+    assert built_symlink.resolve() == build_dir / "crazycharm.py"
     real_link = os.readlink(str(built_symlink))
-    assert real_link == 'crazycharm.py'
+    assert real_link == "crazycharm.py"
 
 
 def test_build_generics_symlink_dir(tmp_path, config):
@@ -668,87 +699,96 @@ def test_build_generics_symlink_dir(tmp_path, config):
     build_dir = tmp_path / BUILD_DIRNAME
     build_dir.mkdir()
 
-    entrypoint = tmp_path / 'crazycharm.py'
+    entrypoint = tmp_path / "crazycharm.py"
     entrypoint.touch()
-    somedir = tmp_path / 'somedir'
+    somedir = tmp_path / "somedir"
     somedir.mkdir()
-    somefile = somedir / 'sanity check'
+    somefile = somedir / "sanity check"
     somefile.touch()
-    the_symlink = tmp_path / 'thelink'
+    the_symlink = tmp_path / "thelink"
     the_symlink.symlink_to(somedir)
 
-    builder = Builder({
-        'from': tmp_path,
-        'entrypoint': entrypoint,
-        'requirement': [],
-    }, config)
+    builder = Builder(
+        {
+            "from": tmp_path,
+            "entrypoint": entrypoint,
+            "requirement": [],
+        },
+        config,
+    )
     builder.handle_generic_paths()
 
-    built_symlink = build_dir / 'thelink'
+    built_symlink = build_dir / "thelink"
     assert built_symlink.is_symlink()
-    assert built_symlink.resolve() == build_dir / 'somedir'
+    assert built_symlink.resolve() == build_dir / "somedir"
     real_link = os.readlink(str(built_symlink))
-    assert real_link == 'somedir'
+    assert real_link == "somedir"
 
     # as a sanity check, the file inside the linked dir should exist
-    assert (build_dir / 'thelink' / 'sanity check').exists()
+    assert (build_dir / "thelink" / "sanity check").exists()
 
 
 def test_build_generics_symlink_deep(tmp_path, config):
     """Correctly re-links a symlink across deep dirs."""
     build_dir = tmp_path / BUILD_DIRNAME
     build_dir.mkdir()
-    entrypoint = tmp_path / 'crazycharm.py'
+    entrypoint = tmp_path / "crazycharm.py"
     entrypoint.touch()
 
-    dir1 = tmp_path / 'dir1'
+    dir1 = tmp_path / "dir1"
     dir1.mkdir()
-    dir2 = tmp_path / 'dir2'
+    dir2 = tmp_path / "dir2"
     dir2.mkdir()
-    original_target = dir1 / 'file.real'
+    original_target = dir1 / "file.real"
     original_target.touch()
-    the_symlink = dir2 / 'file.link'
+    the_symlink = dir2 / "file.link"
     the_symlink.symlink_to(original_target)
 
-    builder = Builder({
-        'from': tmp_path,
-        'entrypoint': entrypoint,
-        'requirement': [],
-    }, config)
+    builder = Builder(
+        {
+            "from": tmp_path,
+            "entrypoint": entrypoint,
+            "requirement": [],
+        },
+        config,
+    )
     builder.handle_generic_paths()
 
-    built_symlink = build_dir / 'dir2' / 'file.link'
+    built_symlink = build_dir / "dir2" / "file.link"
     assert built_symlink.is_symlink()
-    assert built_symlink.resolve() == build_dir / 'dir1' / 'file.real'
+    assert built_symlink.resolve() == build_dir / "dir1" / "file.real"
     real_link = os.readlink(str(built_symlink))
-    assert real_link == '../dir1/file.real'
+    assert real_link == "../dir1/file.real"
 
 
 def test_build_generics_symlink_file_outside(tmp_path, caplog, config):
     """Ignores (with warning) a symlink pointing a file outside projects dir."""
     caplog.set_level(logging.WARNING)
 
-    project_dir = tmp_path / 'test-project'
+    project_dir = tmp_path / "test-project"
     project_dir.mkdir()
 
     build_dir = project_dir / BUILD_DIRNAME
     build_dir.mkdir()
-    entrypoint = project_dir / 'crazycharm.py'
+    entrypoint = project_dir / "crazycharm.py"
     entrypoint.touch()
 
-    outside_project = tmp_path / 'dangerous.txt'
+    outside_project = tmp_path / "dangerous.txt"
     outside_project.touch()
-    the_symlink = project_dir / 'external-file'
+    the_symlink = project_dir / "external-file"
     the_symlink.symlink_to(outside_project)
 
-    builder = Builder({
-        'from': project_dir,
-        'entrypoint': entrypoint,
-        'requirement': [],
-    }, config)
+    builder = Builder(
+        {
+            "from": project_dir,
+            "entrypoint": entrypoint,
+            "requirement": [],
+        },
+        config,
+    )
     builder.handle_generic_paths()
 
-    assert not (build_dir / 'external-file').exists()
+    assert not (build_dir / "external-file").exists()
     expected = "Ignoring symlink because targets outside the project: 'external-file'"
     assert expected in [rec.message for rec in caplog.records]
 
@@ -757,27 +797,30 @@ def test_build_generics_symlink_directory_outside(tmp_path, caplog, config):
     """Ignores (with warning) a symlink pointing a dir outside projects dir."""
     caplog.set_level(logging.WARNING)
 
-    project_dir = tmp_path / 'test-project'
+    project_dir = tmp_path / "test-project"
     project_dir.mkdir()
 
     build_dir = project_dir / BUILD_DIRNAME
     build_dir.mkdir()
-    entrypoint = project_dir / 'crazycharm.py'
+    entrypoint = project_dir / "crazycharm.py"
     entrypoint.touch()
 
-    outside_project = tmp_path / 'dangerous'
+    outside_project = tmp_path / "dangerous"
     outside_project.mkdir()
-    the_symlink = project_dir / 'external-dir'
+    the_symlink = project_dir / "external-dir"
     the_symlink.symlink_to(outside_project)
 
-    builder = Builder({
-        'from': project_dir,
-        'entrypoint': entrypoint,
-        'requirement': [],
-    }, config)
+    builder = Builder(
+        {
+            "from": project_dir,
+            "entrypoint": entrypoint,
+            "requirement": [],
+        },
+        config,
+    )
     builder.handle_generic_paths()
 
-    assert not (build_dir / 'external-dir').exists()
+    assert not (build_dir / "external-dir").exists()
     expected = "Ignoring symlink because targets outside the project: 'external-dir'"
     assert expected in [rec.message for rec in caplog.records]
 
@@ -792,21 +835,24 @@ def test_build_generics_different_filetype(tmp_path, caplog, monkeypatch, config
 
     build_dir = pathlib.Path(BUILD_DIRNAME)
     build_dir.mkdir()
-    entrypoint = pathlib.Path('crazycharm.py')
+    entrypoint = pathlib.Path("crazycharm.py")
     entrypoint.touch()
 
     # create a socket
     sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    sock.bind('test-socket')
+    sock.bind("test-socket")
 
-    builder = Builder({
-        'from': tmp_path,
-        'entrypoint': tmp_path / entrypoint,
-        'requirement': [],
-    }, config)
+    builder = Builder(
+        {
+            "from": tmp_path,
+            "entrypoint": tmp_path / entrypoint,
+            "requirement": [],
+        },
+        config,
+    )
     builder.handle_generic_paths()
 
-    assert not (build_dir / 'test-socket').exists()
+    assert not (build_dir / "test-socket").exists()
     expected = "Ignoring file because of type: 'test-socket'"
     assert expected in [rec.message for rec in caplog.records]
 
@@ -816,19 +862,24 @@ def test_build_dispatcher_modern_dispatch_created(tmp_path, config):
     build_dir = tmp_path / BUILD_DIRNAME
     build_dir.mkdir()
 
-    linked_entrypoint = build_dir / 'somestuff.py'
+    linked_entrypoint = build_dir / "somestuff.py"
 
-    builder = Builder({
-        'from': tmp_path,
-        'entrypoint': 'whatever',
-        'requirement': [],
-    }, config)
+    builder = Builder(
+        {
+            "from": tmp_path,
+            "entrypoint": "whatever",
+            "requirement": [],
+        },
+        config,
+    )
     builder.handle_dispatcher(linked_entrypoint)
 
     included_dispatcher = build_dir / DISPATCH_FILENAME
-    with included_dispatcher.open('rt', encoding='utf8') as fh:
+    with included_dispatcher.open("rt", encoding="utf8") as fh:
         dispatcher_code = fh.read()
-    assert dispatcher_code == DISPATCH_CONTENT.format(entrypoint_relative_path='somestuff.py')
+    assert dispatcher_code == DISPATCH_CONTENT.format(
+        entrypoint_relative_path="somestuff.py"
+    )
 
 
 def test_build_dispatcher_modern_dispatch_respected(tmp_path, config):
@@ -837,18 +888,21 @@ def test_build_dispatcher_modern_dispatch_respected(tmp_path, config):
     build_dir.mkdir()
 
     already_present_dispatch = build_dir / DISPATCH_FILENAME
-    with already_present_dispatch.open('wb') as fh:
-        fh.write(b'abc')
+    with already_present_dispatch.open("wb") as fh:
+        fh.write(b"abc")
 
-    builder = Builder({
-        'from': tmp_path,
-        'entrypoint': 'whatever',
-        'requirement': [],
-    }, config)
-    builder.handle_dispatcher('whatever')
+    builder = Builder(
+        {
+            "from": tmp_path,
+            "entrypoint": "whatever",
+            "requirement": [],
+        },
+        config,
+    )
+    builder.handle_dispatcher("whatever")
 
-    with already_present_dispatch.open('rb') as fh:
-        assert fh.read() == b'abc'
+    with already_present_dispatch.open("rb") as fh:
+        assert fh.read() == b"abc"
 
 
 def test_build_dispatcher_classic_hooks_mandatory_created(tmp_path, config):
@@ -856,22 +910,25 @@ def test_build_dispatcher_classic_hooks_mandatory_created(tmp_path, config):
     build_dir = tmp_path / BUILD_DIRNAME
     build_dir.mkdir()
 
-    linked_entrypoint = build_dir / 'somestuff.py'
+    linked_entrypoint = build_dir / "somestuff.py"
     included_dispatcher = build_dir / DISPATCH_FILENAME
 
-    builder = Builder({
-        'from': tmp_path,
-        'entrypoint': 'whatever',
-        'requirement': [],
-    }, config)
-    with patch('charmcraft.commands.build.MANDATORY_HOOK_NAMES', {'testhook'}):
+    builder = Builder(
+        {
+            "from": tmp_path,
+            "entrypoint": "whatever",
+            "requirement": [],
+        },
+        config,
+    )
+    with patch("charmcraft.commands.build.MANDATORY_HOOK_NAMES", {"testhook"}):
         builder.handle_dispatcher(linked_entrypoint)
 
-    test_hook = build_dir / 'hooks' / 'testhook'
+    test_hook = build_dir / "hooks" / "testhook"
     assert test_hook.is_symlink()
     assert test_hook.resolve() == included_dispatcher
     real_link = os.readlink(str(test_hook))
-    assert real_link == os.path.join('..', DISPATCH_FILENAME)
+    assert real_link == os.path.join("..", DISPATCH_FILENAME)
 
 
 def test_build_dispatcher_classic_hooks_mandatory_respected(tmp_path, config):
@@ -879,27 +936,32 @@ def test_build_dispatcher_classic_hooks_mandatory_respected(tmp_path, config):
     build_dir = tmp_path / BUILD_DIRNAME
     build_dir.mkdir()
 
-    built_hooks_dir = build_dir / 'hooks'
+    built_hooks_dir = build_dir / "hooks"
     built_hooks_dir.mkdir()
-    test_hook = built_hooks_dir / 'testhook'
-    with test_hook.open('wb') as fh:
-        fh.write(b'abc')
+    test_hook = built_hooks_dir / "testhook"
+    with test_hook.open("wb") as fh:
+        fh.write(b"abc")
 
-    linked_entrypoint = build_dir / 'somestuff.py'
+    linked_entrypoint = build_dir / "somestuff.py"
 
-    builder = Builder({
-        'from': tmp_path,
-        'entrypoint': 'whatever',
-        'requirement': [],
-    }, config)
-    with patch('charmcraft.commands.build.MANDATORY_HOOK_NAMES', {'testhook'}):
+    builder = Builder(
+        {
+            "from": tmp_path,
+            "entrypoint": "whatever",
+            "requirement": [],
+        },
+        config,
+    )
+    with patch("charmcraft.commands.build.MANDATORY_HOOK_NAMES", {"testhook"}):
         builder.handle_dispatcher(linked_entrypoint)
 
-    with test_hook.open('rb') as fh:
-        assert fh.read() == b'abc'
+    with test_hook.open("rb") as fh:
+        assert fh.read() == b"abc"
 
 
-def test_build_dispatcher_classic_hooks_linking_charm_replaced(tmp_path, caplog, config):
+def test_build_dispatcher_classic_hooks_linking_charm_replaced(
+    tmp_path, caplog, config
+):
     """Hooks that are just a symlink to the entrypoint are replaced."""
     caplog.set_level(logging.DEBUG, logger="charmcraft")
 
@@ -907,25 +969,28 @@ def test_build_dispatcher_classic_hooks_linking_charm_replaced(tmp_path, caplog,
     build_dir.mkdir()
 
     # simple source code
-    src_dir = build_dir / 'src'
+    src_dir = build_dir / "src"
     src_dir.mkdir()
-    built_charm_script = src_dir / 'charm.py'
-    with built_charm_script.open('wb') as fh:
-        fh.write(b'all the magic')
+    built_charm_script = src_dir / "charm.py"
+    with built_charm_script.open("wb") as fh:
+        fh.write(b"all the magic")
 
     # a test hook, just a symlink to the charm
-    built_hooks_dir = build_dir / 'hooks'
+    built_hooks_dir = build_dir / "hooks"
     built_hooks_dir.mkdir()
-    test_hook = built_hooks_dir / 'somehook'
+    test_hook = built_hooks_dir / "somehook"
     test_hook.symlink_to(built_charm_script)
 
     included_dispatcher = build_dir / DISPATCH_FILENAME
 
-    builder = Builder({
-        'from': tmp_path,
-        'entrypoint': 'whatever',
-        'requirement': [],
-    }, config)
+    builder = Builder(
+        {
+            "from": tmp_path,
+            "entrypoint": "whatever",
+            "requirement": [],
+        },
+        config,
+    )
     builder.handle_dispatcher(built_charm_script)
 
     # the test hook is still there and a symlink, but now pointing to the dispatcher
@@ -940,20 +1005,25 @@ def test_build_dependencies_virtualenv_simple(tmp_path, config):
     build_dir = tmp_path / BUILD_DIRNAME
     build_dir.mkdir()
 
-    builder = Builder({
-        'from': tmp_path,
-        'entrypoint': 'whatever',
-        'requirement': ['reqs.txt'],
-    }, config)
+    builder = Builder(
+        {
+            "from": tmp_path,
+            "entrypoint": "whatever",
+            "requirement": ["reqs.txt"],
+        },
+        config,
+    )
 
-    with patch('charmcraft.commands.build.polite_exec') as mock:
+    with patch("charmcraft.commands.build.polite_exec") as mock:
         mock.return_value = 0
         builder.handle_dependencies()
 
     envpath = build_dir / VENV_DIRNAME
     assert mock.mock_calls == [
-        call(['pip3', 'list']),
-        call(['pip3', 'install', '--target={}'.format(envpath), '--requirement=reqs.txt']),
+        call(["pip3", "list"]),
+        call(
+            ["pip3", "install", "--target={}".format(envpath), "--requirement=reqs.txt"]
+        ),
     ]
 
 
@@ -962,22 +1032,33 @@ def test_build_dependencies_needs_system(tmp_path, config):
     build_dir = tmp_path / BUILD_DIRNAME
     build_dir.mkdir()
 
-    builder = Builder({
-        'from': tmp_path,
-        'entrypoint': 'whatever',
-        'requirement': ['reqs'],
-    }, config)
+    builder = Builder(
+        {
+            "from": tmp_path,
+            "entrypoint": "whatever",
+            "requirement": ["reqs"],
+        },
+        config,
+    )
 
-    with patch('charmcraft.commands.build._pip_needs_system') as is_bionic:
+    with patch("charmcraft.commands.build._pip_needs_system") as is_bionic:
         is_bionic.return_value = True
-        with patch('charmcraft.commands.build.polite_exec') as mock:
+        with patch("charmcraft.commands.build.polite_exec") as mock:
             mock.return_value = 0
             builder.handle_dependencies()
 
     envpath = build_dir / VENV_DIRNAME
     assert mock.mock_calls == [
-        call(['pip3', 'list']),
-        call(['pip3', 'install', '--target={}'.format(envpath), '--system', '--requirement=reqs']),
+        call(["pip3", "list"]),
+        call(
+            [
+                "pip3",
+                "install",
+                "--target={}".format(envpath),
+                "--system",
+                "--requirement=reqs",
+            ]
+        ),
     ]
 
 
@@ -986,21 +1067,31 @@ def test_build_dependencies_virtualenv_multiple(tmp_path, config):
     build_dir = tmp_path / BUILD_DIRNAME
     build_dir.mkdir()
 
-    builder = Builder({
-        'from': tmp_path,
-        'entrypoint': 'whatever',
-        'requirement': ['reqs1.txt', 'reqs2.txt'],
-    }, config)
+    builder = Builder(
+        {
+            "from": tmp_path,
+            "entrypoint": "whatever",
+            "requirement": ["reqs1.txt", "reqs2.txt"],
+        },
+        config,
+    )
 
-    with patch('charmcraft.commands.build.polite_exec') as mock:
+    with patch("charmcraft.commands.build.polite_exec") as mock:
         mock.return_value = 0
         builder.handle_dependencies()
 
     envpath = build_dir / VENV_DIRNAME
     assert mock.mock_calls == [
-        call(['pip3', 'list']),
-        call(['pip3', 'install', '--target={}'.format(envpath),
-              '--requirement=reqs1.txt', '--requirement=reqs2.txt']),
+        call(["pip3", "list"]),
+        call(
+            [
+                "pip3",
+                "install",
+                "--target={}".format(envpath),
+                "--requirement=reqs1.txt",
+                "--requirement=reqs2.txt",
+            ]
+        ),
     ]
 
 
@@ -1009,13 +1100,16 @@ def test_build_dependencies_virtualenv_none(tmp_path, config):
     build_dir = tmp_path / BUILD_DIRNAME
     build_dir.mkdir()
 
-    builder = Builder({
-        'from': tmp_path,
-        'entrypoint': 'whatever',
-        'requirement': [],
-    }, config)
+    builder = Builder(
+        {
+            "from": tmp_path,
+            "entrypoint": "whatever",
+            "requirement": [],
+        },
+        config,
+    )
 
-    with patch('charmcraft.commands.build.polite_exec') as mock:
+    with patch("charmcraft.commands.build.polite_exec") as mock:
         builder.handle_dependencies()
 
     mock.assert_not_called()
@@ -1026,13 +1120,16 @@ def test_build_dependencies_virtualenv_error_basicpip(tmp_path, config):
     build_dir = tmp_path / BUILD_DIRNAME
     build_dir.mkdir()
 
-    builder = Builder({
-        'from': tmp_path,
-        'entrypoint': 'whatever',
-        'requirement': ['something'],
-    }, config)
+    builder = Builder(
+        {
+            "from": tmp_path,
+            "entrypoint": "whatever",
+            "requirement": ["something"],
+        },
+        config,
+    )
 
-    with patch('charmcraft.commands.build.polite_exec') as mock:
+    with patch("charmcraft.commands.build.polite_exec") as mock:
         mock.return_value = -7
         with pytest.raises(CommandError, match="problems using pip"):
             builder.handle_dependencies()
@@ -1043,13 +1140,16 @@ def test_build_dependencies_virtualenv_error_installing(tmp_path, config):
     build_dir = tmp_path / BUILD_DIRNAME
     build_dir.mkdir()
 
-    builder = Builder({
-        'from': tmp_path,
-        'entrypoint': 'whatever',
-        'requirement': ['something'],
-    }, config)
+    builder = Builder(
+        {
+            "from": tmp_path,
+            "entrypoint": "whatever",
+            "requirement": ["something"],
+        },
+        config,
+    )
 
-    with patch('charmcraft.commands.build.polite_exec') as mock:
+    with patch("charmcraft.commands.build.polite_exec") as mock:
         mock.side_effect = [0, -7]
         with pytest.raises(CommandError, match="problems installing dependencies"):
             builder.handle_dependencies()
@@ -1058,67 +1158,72 @@ def test_build_dependencies_virtualenv_error_installing(tmp_path, config):
 def test_build_package_tree_structure(tmp_path, monkeypatch, config):
     """The zip file is properly built internally."""
     # the metadata
-    metadata_data = {'name': 'name-from-metadata'}
-    metadata_file = tmp_path / 'metadata.yaml'
-    with metadata_file.open('wt', encoding='ascii') as fh:
+    metadata_data = {"name": "name-from-metadata"}
+    metadata_file = tmp_path / "metadata.yaml"
+    with metadata_file.open("wt", encoding="ascii") as fh:
         yaml.dump(metadata_data, fh)
 
     # create some dirs and files! a couple of files outside, and the dir we'll zip...
-    file_outside_1 = tmp_path / 'file_outside_1'
-    with file_outside_1.open('wb') as fh:
-        fh.write(b'content_out_1')
-    file_outside_2 = tmp_path / 'file_outside_2'
-    with file_outside_2.open('wb') as fh:
-        fh.write(b'content_out_2')
+    file_outside_1 = tmp_path / "file_outside_1"
+    with file_outside_1.open("wb") as fh:
+        fh.write(b"content_out_1")
+    file_outside_2 = tmp_path / "file_outside_2"
+    with file_outside_2.open("wb") as fh:
+        fh.write(b"content_out_2")
     to_be_zipped_dir = tmp_path / BUILD_DIRNAME
     to_be_zipped_dir.mkdir()
 
     # ...also outside a dir with a file...
-    dir_outside = tmp_path / 'extdir'
+    dir_outside = tmp_path / "extdir"
     dir_outside.mkdir()
-    file_ext = dir_outside / 'file_ext'
-    with file_ext.open('wb') as fh:
-        fh.write(b'external file')
+    file_ext = dir_outside / "file_ext"
+    with file_ext.open("wb") as fh:
+        fh.write(b"external file")
 
     # ...then another file inside, and another dir...
-    file_inside = to_be_zipped_dir / 'file_inside'
-    with file_inside.open('wb') as fh:
-        fh.write(b'content_in')
-    dir_inside = to_be_zipped_dir / 'somedir'
+    file_inside = to_be_zipped_dir / "file_inside"
+    with file_inside.open("wb") as fh:
+        fh.write(b"content_in")
+    dir_inside = to_be_zipped_dir / "somedir"
     dir_inside.mkdir()
 
     # ...also inside, a link to the external dir...
-    dir_linked_inside = to_be_zipped_dir / 'linkeddir'
+    dir_linked_inside = to_be_zipped_dir / "linkeddir"
     dir_linked_inside.symlink_to(dir_outside)
 
     # ...and finally another real file, and two symlinks
-    file_deep_1 = dir_inside / 'file_deep_1'
-    with file_deep_1.open('wb') as fh:
-        fh.write(b'content_deep')
-    file_deep_2 = dir_inside / 'file_deep_2'
+    file_deep_1 = dir_inside / "file_deep_1"
+    with file_deep_1.open("wb") as fh:
+        fh.write(b"content_deep")
+    file_deep_2 = dir_inside / "file_deep_2"
     file_deep_2.symlink_to(file_inside)
-    file_deep_3 = dir_inside / 'file_deep_3'
+    file_deep_3 = dir_inside / "file_deep_3"
     file_deep_3.symlink_to(file_outside_1)
 
     # zip it
     monkeypatch.chdir(tmp_path)  # so the zip file is left in the temp dir
-    builder = Builder({
-        'from': tmp_path,
-        'entrypoint': 'whatever',
-        'requirement': [],
-    }, config)
+    builder = Builder(
+        {
+            "from": tmp_path,
+            "entrypoint": "whatever",
+            "requirement": [],
+        },
+        config,
+    )
     zipname = builder.handle_package()
 
     # check the stuff outside is not in the zip, the stuff inside is zipped (with
     # contents!), and all relative to build dir
     zf = zipfile.ZipFile(zipname)
-    assert 'file_outside_1' not in [x.filename for x in zf.infolist()]
-    assert 'file_outside_2' not in [x.filename for x in zf.infolist()]
-    assert zf.read('file_inside') == b"content_in"
-    assert zf.read('somedir/file_deep_1') == b"content_deep"  # own
-    assert zf.read('somedir/file_deep_2') == b"content_in"  # from file inside
-    assert zf.read('somedir/file_deep_3') == b"content_out_1"  # from file outside 1
-    assert zf.read('linkeddir/file_ext') == b"external file"  # from file in the outside linked dir
+    assert "file_outside_1" not in [x.filename for x in zf.infolist()]
+    assert "file_outside_2" not in [x.filename for x in zf.infolist()]
+    assert zf.read("file_inside") == b"content_in"
+    assert zf.read("somedir/file_deep_1") == b"content_deep"  # own
+    assert zf.read("somedir/file_deep_2") == b"content_in"  # from file inside
+    assert zf.read("somedir/file_deep_3") == b"content_out_1"  # from file outside 1
+    assert (
+        zf.read("linkeddir/file_ext") == b"external file"
+    )  # from file in the outside linked dir
 
 
 def test_build_package_name(tmp_path, monkeypatch, config):
@@ -1127,18 +1232,21 @@ def test_build_package_name(tmp_path, monkeypatch, config):
     to_be_zipped_dir.mkdir()
 
     # the metadata
-    metadata_data = {'name': 'name-from-metadata'}
-    metadata_file = tmp_path / 'metadata.yaml'
-    with metadata_file.open('wt', encoding='ascii') as fh:
+    metadata_data = {"name": "name-from-metadata"}
+    metadata_file = tmp_path / "metadata.yaml"
+    with metadata_file.open("wt", encoding="ascii") as fh:
         yaml.dump(metadata_data, fh)
 
     # zip it
     monkeypatch.chdir(tmp_path)  # so the zip file is left in the temp dir
-    builder = Builder({
-        'from': tmp_path,
-        'entrypoint': 'whatever',
-        'requirement': [],
-    }, config)
+    builder = Builder(
+        {
+            "from": tmp_path,
+            "entrypoint": "whatever",
+            "requirement": [],
+        },
+        config,
+    )
     zipname = builder.handle_package()
 
     assert zipname == "name-from-metadata.charm"
@@ -1149,42 +1257,46 @@ def test_builder_without_jujuignore(tmp_path, config):
     build_dir = tmp_path / BUILD_DIRNAME
     build_dir.mkdir()
 
-    builder = Builder({
-        'from': tmp_path,
-        'entrypoint': 'whatever',
-        'requirement': [],
-    }, config)
+    builder = Builder(
+        {
+            "from": tmp_path,
+            "entrypoint": "whatever",
+            "requirement": [],
+        },
+        config,
+    )
     ignore = builder._load_juju_ignore()
-    assert ignore.match('/.git', is_dir=True)
-    assert ignore.match('/build', is_dir=True)
-    assert not ignore.match('myfile.py', is_dir=False)
+    assert ignore.match("/.git", is_dir=True)
+    assert ignore.match("/build", is_dir=True)
+    assert not ignore.match("myfile.py", is_dir=False)
 
 
 def test_builder_with_jujuignore(tmp_path, config):
     """With a .jujuignore we will include additional ignores."""
     build_dir = tmp_path / BUILD_DIRNAME
     build_dir.mkdir()
-    with (tmp_path / '.jujuignore').open('w', encoding='utf-8') as ignores:
-        ignores.write(
-            '*.py\n'
-            '/h\xef.txt\n'
-        )
+    with (tmp_path / ".jujuignore").open("w", encoding="utf-8") as ignores:
+        ignores.write("*.py\n" "/h\xef.txt\n")
 
-    builder = Builder({
-        'from': tmp_path,
-        'entrypoint': 'whatever',
-        'requirement': [],
-    }, config)
+    builder = Builder(
+        {
+            "from": tmp_path,
+            "entrypoint": "whatever",
+            "requirement": [],
+        },
+        config,
+    )
     ignore = builder._load_juju_ignore()
-    assert ignore.match('/.git', is_dir=True)
-    assert ignore.match('/build', is_dir=True)
-    assert ignore.match('myfile.py', is_dir=False)
-    assert not ignore.match('hi.txt', is_dir=False)
-    assert ignore.match('h\xef.txt', is_dir=False)
-    assert not ignore.match('myfile.c', is_dir=False)
+    assert ignore.match("/.git", is_dir=True)
+    assert ignore.match("/build", is_dir=True)
+    assert ignore.match("myfile.py", is_dir=False)
+    assert not ignore.match("hi.txt", is_dir=False)
+    assert ignore.match("h\xef.txt", is_dir=False)
+    assert not ignore.match("myfile.c", is_dir=False)
 
 
 # --- tests for relativise helper
+
 
 def test_relativise_sameparent():
     """Two files in the same dir."""

--- a/tests/commands/test_init.py
+++ b/tests/commands/test_init.py
@@ -27,18 +27,18 @@ from tests.test_infra import pep8_test, get_python_filepaths, pep257_test
 
 
 def test_init_pep257(tmp_path, config):
-    cmd = InitCommand('group', config)
-    cmd.run(Namespace(name='my-charm', author='J Doe', series='k8s', force=False))
+    cmd = InitCommand("group", config)
+    cmd.run(Namespace(name="my-charm", author="J Doe", series="k8s", force=False))
     paths = get_python_filepaths(roots=[str(tmp_path / "src")], python_paths=[])
     pep257_test(paths)
 
 
 def test_init_pep8(tmp_path, config, *, author="J Doe"):
-    cmd = InitCommand('group', config)
-    cmd.run(Namespace(name='my-charm', author=author, series='k8s', force=False))
+    cmd = InitCommand("group", config)
+    cmd.run(Namespace(name="my-charm", author=author, series="k8s", force=False))
     paths = get_python_filepaths(
-        roots=[str(tmp_path / "src"), str(tmp_path / "tests")],
-        python_paths=[])
+        roots=[str(tmp_path / "src"), str(tmp_path / "tests")], python_paths=[]
+    )
     pep8_test(paths)
 
 
@@ -47,8 +47,10 @@ def test_init_non_ascii_author(tmp_path, config):
 
 
 def test_all_the_files(tmp_path, config):
-    cmd = InitCommand('group', config)
-    cmd.run(Namespace(name='my-charm', author="ಅಪರಿಚಿತ ವ್ಯಕ್ತಿ", series='k8s', force=False))
+    cmd = InitCommand("group", config)
+    cmd.run(
+        Namespace(name="my-charm", author="ಅಪರಿಚಿತ ವ್ಯಕ್ತಿ", series="k8s", force=False)
+    )
     assert sorted(str(p.relative_to(tmp_path)) for p in tmp_path.glob("**/*")) == [
         ".flake8",
         ".gitignore",
@@ -70,29 +72,31 @@ def test_all_the_files(tmp_path, config):
 
 
 def test_force(tmp_path, config):
-    cmd = InitCommand('group', config)
-    tmp_file = tmp_path / 'README.md'
-    with tmp_file.open('w') as f:
-        f.write('This is a nonsense readme')
-    cmd.run(Namespace(name='my-charm', author="ಅಪರಿಚಿತ ವ್ಯಕ್ತಿ", series='k8s', force=True))
+    cmd = InitCommand("group", config)
+    tmp_file = tmp_path / "README.md"
+    with tmp_file.open("w") as f:
+        f.write("This is a nonsense readme")
+    cmd.run(
+        Namespace(name="my-charm", author="ಅಪರಿಚಿತ ವ್ಯಕ್ತಿ", series="k8s", force=True)
+    )
 
     # Check that init ran
-    assert (tmp_path / 'LICENSE').exists()
+    assert (tmp_path / "LICENSE").exists()
 
     # Check that init did not overwrite files
-    with tmp_file.open('r') as f:
-        assert f.read() == 'This is a nonsense readme'
+    with tmp_file.open("r") as f:
+        assert f.read() == "This is a nonsense readme"
 
 
 def test_bad_name(config):
-    cmd = InitCommand('group', config)
+    cmd = InitCommand("group", config)
     with pytest.raises(CommandError):
-        cmd.run(Namespace(name='1234', author="שראלה ישראל", series='k8s', force=False))
+        cmd.run(Namespace(name="1234", author="שראלה ישראל", series="k8s", force=False))
 
 
 def test_executables(tmp_path, config):
-    cmd = InitCommand('group', config)
-    cmd.run(Namespace(name='my-charm', author="홍길동", series='k8s', force=False))
+    cmd = InitCommand("group", config)
+    cmd.run(Namespace(name="my-charm", author="홍길동", series="k8s", force=False))
     assert (tmp_path / "run_tests").stat().st_mode & S_IXALL == S_IXALL
     assert (tmp_path / "src/charm.py").stat().st_mode & S_IXALL == S_IXALL
 
@@ -102,17 +106,17 @@ def test_tests(tmp_path, config):
     # virtualenv libs and bins (if any), as they need them, but we're not creating a
     # venv for the local tests (note that for CI doesn't use a venv)
     env = os.environ.copy()
-    env_paths = [p for p in sys.path if 'env/lib/python' in p]
+    env_paths = [p for p in sys.path if "env/lib/python" in p]
     if env_paths:
-        if 'PYTHONPATH' in env:
-            env['PYTHONPATH'] += ':' + ':'.join(env_paths)
+        if "PYTHONPATH" in env:
+            env["PYTHONPATH"] += ":" + ":".join(env_paths)
         else:
-            env['PYTHONPATH'] = ':'.join(env_paths)
+            env["PYTHONPATH"] = ":".join(env_paths)
         for path in env_paths:
-            bin_path = path[:path.index('env/lib/python')] + 'env/bin'
-            env['PATH'] = bin_path + ':' + env['PATH']
+            bin_path = path[: path.index("env/lib/python")] + "env/bin"
+            env["PATH"] = bin_path + ":" + env["PATH"]
 
-    cmd = InitCommand('group', config)
-    cmd.run(Namespace(name='my-charm', author="だれだれ", series='k8s', force=False))
+    cmd = InitCommand("group", config)
+    cmd.run(Namespace(name="my-charm", author="だれだれ", series="k8s", force=False))
 
     subprocess.run(["./run_tests"], cwd=str(tmp_path), check=True, env=env)

--- a/tests/commands/test_pack.py
+++ b/tests/commands/test_pack.py
@@ -38,12 +38,12 @@ noargs = Namespace()
 @pytest.fixture
 def bundle_yaml(tmp_path):
     """Create an empty bundle.yaml, with the option to set values to it."""
-    bundle_path = tmp_path / 'bundle.yaml'
+    bundle_path = tmp_path / "bundle.yaml"
     bundle_path.write_text("{}")
     content = {}
 
     def func(*, name):
-        content['name'] = name
+        content["name"] = name
         encoded = yaml.dump(content)
         bundle_path.write_text(encoded)
         return encoded
@@ -53,91 +53,99 @@ def bundle_yaml(tmp_path):
 
 # -- tests for main building process
 
+
 def test_simple_succesful_build(tmp_path, caplog, bundle_yaml, config):
     """A simple happy story."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
     # mandatory files (other thant the automatically provided manifest)
-    content = bundle_yaml(name='testbundle')
-    config.set(type='bundle')
-    (tmp_path / 'README.md').write_text("test readme")
+    content = bundle_yaml(name="testbundle")
+    config.set(type="bundle")
+    (tmp_path / "README.md").write_text("test readme")
 
     # build!
-    PackCommand('group', config).run(noargs)
+    PackCommand("group", config).run(noargs)
 
     # check
-    zipname = tmp_path / 'testbundle.zip'
+    zipname = tmp_path / "testbundle.zip"
     zf = zipfile.ZipFile(zipname)
-    assert 'charmcraft.yaml' not in [x.filename for x in zf.infolist()]
-    assert zf.read('bundle.yaml') == content.encode('ascii')
-    assert zf.read('README.md') == b"test readme"
+    assert "charmcraft.yaml" not in [x.filename for x in zf.infolist()]
+    assert zf.read("bundle.yaml") == content.encode("ascii")
+    assert zf.read("README.md") == b"test readme"
 
     expected = "Created '{}'.".format(zipname)
     assert [expected] == [rec.message for rec in caplog.records]
 
     # check the manifest is present and with particular values that depend on given info
-    manifest = yaml.safe_load(zf.read('manifest.yaml'))
-    assert manifest['charmcraft-started-at'] == config.project.started_at.isoformat() + "Z"
+    manifest = yaml.safe_load(zf.read("manifest.yaml"))
+    assert (
+        manifest["charmcraft-started-at"] == config.project.started_at.isoformat() + "Z"
+    )
 
     # verify that the manifest was not leftover in user's project
-    assert not (tmp_path / 'manifest.yaml').exists()
+    assert not (tmp_path / "manifest.yaml").exists()
 
 
 def test_missing_bundle_file(tmp_path, config):
     """Can not build a bundle without bundle.yaml."""
     # build without a bundle.yaml!
     with pytest.raises(CommandError) as cm:
-        PackCommand('group', config).run(noargs)
+        PackCommand("group", config).run(noargs)
     assert str(cm.value) == (
-        "Missing or invalid main bundle file: '{}'.".format(tmp_path / 'bundle.yaml'))
+        "Missing or invalid main bundle file: '{}'.".format(tmp_path / "bundle.yaml")
+    )
 
 
 def test_missing_other_mandatory_file(tmp_path, config, bundle_yaml):
     """Can not build a bundle without any of the mandatory files."""
-    bundle_yaml(name='testbundle')
-    config.set(type='bundle')
+    bundle_yaml(name="testbundle")
+    config.set(type="bundle")
 
     # build without a README!
     with pytest.raises(CommandError) as cm:
-        PackCommand('group', config).run(noargs)
-    assert str(cm.value) == "Missing mandatory file: {}.".format(tmp_path / 'README.md')
+        PackCommand("group", config).run(noargs)
+    assert str(cm.value) == "Missing mandatory file: {}.".format(tmp_path / "README.md")
 
 
 def test_missing_name_in_bundle(tmp_path, bundle_yaml, config):
     """Can not build a bundle without name."""
-    config.set(type='bundle')
+    config.set(type="bundle")
 
     # build!
     with pytest.raises(CommandError) as cm:
-        PackCommand('group', config).run(noargs)
+        PackCommand("group", config).run(noargs)
     assert str(cm.value) == (
-        "Invalid bundle config; missing a 'name' field indicating the bundle's name in file '{}'."
-        .format(tmp_path / 'bundle.yaml'))
+        "Invalid bundle config; missing a 'name' field indicating the bundle's name in file '{}'.".format(
+            tmp_path / "bundle.yaml"
+        )
+    )
 
 
 def test_bad_type_in_charmcraft(bundle_yaml, config):
     """The charmcraft.yaml file must have a proper type field."""
-    bundle_yaml(name='testbundle')
-    config.set(type='charm')
+    bundle_yaml(name="testbundle")
+    config.set(type="charm")
 
     # build!
     with pytest.raises(CommandError) as cm:
-        PackCommand('group', config).run(noargs)
+        PackCommand("group", config).run(noargs)
     assert str(cm.value) == (
-        "Bad config: 'type' field in charmcraft.yaml must be 'bundle' for this command.")
+        "Bad config: 'type' field in charmcraft.yaml must be 'bundle' for this command."
+    )
 
 
 # -- tests for get paths helper
 
+
 def test_getpaths_mandatory_ok(tmp_path, config):
     """Simple succesful case getting all mandatory files."""
-    test_mandatory = ['foo.txt', 'bar.bin']
-    test_file1 = (tmp_path / 'foo.txt')
+    test_mandatory = ["foo.txt", "bar.bin"]
+    test_file1 = tmp_path / "foo.txt"
     test_file1.touch()
-    test_file2 = (tmp_path / 'bar.bin')
+    test_file2 = tmp_path / "bar.bin"
     test_file2.touch()
 
-    with patch.object(pack, 'MANDATORY_FILES', test_mandatory):
+    with patch.object(pack, "MANDATORY_FILES", test_mandatory):
         result = get_paths_to_include(config)
 
     assert result == [test_file2, test_file1]
@@ -147,13 +155,13 @@ def test_getpaths_extra_ok(tmp_path, caplog, config):
     """Extra files were indicated ok."""
     caplog.set_level(logging.DEBUG, logger="charmcraft.commands")
 
-    config.set(prime=['f2.txt', 'f1.txt'])
-    testfile1 = tmp_path / 'f1.txt'
+    config.set(prime=["f2.txt", "f1.txt"])
+    testfile1 = tmp_path / "f1.txt"
     testfile1.touch()
-    testfile2 = tmp_path / 'f2.txt'
+    testfile2 = tmp_path / "f2.txt"
     testfile2.touch()
 
-    with patch.object(pack, 'MANDATORY_FILES', []):
+    with patch.object(pack, "MANDATORY_FILES", []):
         result = get_paths_to_include(config)
     assert result == [testfile1, testfile2]
 
@@ -168,11 +176,11 @@ def test_getpaths_extra_missing(tmp_path, caplog, config):
     """Extra files were indicated but not found."""
     caplog.set_level(logging.DEBUG, logger="charmcraft.commands")
 
-    config.set(prime=['f2.txt', 'f1.txt'])
-    testfile1 = tmp_path / 'f1.txt'
+    config.set(prime=["f2.txt", "f1.txt"])
+    testfile1 = tmp_path / "f1.txt"
     testfile1.touch()
 
-    with patch.object(pack, 'MANDATORY_FILES', []):
+    with patch.object(pack, "MANDATORY_FILES", []):
         result = get_paths_to_include(config)
     assert result == [testfile1]
 
@@ -185,12 +193,12 @@ def test_getpaths_extra_missing(tmp_path, caplog, config):
 
 def test_getpaths_extra_long_path(tmp_path, config):
     """An extra file can be deep in directories."""
-    config.set(prime=['foo/bar/baz/extra.txt'])
-    testfile = tmp_path / 'foo' / 'bar' / 'baz' / 'extra.txt'
+    config.set(prime=["foo/bar/baz/extra.txt"])
+    testfile = tmp_path / "foo" / "bar" / "baz" / "extra.txt"
     testfile.parent.mkdir(parents=True)
     testfile.touch()
 
-    with patch.object(pack, 'MANDATORY_FILES', []):
+    with patch.object(pack, "MANDATORY_FILES", []):
         result = get_paths_to_include(config)
     assert result == [testfile]
 
@@ -199,15 +207,15 @@ def test_getpaths_extra_wildcards_ok(tmp_path, caplog, config):
     """Use wildcards to specify several files ok."""
     caplog.set_level(logging.DEBUG, logger="charmcraft.commands")
 
-    config.set(prime=['*.txt'])
-    testfile1 = tmp_path / 'f1.txt'
+    config.set(prime=["*.txt"])
+    testfile1 = tmp_path / "f1.txt"
     testfile1.touch()
-    testfile2 = tmp_path / 'f2.bin'
+    testfile2 = tmp_path / "f2.bin"
     testfile2.touch()
-    testfile3 = tmp_path / 'f3.txt'
+    testfile3 = tmp_path / "f3.txt"
     testfile3.touch()
 
-    with patch.object(pack, 'MANDATORY_FILES', []):
+    with patch.object(pack, "MANDATORY_FILES", []):
         result = get_paths_to_include(config)
     assert result == [testfile1, testfile3]
 
@@ -221,9 +229,9 @@ def test_getpaths_extra_wildcards_not_found(tmp_path, caplog, config):
     """Use wildcards to specify several files but nothing found."""
     caplog.set_level(logging.DEBUG, logger="charmcraft.commands")
 
-    config.set(prime=['*.txt'])
+    config.set(prime=["*.txt"])
 
-    with patch.object(pack, 'MANDATORY_FILES', []):
+    with patch.object(pack, "MANDATORY_FILES", []):
         result = get_paths_to_include(config)
     assert result == []
 
@@ -235,14 +243,14 @@ def test_getpaths_extra_wildcards_not_found(tmp_path, caplog, config):
 
 def test_getpaths_extra_globstar(tmp_path, config):
     """Double star means whatever directories are in the path."""
-    config.set(prime=['lib/**/*'])
+    config.set(prime=["lib/**/*"])
     srcpaths = (
-        ('lib/foo/f1.txt', True),
-        ('lib/foo/deep/fx.txt', True),
-        ('lib/bar/f2.txt', True),
-        ('lib/f3.txt', True),
-        ('extra/lib/f.txt', False),
-        ('libs/fs.txt', False),
+        ("lib/foo/f1.txt", True),
+        ("lib/foo/deep/fx.txt", True),
+        ("lib/bar/f2.txt", True),
+        ("lib/f3.txt", True),
+        ("extra/lib/f.txt", False),
+        ("libs/fs.txt", False),
     )
     allexpected = []
     for srcpath, expected in srcpaths:
@@ -252,25 +260,25 @@ def test_getpaths_extra_globstar(tmp_path, config):
         if expected:
             allexpected.append(testfile)
 
-    with patch.object(pack, 'MANDATORY_FILES', []):
+    with patch.object(pack, "MANDATORY_FILES", []):
         result = get_paths_to_include(config)
     assert result == sorted(allexpected)
 
 
 def test_getpaths_extra_globstar_specific_files(tmp_path, config):
     """Combination of both mechanisms."""
-    config.set(prime=['lib/**/*.txt'])
+    config.set(prime=["lib/**/*.txt"])
     srcpaths = (
-        ('lib/foo/f1.txt', True),
-        ('lib/foo/f1.nop', False),
-        ('lib/foo/deep/fx.txt', True),
-        ('lib/foo/deep/fx.nop', False),
-        ('lib/bar/f2.txt', True),
-        ('lib/bar/f2.nop', False),
-        ('lib/f3.txt', True),
-        ('lib/f3.nop', False),
-        ('extra/lib/f.txt', False),
-        ('libs/fs.nop', False),
+        ("lib/foo/f1.txt", True),
+        ("lib/foo/f1.nop", False),
+        ("lib/foo/deep/fx.txt", True),
+        ("lib/foo/deep/fx.nop", False),
+        ("lib/bar/f2.txt", True),
+        ("lib/bar/f2.nop", False),
+        ("lib/f3.txt", True),
+        ("lib/f3.nop", False),
+        ("extra/lib/f.txt", False),
+        ("libs/fs.nop", False),
     )
     allexpected = []
     for srcpath, expected in srcpaths:
@@ -280,62 +288,63 @@ def test_getpaths_extra_globstar_specific_files(tmp_path, config):
         if expected:
             allexpected.append(testfile)
 
-    with patch.object(pack, 'MANDATORY_FILES', []):
+    with patch.object(pack, "MANDATORY_FILES", []):
         result = get_paths_to_include(config)
     assert result == sorted(allexpected)
 
 
 # -- tests for zip builder
 
+
 def test_zipbuild_simple(tmp_path):
     """Build a bunch of files in the zip."""
-    testfile1 = tmp_path / 'foo.txt'
+    testfile1 = tmp_path / "foo.txt"
     testfile1.write_bytes(b"123\x00456")
-    subdir = tmp_path / 'bar'
+    subdir = tmp_path / "bar"
     subdir.mkdir()
-    testfile2 = subdir / 'baz.txt'
+    testfile2 = subdir / "baz.txt"
     testfile2.write_bytes(b"mo\xc3\xb1o")
 
-    zip_filepath = tmp_path / 'testresult.zip'
+    zip_filepath = tmp_path / "testresult.zip"
     build_zip(zip_filepath, tmp_path, [testfile1, testfile2])
 
     zf = zipfile.ZipFile(zip_filepath)
-    assert sorted(x.filename for x in zf.infolist()) == ['bar/baz.txt', 'foo.txt']
-    assert zf.read('foo.txt') == b"123\x00456"
-    assert zf.read('bar/baz.txt') == b"mo\xc3\xb1o"
+    assert sorted(x.filename for x in zf.infolist()) == ["bar/baz.txt", "foo.txt"]
+    assert zf.read("foo.txt") == b"123\x00456"
+    assert zf.read("bar/baz.txt") == b"mo\xc3\xb1o"
 
 
 def test_zipbuild_symlink_simple(tmp_path):
     """Symlinks are supported."""
-    testfile1 = tmp_path / 'real.txt'
+    testfile1 = tmp_path / "real.txt"
     testfile1.write_bytes(b"123\x00456")
-    testfile2 = tmp_path / 'link.txt'
+    testfile2 = tmp_path / "link.txt"
     testfile2.symlink_to(testfile1)
 
-    zip_filepath = tmp_path / 'testresult.zip'
+    zip_filepath = tmp_path / "testresult.zip"
     build_zip(zip_filepath, tmp_path, [testfile1, testfile2])
 
     zf = zipfile.ZipFile(zip_filepath)
-    assert sorted(x.filename for x in zf.infolist()) == ['link.txt', 'real.txt']
-    assert zf.read('real.txt') == b"123\x00456"
-    assert zf.read('link.txt') == b"123\x00456"
+    assert sorted(x.filename for x in zf.infolist()) == ["link.txt", "real.txt"]
+    assert zf.read("real.txt") == b"123\x00456"
+    assert zf.read("link.txt") == b"123\x00456"
 
 
 def test_zipbuild_symlink_outside(tmp_path):
     """No matter where the symlink points to."""
     # outside the build dir
-    testfile1 = tmp_path / 'real.txt'
+    testfile1 = tmp_path / "real.txt"
     testfile1.write_bytes(b"123\x00456")
 
     # inside the build dir
-    build_dir = tmp_path / 'somedir'
+    build_dir = tmp_path / "somedir"
     build_dir.mkdir()
-    testfile2 = build_dir / 'link.txt'
+    testfile2 = build_dir / "link.txt"
     testfile2.symlink_to(testfile1)
 
-    zip_filepath = tmp_path / 'testresult.zip'
+    zip_filepath = tmp_path / "testresult.zip"
     build_zip(zip_filepath, build_dir, [testfile2])
 
     zf = zipfile.ZipFile(zip_filepath)
-    assert sorted(x.filename for x in zf.infolist()) == ['link.txt']
-    assert zf.read('link.txt') == b"123\x00456"
+    assert sorted(x.filename for x in zf.infolist()) == ["link.txt"]
+    assert zf.read("link.txt") == b"123\x00456"

--- a/tests/commands/test_pack.py
+++ b/tests/commands/test_pack.py
@@ -115,7 +115,8 @@ def test_missing_name_in_bundle(tmp_path, bundle_yaml, config):
     with pytest.raises(CommandError) as cm:
         PackCommand("group", config).run(noargs)
     assert str(cm.value) == (
-        "Invalid bundle config; missing a 'name' field indicating the bundle's name in file '{}'.".format(
+        "Invalid bundle config; "
+        "missing a 'name' field indicating the bundle's name in file '{}'.".format(
             tmp_path / "bundle.yaml"
         )
     )

--- a/tests/commands/test_store_api.py
+++ b/tests/commands/test_store_api.py
@@ -30,15 +30,18 @@ from charmcraft.commands.store.store import Store, Library
 def client_mock():
     """Fixture to provide a mocked client."""
     client_mock = MagicMock()
-    with patch('charmcraft.commands.store.store.Client', lambda api, storage: client_mock):
+    with patch(
+        "charmcraft.commands.store.store.Client", lambda api, storage: client_mock
+    ):
         yield client_mock
 
 
 # -- tests for client usage
 
+
 def test_client_init(config):
     """Check that the client is initiated ok even without config."""
-    with patch('charmcraft.commands.store.store.Client') as client_mock:
+    with patch("charmcraft.commands.store.store.Client") as client_mock:
         Store(config.charmhub)
     assert client_mock.mock_calls == [
         call(config.charmhub.api_url, config.charmhub.storage_url),
@@ -54,7 +57,7 @@ def test_login(client_mock, config):
     result = store.login()
     assert client_mock.mock_calls == [
         call.clear_credentials(),
-        call.get('/v1/whoami'),
+        call.get("/v1/whoami"),
     ]
     assert result is None
 
@@ -72,17 +75,17 @@ def test_logout(client_mock, config):
 def test_whoami(client_mock, config):
     """Simple whoami case."""
     store = Store(config.charmhub)
-    auth_response = {'display-name': 'John Doe', 'username': 'jdoe', 'id': '-1'}
+    auth_response = {"display-name": "John Doe", "username": "jdoe", "id": "-1"}
     client_mock.get.return_value = auth_response
 
     result = store.whoami()
 
     assert client_mock.mock_calls == [
-        call.get('/v1/whoami'),
+        call.get("/v1/whoami"),
     ]
-    assert result.name == 'John Doe'
-    assert result.username == 'jdoe'
-    assert result.userid == '-1'
+    assert result.name == "John Doe"
+    assert result.username == "jdoe"
+    assert result.userid == "-1"
 
 
 # -- tests for register and list names
@@ -91,10 +94,10 @@ def test_whoami(client_mock, config):
 def test_register_name(client_mock, config):
     """Simple register case."""
     store = Store(config.charmhub)
-    result = store.register_name('testname', 'stuff')
+    result = store.register_name("testname", "stuff")
 
     assert client_mock.mock_calls == [
-        call.post('/v1/charm', {'name': 'testname', 'type': 'stuff'}),
+        call.post("/v1/charm", {"name": "testname", "type": "stuff"}),
     ]
     assert result is None
 
@@ -103,14 +106,12 @@ def test_list_registered_names_empty(client_mock, config):
     """List registered names getting an empty response."""
     store = Store(config.charmhub)
 
-    auth_response = {'results': []}
+    auth_response = {"results": []}
     client_mock.get.return_value = auth_response
 
     result = store.list_registered_names()
 
-    assert client_mock.mock_calls == [
-        call.get('/v1/charm')
-    ]
+    assert client_mock.mock_calls == [call.get("/v1/charm")]
     assert result == []
 
 
@@ -118,29 +119,30 @@ def test_list_registered_names_multiple(client_mock, config):
     """List registered names getting a multiple response."""
     store = Store(config.charmhub)
 
-    auth_response = {'results': [
-        {'name': 'name1', 'type': 'charm', 'private': False, 'status': 'status1'},
-        {'name': 'name2', 'type': 'bundle', 'private': True, 'status': 'status2'},
-    ]}
+    auth_response = {
+        "results": [
+            {"name": "name1", "type": "charm", "private": False, "status": "status1"},
+            {"name": "name2", "type": "bundle", "private": True, "status": "status2"},
+        ]
+    }
     client_mock.get.return_value = auth_response
 
     result = store.list_registered_names()
 
-    assert client_mock.mock_calls == [
-        call.get('/v1/charm')
-    ]
+    assert client_mock.mock_calls == [call.get("/v1/charm")]
     item1, item2 = result
-    assert item1.name == 'name1'
-    assert item1.entity_type == 'charm'
+    assert item1.name == "name1"
+    assert item1.entity_type == "charm"
     assert not item1.private
-    assert item1.status == 'status1'
-    assert item2.name == 'name2'
-    assert item2.entity_type == 'bundle'
+    assert item1.status == "status1"
+    assert item2.name == "name2"
+    assert item2.entity_type == "bundle"
     assert item2.private
-    assert item2.status == 'status2'
+    assert item2.status == "status2"
 
 
 # -- tests for the upload functionality (both for charm/bundles and resources)
+
 
 def test_upload_straightforward(client_mock, caplog, config):
     """The full and successful upload case."""
@@ -148,31 +150,36 @@ def test_upload_straightforward(client_mock, caplog, config):
     store = Store(config.charmhub)
 
     # the first response, for when pushing bytes
-    test_upload_id = 'test-upload-id'
+    test_upload_id = "test-upload-id"
     client_mock.push.return_value = test_upload_id
 
     # the second response, for telling the store it was pushed
-    test_status_url = 'https://store.c.c/status'
-    client_mock.post.return_value = {'status-url': test_status_url}
+    test_status_url = "https://store.c.c/status"
+    client_mock.post.return_value = {"status-url": test_status_url}
 
     # the third response, status ok (note the patched UPLOAD_ENDING_STATUSES below)
     test_revision = 123
-    test_status_ok = 'test-status'
+    test_status_ok = "test-status"
     status_response = {
-        'revisions': [{'status': test_status_ok, 'revision': test_revision, 'errors': None}]}
+        "revisions": [
+            {"status": test_status_ok, "revision": test_revision, "errors": None}
+        ]
+    }
     client_mock.get.return_value = status_response
 
-    test_status_resolution = 'test-ok-or-not'
+    test_status_resolution = "test-ok-or-not"
     fake_statuses = {test_status_ok: test_status_resolution}
-    test_filepath = 'test-filepath'
-    test_endpoint = '/v1/test/revisions/endpoint/'
-    with patch.dict('charmcraft.commands.store.store.UPLOAD_ENDING_STATUSES', fake_statuses):
+    test_filepath = "test-filepath"
+    test_endpoint = "/v1/test/revisions/endpoint/"
+    with patch.dict(
+        "charmcraft.commands.store.store.UPLOAD_ENDING_STATUSES", fake_statuses
+    ):
         result = store._upload(test_endpoint, test_filepath)
 
     # check all client calls
     assert client_mock.mock_calls == [
         call.push(test_filepath),
-        call.post(test_endpoint, {'upload-id': test_upload_id}),
+        call.post(test_endpoint, {"upload-id": test_upload_id}),
         call.get(test_status_url),
     ]
 
@@ -195,27 +202,38 @@ def test_upload_polls_status(client_mock, caplog, config):
     store = Store(config.charmhub)
 
     # first and second response, for pushing bytes and let the store know about it
-    test_upload_id = 'test-upload-id'
+    test_upload_id = "test-upload-id"
     client_mock.push.return_value = test_upload_id
-    test_status_url = 'https://store.c.c/status'
-    client_mock.post.return_value = {'status-url': test_status_url}
+    test_status_url = "https://store.c.c/status"
+    client_mock.post.return_value = {"status-url": test_status_url}
 
     # the status checking response, will answer something not done yet twice, then ok
     test_revision = 123
-    test_status_ok = 'test-status'
+    test_status_ok = "test-status"
     status_response_1 = {
-        'revisions': [{'status': 'still-scanning', 'revision': None, 'errors': None}]}
+        "revisions": [{"status": "still-scanning", "revision": None, "errors": None}]
+    }
     status_response_2 = {
-        'revisions': [{'status': 'more-revisions', 'revision': None, 'errors': None}]}
+        "revisions": [{"status": "more-revisions", "revision": None, "errors": None}]
+    }
     status_response_3 = {
-        'revisions': [{'status': test_status_ok, 'revision': test_revision, 'errors': None}]}
-    client_mock.get.side_effect = [status_response_1, status_response_2, status_response_3]
+        "revisions": [
+            {"status": test_status_ok, "revision": test_revision, "errors": None}
+        ]
+    }
+    client_mock.get.side_effect = [
+        status_response_1,
+        status_response_2,
+        status_response_3,
+    ]
 
-    test_status_resolution = 'clean and crispy'
+    test_status_resolution = "clean and crispy"
     fake_statuses = {test_status_ok: test_status_resolution}
-    with patch.dict('charmcraft.commands.store.store.UPLOAD_ENDING_STATUSES', fake_statuses):
-        with patch('charmcraft.commands.store.store.POLL_DELAY', 0.01):
-            result = store._upload('/test/endpoint/', 'some-filepath')
+    with patch.dict(
+        "charmcraft.commands.store.store.UPLOAD_ENDING_STATUSES", fake_statuses
+    ):
+        with patch("charmcraft.commands.store.store.POLL_DELAY", 0.01):
+            result = store._upload("/test/endpoint/", "some-filepath")
 
     # check the status-checking client calls (kept going until third one)
     assert client_mock.mock_calls[2:] == [
@@ -244,31 +262,37 @@ def test_upload_error(client_mock, config):
     store = Store(config.charmhub)
 
     # the first response, for when pushing bytes
-    test_upload_id = 'test-upload-id'
+    test_upload_id = "test-upload-id"
     client_mock.push.return_value = test_upload_id
 
     # the second response, for telling the store it was pushed
-    test_status_url = 'https://store.c.c/status'
-    client_mock.post.return_value = {'status-url': test_status_url}
+    test_status_url = "https://store.c.c/status"
+    client_mock.post.return_value = {"status-url": test_status_url}
 
     # the third response, status in error (note the patched UPLOAD_ENDING_STATUSES below)
     test_revision = 123
-    test_status_bad = 'test-status'
-    status_response = {'revisions': [{
-        'status': test_status_bad,
-        'revision': test_revision,
-        'errors': [
-            {'message': "error text 1", 'code': "error-code-1"},
-            {'message': "error text 2", 'code': "error-code-2"},
-        ],
-    }]}
+    test_status_bad = "test-status"
+    status_response = {
+        "revisions": [
+            {
+                "status": test_status_bad,
+                "revision": test_revision,
+                "errors": [
+                    {"message": "error text 1", "code": "error-code-1"},
+                    {"message": "error text 2", "code": "error-code-2"},
+                ],
+            }
+        ]
+    }
     client_mock.get.return_value = status_response
 
-    test_status_resolution = 'test-ok-or-not'
+    test_status_resolution = "test-ok-or-not"
     fake_statuses = {test_status_bad: test_status_resolution}
-    test_filepath = 'test-filepath'
-    with patch.dict('charmcraft.commands.store.store.UPLOAD_ENDING_STATUSES', fake_statuses):
-        result = store._upload('/test/endpoint/', test_filepath)
+    test_filepath = "test-filepath"
+    with patch.dict(
+        "charmcraft.commands.store.store.UPLOAD_ENDING_STATUSES", fake_statuses
+    ):
+        result = store._upload("/test/endpoint/", test_filepath)
 
     # check result
     assert result.ok == test_status_resolution
@@ -284,27 +308,29 @@ def test_upload_error(client_mock, config):
 def test_upload_charmbundles_endpoint(config):
     """The bundle/charm upload prepares ok the endpoint and calls the generic _upload."""
     store = Store(config.charmhub)
-    test_results = 'test-results'
+    test_results = "test-results"
 
-    with patch.object(store, '_upload') as mock:
+    with patch.object(store, "_upload") as mock:
         mock.return_value = test_results
-        result = store.upload('test-charm', 'test-filepath')
-    mock.assert_called_once_with('/v1/charm/test-charm/revisions', 'test-filepath')
+        result = store.upload("test-charm", "test-filepath")
+    mock.assert_called_once_with("/v1/charm/test-charm/revisions", "test-filepath")
     assert result == test_results
 
 
 def test_upload_resources_endpoint(config):
     """The resource upload prepares ok the endpoint and calls the generic _upload."""
     store = Store(config.charmhub)
-    test_results = 'test-results'
+    test_results = "test-results"
 
-    with patch.object(store, '_upload') as mock:
+    with patch.object(store, "_upload") as mock:
         mock.return_value = test_results
         result = store.upload_resource(
-            'test-charm', 'test-resource', 'test-type', 'test-filepath')
-    expected_endpoint = '/v1/charm/test-charm/resources/test-resource/revisions'
+            "test-charm", "test-resource", "test-type", "test-filepath"
+        )
+    expected_endpoint = "/v1/charm/test-charm/resources/test-resource/revisions"
     mock.assert_called_once_with(
-        expected_endpoint, 'test-filepath', extra_fields={'type': 'test-type'})
+        expected_endpoint, "test-filepath", extra_fields={"type": "test-type"}
+    )
     assert result == test_results
 
 
@@ -314,32 +340,39 @@ def test_upload_including_extra_parameters(client_mock, caplog, config):
     store = Store(config.charmhub)
 
     # the first response, for when pushing bytes
-    test_upload_id = 'test-upload-id'
+    test_upload_id = "test-upload-id"
     client_mock.push.return_value = test_upload_id
 
     # the second response, for telling the store it was pushed
-    test_status_url = 'https://store.c.c/status'
-    client_mock.post.return_value = {'status-url': test_status_url}
+    test_status_url = "https://store.c.c/status"
+    client_mock.post.return_value = {"status-url": test_status_url}
 
     # the third response, status ok (note the patched UPLOAD_ENDING_STATUSES below)
     test_revision = 123
-    test_status_ok = 'test-status'
+    test_status_ok = "test-status"
     status_response = {
-        'revisions': [{'status': test_status_ok, 'revision': test_revision, 'errors': None}]}
+        "revisions": [
+            {"status": test_status_ok, "revision": test_revision, "errors": None}
+        ]
+    }
     client_mock.get.return_value = status_response
 
-    test_status_resolution = 'test-ok-or-not'
+    test_status_resolution = "test-ok-or-not"
     fake_statuses = {test_status_ok: test_status_resolution}
-    test_filepath = 'test-filepath'
-    test_endpoint = '/v1/test/revisions/endpoint/'
-    extra_fields = {'extra-key': '1', 'more': '2'}
-    with patch.dict('charmcraft.commands.store.store.UPLOAD_ENDING_STATUSES', fake_statuses):
+    test_filepath = "test-filepath"
+    test_endpoint = "/v1/test/revisions/endpoint/"
+    extra_fields = {"extra-key": "1", "more": "2"}
+    with patch.dict(
+        "charmcraft.commands.store.store.UPLOAD_ENDING_STATUSES", fake_statuses
+    ):
         store._upload(test_endpoint, test_filepath, extra_fields=extra_fields)
 
     # check all client calls
     assert client_mock.mock_calls == [
         call.push(test_filepath),
-        call.post(test_endpoint, {'upload-id': test_upload_id, 'extra-key': '1', 'more': '2'}),
+        call.post(
+            test_endpoint, {"upload-id": test_upload_id, "extra-key": "1", "more": "2"}
+        ),
         call.get(test_status_url),
     ]
 
@@ -350,64 +383,62 @@ def test_upload_including_extra_parameters(client_mock, caplog, config):
 def test_list_revisions_ok(client_mock, config):
     """One revision ok."""
     store = Store(config.charmhub)
-    client_mock.get.return_value = {'revisions': [
-        {
-            'revision': 7,
-            'version': 'v7',
-            'created-at': '2020-06-29T22:11:00.123',
-            'status': 'approved',
-            'errors': None,
-        }
-    ]}
+    client_mock.get.return_value = {
+        "revisions": [
+            {
+                "revision": 7,
+                "version": "v7",
+                "created-at": "2020-06-29T22:11:00.123",
+                "status": "approved",
+                "errors": None,
+            }
+        ]
+    }
 
-    result = store.list_revisions('some-name')
+    result = store.list_revisions("some-name")
 
-    assert client_mock.mock_calls == [
-        call.get('/v1/charm/some-name/revisions')
-    ]
+    assert client_mock.mock_calls == [call.get("/v1/charm/some-name/revisions")]
 
     (item,) = result
     assert item.revision == 7
-    assert item.version == 'v7'
-    assert item.created_at == parser.parse('2020-06-29T22:11:00.123')
-    assert item.status == 'approved'
+    assert item.version == "v7"
+    assert item.created_at == parser.parse("2020-06-29T22:11:00.123")
+    assert item.status == "approved"
     assert item.errors == []
 
 
 def test_list_revisions_empty(client_mock, config):
     """No revisions listed."""
     store = Store(config.charmhub)
-    client_mock.get.return_value = {'revisions': []}
+    client_mock.get.return_value = {"revisions": []}
 
-    result = store.list_revisions('some-name')
+    result = store.list_revisions("some-name")
 
-    assert client_mock.mock_calls == [
-        call.get('/v1/charm/some-name/revisions')
-    ]
+    assert client_mock.mock_calls == [call.get("/v1/charm/some-name/revisions")]
     assert result == []
 
 
 def test_list_revisions_errors(client_mock, config):
     """One revision with errors."""
     store = Store(config.charmhub)
-    client_mock.get.return_value = {'revisions': [
-        {
-            'revision': 7,
-            'version': 'v7',
-            'created-at': '2020-06-29T22:11:00.123',
-            'status': 'rejected',
-            'errors': [
-                {'message': "error text 1", 'code': "error-code-1"},
-                {'message': "error text 2", 'code': "error-code-2"},
-            ],
-        }
-    ]}
+    client_mock.get.return_value = {
+        "revisions": [
+            {
+                "revision": 7,
+                "version": "v7",
+                "created-at": "2020-06-29T22:11:00.123",
+                "status": "rejected",
+                "errors": [
+                    {"message": "error text 1", "code": "error-code-1"},
+                    {"message": "error text 2", "code": "error-code-2"},
+                ],
+            }
+        ]
+    }
 
-    result = store.list_revisions('some-name')
+    result = store.list_revisions("some-name")
 
-    assert client_mock.mock_calls == [
-        call.get('/v1/charm/some-name/revisions')
-    ]
+    assert client_mock.mock_calls == [call.get("/v1/charm/some-name/revisions")]
 
     (item,) = result
     error1, error2 = item.errors
@@ -419,42 +450,44 @@ def test_list_revisions_errors(client_mock, config):
 
 def test_list_revisions_several_mixed(client_mock, config):
     """All cases mixed."""
-    client_mock.get.return_value = {'revisions': [
-        {
-            'revision': 1,
-            'version': 'v1',
-            'created-at': '2020-06-29T22:11:01',
-            'status': 'rejected',
-            'errors': [
-                {'message': "error", 'code': "code"},
-            ],
-        },
-        {
-            'revision': 2,
-            'version': 'v2',
-            'created-at': '2020-06-29T22:11:02',
-            'status': 'approved',
-            'errors': None,
-        },
-    ]}
+    client_mock.get.return_value = {
+        "revisions": [
+            {
+                "revision": 1,
+                "version": "v1",
+                "created-at": "2020-06-29T22:11:01",
+                "status": "rejected",
+                "errors": [
+                    {"message": "error", "code": "code"},
+                ],
+            },
+            {
+                "revision": 2,
+                "version": "v2",
+                "created-at": "2020-06-29T22:11:02",
+                "status": "approved",
+                "errors": None,
+            },
+        ]
+    }
 
     store = Store(config.charmhub)
-    result = store.list_revisions('some-name')
+    result = store.list_revisions("some-name")
 
     (item1, item2) = result
 
     assert item1.revision == 1
-    assert item1.version == 'v1'
-    assert item1.created_at == parser.parse('2020-06-29T22:11:01')
-    assert item1.status == 'rejected'
+    assert item1.version == "v1"
+    assert item1.created_at == parser.parse("2020-06-29T22:11:01")
+    assert item1.status == "rejected"
     (error,) = item1.errors
     assert error.message == "error"
     assert error.code == "code"
 
     assert item2.revision == 2
-    assert item2.version == 'v2'
-    assert item2.created_at == parser.parse('2020-06-29T22:11:02')
-    assert item2.status == 'approved'
+    assert item2.version == "v2"
+    assert item2.created_at == parser.parse("2020-06-29T22:11:02")
+    assert item2.status == "approved"
     assert item2.errors == []
 
 
@@ -464,55 +497,56 @@ def test_list_revisions_several_mixed(client_mock, config):
 def test_release_simple(client_mock, config):
     """Releasing a revision into one channel."""
     store = Store(config.charmhub)
-    store.release('testname', 123, ['somechannel'], [])
+    store.release("testname", 123, ["somechannel"], [])
 
-    expected_body = [{'revision': 123, 'channel': 'somechannel', 'resources': []}]
+    expected_body = [{"revision": 123, "channel": "somechannel", "resources": []}]
     assert client_mock.mock_calls == [
-        call.post('/v1/charm/testname/releases', expected_body),
+        call.post("/v1/charm/testname/releases", expected_body),
     ]
 
 
 def test_release_multiple_channels(client_mock, config):
     """Releasing a revision into multiple channels."""
     store = Store(config.charmhub)
-    store.release('testname', 123, ['channel1', 'channel2', 'channel3'], [])
+    store.release("testname", 123, ["channel1", "channel2", "channel3"], [])
 
     expected_body = [
-        {'revision': 123, 'channel': 'channel1', 'resources': []},
-        {'revision': 123, 'channel': 'channel2', 'resources': []},
-        {'revision': 123, 'channel': 'channel3', 'resources': []},
+        {"revision": 123, "channel": "channel1", "resources": []},
+        {"revision": 123, "channel": "channel2", "resources": []},
+        {"revision": 123, "channel": "channel3", "resources": []},
     ]
     assert client_mock.mock_calls == [
-        call.post('/v1/charm/testname/releases', expected_body),
+        call.post("/v1/charm/testname/releases", expected_body),
     ]
 
 
 def test_release_with_resources(client_mock, config):
     """Releasing with resources attached."""
     store = Store(config.charmhub)
-    r1 = ResourceOption(name='foo', revision=3)
-    r2 = ResourceOption(name='bar', revision=17)
-    store.release('testname', 123, ['channel1', 'channel2'], [r1, r2])
+    r1 = ResourceOption(name="foo", revision=3)
+    r2 = ResourceOption(name="bar", revision=17)
+    store.release("testname", 123, ["channel1", "channel2"], [r1, r2])
 
     expected_body = [
         {
-            'revision': 123,
-            'channel': 'channel1',
-            'resources': [
-                {'name': 'foo', 'revision': 3},
-                {'name': 'bar', 'revision': 17},
-            ]
-        }, {
-            'revision': 123,
-            'channel': 'channel2',
-            'resources': [
-                {'name': 'foo', 'revision': 3},
-                {'name': 'bar', 'revision': 17},
-            ]
-        }
+            "revision": 123,
+            "channel": "channel1",
+            "resources": [
+                {"name": "foo", "revision": 3},
+                {"name": "bar", "revision": 17},
+            ],
+        },
+        {
+            "revision": 123,
+            "channel": "channel2",
+            "resources": [
+                {"name": "foo", "revision": 3},
+                {"name": "bar", "revision": 17},
+            ],
+        },
     ]
     assert client_mock.mock_calls == [
-        call.post('/v1/charm/testname/releases', expected_body),
+        call.post("/v1/charm/testname/releases", expected_body),
     ]
 
 
@@ -522,192 +556,197 @@ def test_release_with_resources(client_mock, config):
 def test_status_ok(client_mock, config):
     """Get all the release information."""
     client_mock.get.return_value = {
-        'channel-map': [
+        "channel-map": [
             {
-                'channel': 'latest/beta',
-                'expiration-date': None,
-                'platform': {'architecture': 'all', 'os': 'all', 'series': 'all'},
-                'progressive': {'paused': None, 'percentage': None},
-                'revision': 5,
-                'when': '2020-07-16T18:45:24Z',
-                'resources': [],
-            }, {
-                'channel': 'latest/edge/mybranch',
-                'expiration-date': '2020-08-16T18:46:02Z',
-                'platform': {'architecture': 'all', 'os': 'all', 'series': 'all'},
-                'progressive': {'paused': None, 'percentage': None},
-                'revision': 10,
-                'when': '2020-07-16T18:46:02Z',
-                'resources': [],
-            }
+                "channel": "latest/beta",
+                "expiration-date": None,
+                "platform": {"architecture": "all", "os": "all", "series": "all"},
+                "progressive": {"paused": None, "percentage": None},
+                "revision": 5,
+                "when": "2020-07-16T18:45:24Z",
+                "resources": [],
+            },
+            {
+                "channel": "latest/edge/mybranch",
+                "expiration-date": "2020-08-16T18:46:02Z",
+                "platform": {"architecture": "all", "os": "all", "series": "all"},
+                "progressive": {"paused": None, "percentage": None},
+                "revision": 10,
+                "when": "2020-07-16T18:46:02Z",
+                "resources": [],
+            },
         ],
-        'package': {
-            'channels': [
+        "package": {
+            "channels": [
                 {
-                    'branch': None,
-                    'fallback': None,
-                    'name': 'latest/stable',
-                    'risk': 'stable',
-                    'track': 'latest',
-                }, {
-                    'branch': 'mybranch',
-                    'fallback':
-                    'latest/stable',
-                    'name': 'latest/edge/mybranch',
-                    'risk': 'edge',
-                    'track': 'latest',
+                    "branch": None,
+                    "fallback": None,
+                    "name": "latest/stable",
+                    "risk": "stable",
+                    "track": "latest",
+                },
+                {
+                    "branch": "mybranch",
+                    "fallback": "latest/stable",
+                    "name": "latest/edge/mybranch",
+                    "risk": "edge",
+                    "track": "latest",
                 },
             ]
         },
-        'revisions': [
+        "revisions": [
             {
-                'revision': 5,
-                'version': '5',
-                'created-at': '2020-06-29T22:11:05',
-                'status': 'approved',
-                'errors': None,
-            }, {
-                'revision': 10,
-                'version': '63a852b',
-                'created-at': '2020-06-29T22:11:10',
-                'status': 'approved',
-                'errors': None,
+                "revision": 5,
+                "version": "5",
+                "created-at": "2020-06-29T22:11:05",
+                "status": "approved",
+                "errors": None,
+            },
+            {
+                "revision": 10,
+                "version": "63a852b",
+                "created-at": "2020-06-29T22:11:10",
+                "status": "approved",
+                "errors": None,
             },
         ],
     }
 
     store = Store(config.charmhub)
-    channel_map, channels, revisions = store.list_releases('testname')
+    channel_map, channels, revisions = store.list_releases("testname")
 
     # check how the client is used
     assert client_mock.mock_calls == [
-        call.get('/v1/charm/testname/releases'),
+        call.get("/v1/charm/testname/releases"),
     ]
 
     # check response
     cmap1, cmap2 = channel_map
     assert cmap1.revision == 5
-    assert cmap1.channel == 'latest/beta'
+    assert cmap1.channel == "latest/beta"
     assert cmap1.expires_at is None
     assert cmap1.resources == []
     assert cmap2.revision == 10
-    assert cmap2.channel == 'latest/edge/mybranch'
-    assert cmap2.expires_at == parser.parse('2020-08-16T18:46:02Z')
+    assert cmap2.channel == "latest/edge/mybranch"
+    assert cmap2.expires_at == parser.parse("2020-08-16T18:46:02Z")
     assert cmap2.resources == []
 
     channel1, channel2 = channels
-    assert channel1.name == 'latest/stable'
-    assert channel1.track == 'latest'
-    assert channel1.risk == 'stable'
+    assert channel1.name == "latest/stable"
+    assert channel1.track == "latest"
+    assert channel1.risk == "stable"
     assert channel1.branch is None
-    assert channel2.name == 'latest/edge/mybranch'
-    assert channel2.track == 'latest'
-    assert channel2.risk == 'edge'
-    assert channel2.branch == 'mybranch'
+    assert channel2.name == "latest/edge/mybranch"
+    assert channel2.track == "latest"
+    assert channel2.risk == "edge"
+    assert channel2.branch == "mybranch"
 
     rev1, rev2 = revisions
     assert rev1.revision == 5
-    assert rev1.version == '5'
-    assert rev1.created_at == parser.parse('2020-06-29T22:11:05')
-    assert rev1.status == 'approved'
+    assert rev1.version == "5"
+    assert rev1.created_at == parser.parse("2020-06-29T22:11:05")
+    assert rev1.status == "approved"
     assert rev1.errors == []
     assert rev2.revision == 10
-    assert rev2.version == '63a852b'
-    assert rev2.created_at == parser.parse('2020-06-29T22:11:10')
-    assert rev2.status == 'approved'
+    assert rev2.version == "63a852b"
+    assert rev2.created_at == parser.parse("2020-06-29T22:11:10")
+    assert rev2.status == "approved"
     assert rev2.errors == []
 
 
 def test_status_with_resources(client_mock, config):
     """Get all the release information."""
     client_mock.get.return_value = {
-        'channel-map': [
+        "channel-map": [
             {
-                'channel': 'latest/stable',
-                'expiration-date': None,
-                'platform': {'architecture': 'all', 'os': 'all', 'series': 'all'},
-                'progressive': {'paused': None, 'percentage': None},
-                'revision': 5,
-                'when': '2020-07-16T18:45:24Z',
-                'resources': [
+                "channel": "latest/stable",
+                "expiration-date": None,
+                "platform": {"architecture": "all", "os": "all", "series": "all"},
+                "progressive": {"paused": None, "percentage": None},
+                "revision": 5,
+                "when": "2020-07-16T18:45:24Z",
+                "resources": [
                     {
-                        'name': 'test-resource-1',
-                        'revision': 2,
-                        'type': 'file',
+                        "name": "test-resource-1",
+                        "revision": 2,
+                        "type": "file",
                     },
                 ],
-            }, {
-                'channel': 'latest/edge',
-                'expiration-date': '2020-08-16T18:46:02Z',
-                'platform': {'architecture': 'all', 'os': 'all', 'series': 'all'},
-                'progressive': {'paused': None, 'percentage': None},
-                'revision': 5,
-                'when': '2020-07-16T18:46:02Z',
-                'resources': [
+            },
+            {
+                "channel": "latest/edge",
+                "expiration-date": "2020-08-16T18:46:02Z",
+                "platform": {"architecture": "all", "os": "all", "series": "all"},
+                "progressive": {"paused": None, "percentage": None},
+                "revision": 5,
+                "when": "2020-07-16T18:46:02Z",
+                "resources": [
                     {
-                        'name': 'test-resource-1',
-                        'revision': 2,
-                        'type': 'file',
-                    }, {
-                        'name': 'test-resource-2',
-                        'revision': 329,
-                        'type': 'file',
+                        "name": "test-resource-1",
+                        "revision": 2,
+                        "type": "file",
+                    },
+                    {
+                        "name": "test-resource-2",
+                        "revision": 329,
+                        "type": "file",
                     },
                 ],
-            }
+            },
         ],
-        'package': {
-            'channels': [
+        "package": {
+            "channels": [
                 {
-                    'branch': None,
-                    'fallback': None,
-                    'name': 'latest/edge',
-                    'risk': 'edge',
-                    'track': 'latest',
-                }, {
-                    'branch': None,
-                    'fallback': None,
-                    'name': 'latest/stable',
-                    'risk': 'stable',
-                    'track': 'latest',
+                    "branch": None,
+                    "fallback": None,
+                    "name": "latest/edge",
+                    "risk": "edge",
+                    "track": "latest",
+                },
+                {
+                    "branch": None,
+                    "fallback": None,
+                    "name": "latest/stable",
+                    "risk": "stable",
+                    "track": "latest",
                 },
             ]
         },
-        'revisions': [
+        "revisions": [
             {
-                'revision': 5,
-                'version': '5',
-                'created-at': '2020-06-29T22:11:05',
-                'status': 'approved',
-                'errors': None,
+                "revision": 5,
+                "version": "5",
+                "created-at": "2020-06-29T22:11:05",
+                "status": "approved",
+                "errors": None,
             },
         ],
     }
 
     store = Store(config.charmhub)
-    channel_map, _, _ = store.list_releases('testname')
+    channel_map, _, _ = store.list_releases("testname")
 
     # check response
     cmap1, cmap2 = channel_map
 
     assert cmap1.revision == 5
-    assert cmap1.channel == 'latest/stable'
+    assert cmap1.channel == "latest/stable"
     assert cmap1.expires_at is None
     (res,) = cmap1.resources
-    assert res.name == 'test-resource-1'
+    assert res.name == "test-resource-1"
     assert res.revision == 2
-    assert res.resource_type == 'file'
+    assert res.resource_type == "file"
 
     assert cmap2.revision == 5
-    assert cmap2.channel == 'latest/edge'
-    assert cmap2.expires_at == parser.parse('2020-08-16T18:46:02Z')
+    assert cmap2.channel == "latest/edge"
+    assert cmap2.expires_at == parser.parse("2020-08-16T18:46:02Z")
     (res1, res2) = cmap2.resources
-    assert res1.name == 'test-resource-1'
+    assert res1.name == "test-resource-1"
     assert res1.revision == 2
-    assert res1.resource_type == 'file'
-    assert res2.name == 'test-resource-2'
+    assert res1.resource_type == "file"
+    assert res2.name == "test-resource-2"
     assert res2.revision == 329
-    assert res2.resource_type == 'file'
+    assert res2.resource_type == "file"
 
 
 # -- tests for library related functions
@@ -716,48 +755,51 @@ def test_status_with_resources(client_mock, config):
 def test_create_library_id(client_mock, config):
     """Create a new library in the store."""
     store = Store(config.charmhub)
-    client_mock.post.return_value = {'library-id': 'test-lib-id'}
+    client_mock.post.return_value = {"library-id": "test-lib-id"}
 
-    result = store.create_library_id('test-charm-name', 'test-lib-name')
+    result = store.create_library_id("test-charm-name", "test-lib-name")
 
     assert client_mock.mock_calls == [
-        call.post('/v1/charm/libraries/test-charm-name', {'library-name': 'test-lib-name'}),
+        call.post(
+            "/v1/charm/libraries/test-charm-name", {"library-name": "test-lib-name"}
+        ),
     ]
-    assert result == 'test-lib-id'
+    assert result == "test-lib-id"
 
 
 def test_create_library_revision(client_mock, config):
     """Create a new library revision in the store."""
-    test_charm_name = 'test-charm-name'
-    test_lib_name = 'test-lib-name'
-    test_lib_id = 'test-lib-id'
-    test_api = 'test-api-version'
-    test_patch = 'test-patch-version'
-    test_content = 'test content with quite a lot of funny Python code :p'
-    test_hash = '1234'
+    test_charm_name = "test-charm-name"
+    test_lib_name = "test-lib-name"
+    test_lib_id = "test-lib-id"
+    test_api = "test-api-version"
+    test_patch = "test-patch-version"
+    test_content = "test content with quite a lot of funny Python code :p"
+    test_hash = "1234"
 
     store = Store(config.charmhub)
     client_mock.post.return_value = {
-        'api': test_api,
-        'content': test_content,
-        'hash': test_hash,
-        'library-id': test_lib_id,
-        'library-name': test_lib_name,
-        'charm-name': test_charm_name,
-        'patch': test_patch,
+        "api": test_api,
+        "content": test_content,
+        "hash": test_hash,
+        "library-id": test_lib_id,
+        "library-name": test_lib_name,
+        "charm-name": test_charm_name,
+        "patch": test_patch,
     }
 
     result_lib = store.create_library_revision(
-        test_charm_name, test_lib_id, test_api, test_patch, test_content, test_hash)
+        test_charm_name, test_lib_id, test_api, test_patch, test_content, test_hash
+    )
 
     payload = {
-        'api': test_api,
-        'patch': test_patch,
-        'content': test_content,
-        'hash': test_hash,
+        "api": test_api,
+        "patch": test_patch,
+        "content": test_content,
+        "hash": test_hash,
     }
     assert client_mock.mock_calls == [
-        call.post('/v1/charm/libraries/test-charm-name/' + test_lib_id, payload),
+        call.post("/v1/charm/libraries/test-charm-name/" + test_lib_id, payload),
     ]
     assert result_lib.api == test_api
     assert result_lib.content == test_content
@@ -770,29 +812,33 @@ def test_create_library_revision(client_mock, config):
 
 def test_get_library(client_mock, config):
     """Get all the information (including content) for a library revision."""
-    test_charm_name = 'test-charm-name'
-    test_lib_name = 'test-lib-name'
-    test_lib_id = 'test-lib-id'
-    test_api = 'test-api-version'
-    test_patch = 'test-patch-version'
-    test_content = 'test content with quite a lot of funny Python code :p'
-    test_hash = '1234'
+    test_charm_name = "test-charm-name"
+    test_lib_name = "test-lib-name"
+    test_lib_id = "test-lib-id"
+    test_api = "test-api-version"
+    test_patch = "test-patch-version"
+    test_content = "test content with quite a lot of funny Python code :p"
+    test_hash = "1234"
 
     store = Store(config.charmhub)
     client_mock.get.return_value = {
-        'api': test_api,
-        'content': test_content,
-        'hash': test_hash,
-        'library-id': test_lib_id,
-        'library-name': test_lib_name,
-        'charm-name': test_charm_name,
-        'patch': test_patch,
+        "api": test_api,
+        "content": test_content,
+        "hash": test_hash,
+        "library-id": test_lib_id,
+        "library-name": test_lib_name,
+        "charm-name": test_charm_name,
+        "patch": test_patch,
     }
 
     result_lib = store.get_library(test_charm_name, test_lib_id, test_api)
 
     assert client_mock.mock_calls == [
-        call.get('/v1/charm/libraries/test-charm-name/{}?api={}'.format(test_lib_id, test_api)),
+        call.get(
+            "/v1/charm/libraries/test-charm-name/{}?api={}".format(
+                test_lib_id, test_api
+            )
+        ),
     ]
     assert result_lib.api == test_api
     assert result_lib.content == test_content
@@ -805,122 +851,149 @@ def test_get_library(client_mock, config):
 
 def test_get_tips_simple(client_mock, config):
     """Get info for a lib, simple case with successful result."""
-    test_charm_name = 'test-charm-name'
-    test_lib_name = 'test-lib-name'
-    test_lib_id = 'test-lib-id'
-    test_api = 'test-api-version'
-    test_patch = 'test-patch-version'
-    test_content = 'test content with quite a lot of funny Python code :p'
-    test_hash = '1234'
+    test_charm_name = "test-charm-name"
+    test_lib_name = "test-lib-name"
+    test_lib_id = "test-lib-id"
+    test_api = "test-api-version"
+    test_patch = "test-patch-version"
+    test_content = "test content with quite a lot of funny Python code :p"
+    test_hash = "1234"
 
     store = Store(config.charmhub)
-    client_mock.post.return_value = {'libraries': [{
-        'api': test_api,
-        'content': test_content,
-        'hash': test_hash,
-        'library-id': test_lib_id,
-        'library-name': test_lib_name,
-        'charm-name': test_charm_name,
-        'patch': test_patch,
-    }]}
+    client_mock.post.return_value = {
+        "libraries": [
+            {
+                "api": test_api,
+                "content": test_content,
+                "hash": test_hash,
+                "library-id": test_lib_id,
+                "library-name": test_lib_name,
+                "charm-name": test_charm_name,
+                "patch": test_patch,
+            }
+        ]
+    }
 
     query_info = [
-        {'lib_id': test_lib_id},
+        {"lib_id": test_lib_id},
     ]
     result = store.get_libraries_tips(query_info)
 
     payload = [
-        {'library-id': test_lib_id},
+        {"library-id": test_lib_id},
     ]
     assert client_mock.mock_calls == [
-        call.post('/v1/charm/libraries/bulk', payload),
+        call.post("/v1/charm/libraries/bulk", payload),
     ]
     expected = {
         (test_lib_id, test_api): Library(
-            api=test_api, content=test_content, content_hash=test_hash, lib_id=test_lib_id,
-            lib_name=test_lib_name, charm_name=test_charm_name, patch=test_patch),
+            api=test_api,
+            content=test_content,
+            content_hash=test_hash,
+            lib_id=test_lib_id,
+            lib_name=test_lib_name,
+            charm_name=test_charm_name,
+            patch=test_patch,
+        ),
     }
     assert result == expected
 
 
 def test_get_tips_empty(client_mock, config):
     """Get info for a lib, with an empty response."""
-    test_lib_id = 'test-lib-id'
+    test_lib_id = "test-lib-id"
 
     store = Store(config.charmhub)
-    client_mock.post.return_value = {'libraries': []}
+    client_mock.post.return_value = {"libraries": []}
 
     query_info = [
-        {'lib_id': test_lib_id},
+        {"lib_id": test_lib_id},
     ]
     result = store.get_libraries_tips(query_info)
 
     payload = [
-        {'library-id': test_lib_id},
+        {"library-id": test_lib_id},
     ]
     assert client_mock.mock_calls == [
-        call.post('/v1/charm/libraries/bulk', payload),
+        call.post("/v1/charm/libraries/bulk", payload),
     ]
     assert result == {}
 
 
 def test_get_tips_several(client_mock, config):
     """Get info for multiple libs at once."""
-    test_charm_name_1 = 'test-charm-name-1'
-    test_lib_name_1 = 'test-lib-name-1'
-    test_lib_id_1 = 'test-lib-id-1'
-    test_api_1 = 'test-api-version-1'
-    test_patch_1 = 'test-patch-version-1'
-    test_content_1 = 'test content with quite a lot of funny Python code :p'
-    test_hash_1 = '1234'
+    test_charm_name_1 = "test-charm-name-1"
+    test_lib_name_1 = "test-lib-name-1"
+    test_lib_id_1 = "test-lib-id-1"
+    test_api_1 = "test-api-version-1"
+    test_patch_1 = "test-patch-version-1"
+    test_content_1 = "test content with quite a lot of funny Python code :p"
+    test_hash_1 = "1234"
 
-    test_charm_name_2 = 'test-charm-name-2'
-    test_lib_name_2 = 'test-lib-name-2'
-    test_lib_id_2 = 'test-lib-id-2'
-    test_api_2 = 'test-api-version-2'
-    test_patch_2 = 'test-patch-version-2'
-    test_content_2 = 'more awesome Python code :)'
-    test_hash_2 = '5678'
+    test_charm_name_2 = "test-charm-name-2"
+    test_lib_name_2 = "test-lib-name-2"
+    test_lib_id_2 = "test-lib-id-2"
+    test_api_2 = "test-api-version-2"
+    test_patch_2 = "test-patch-version-2"
+    test_content_2 = "more awesome Python code :)"
+    test_hash_2 = "5678"
 
     store = Store(config.charmhub)
-    client_mock.post.return_value = {'libraries': [{
-        'api': test_api_1,
-        'content': test_content_1,
-        'hash': test_hash_1,
-        'library-id': test_lib_id_1,
-        'library-name': test_lib_name_1,
-        'charm-name': test_charm_name_1,
-        'patch': test_patch_1,
-    }, {
-        'api': test_api_2,
-        'content': test_content_2,
-        'hash': test_hash_2,
-        'library-id': test_lib_id_2,
-        'library-name': test_lib_name_2,
-        'charm-name': test_charm_name_2,
-        'patch': test_patch_2,
-    }]}
+    client_mock.post.return_value = {
+        "libraries": [
+            {
+                "api": test_api_1,
+                "content": test_content_1,
+                "hash": test_hash_1,
+                "library-id": test_lib_id_1,
+                "library-name": test_lib_name_1,
+                "charm-name": test_charm_name_1,
+                "patch": test_patch_1,
+            },
+            {
+                "api": test_api_2,
+                "content": test_content_2,
+                "hash": test_hash_2,
+                "library-id": test_lib_id_2,
+                "library-name": test_lib_name_2,
+                "charm-name": test_charm_name_2,
+                "patch": test_patch_2,
+            },
+        ]
+    }
 
     query_info = [
-        {'lib_id': test_lib_id_1},
-        {'lib_id': test_lib_id_2},
+        {"lib_id": test_lib_id_1},
+        {"lib_id": test_lib_id_2},
     ]
     result = store.get_libraries_tips(query_info)
 
     payload = [
-        {'library-id': test_lib_id_1},
-        {'library-id': test_lib_id_2},
+        {"library-id": test_lib_id_1},
+        {"library-id": test_lib_id_2},
     ]
     assert client_mock.mock_calls == [
-        call.post('/v1/charm/libraries/bulk', payload),
+        call.post("/v1/charm/libraries/bulk", payload),
     ]
     expected = {
         (test_lib_id_1, test_api_1): Library(
-            api=test_api_1, content=test_content_1, content_hash=test_hash_1, lib_id=test_lib_id_1,
-            lib_name=test_lib_name_1, charm_name=test_charm_name_1, patch=test_patch_1),
+            api=test_api_1,
+            content=test_content_1,
+            content_hash=test_hash_1,
+            lib_id=test_lib_id_1,
+            lib_name=test_lib_name_1,
+            charm_name=test_charm_name_1,
+            patch=test_patch_1,
+        ),
         (test_lib_id_2, test_api_2): Library(
-            api=test_api_2, content=test_content_2, content_hash=test_hash_2, lib_id=test_lib_id_2,
-            lib_name=test_lib_name_2, charm_name=test_charm_name_2, patch=test_patch_2),
+            api=test_api_2,
+            content=test_content_2,
+            content_hash=test_hash_2,
+            lib_id=test_lib_id_2,
+            lib_name=test_lib_name_2,
+            charm_name=test_charm_name_2,
+            patch=test_patch_2,
+        ),
     }
     assert result == expected
 
@@ -928,179 +1001,191 @@ def test_get_tips_several(client_mock, config):
 def test_get_tips_query_combinations(client_mock, config):
     """Use all the combinations to specify what's queried."""
     store = Store(config.charmhub)
-    client_mock.post.return_value = {'libraries': []}
+    client_mock.post.return_value = {"libraries": []}
 
     query_info = [
-        {'lib_id': 'test-lib-id-1'},
-        {'lib_id': 'test-lib-id-2', 'api': 2},
-        {'charm_name': 'test-charm-name-3'},
-        {'charm_name': 'test-charm-name-4', 'api': 4},
-        {'charm_name': 'test-charm-name-5', 'lib_name': 'test-lib-name-5'},
-        {'charm_name': 'test-charm-name-6', 'lib_name': 'test-lib-name-6', 'api': 6},
+        {"lib_id": "test-lib-id-1"},
+        {"lib_id": "test-lib-id-2", "api": 2},
+        {"charm_name": "test-charm-name-3"},
+        {"charm_name": "test-charm-name-4", "api": 4},
+        {"charm_name": "test-charm-name-5", "lib_name": "test-lib-name-5"},
+        {"charm_name": "test-charm-name-6", "lib_name": "test-lib-name-6", "api": 6},
     ]
     store.get_libraries_tips(query_info)
 
     payload = [
-        {'library-id': 'test-lib-id-1'},
-        {'library-id': 'test-lib-id-2', 'api': 2},
-        {'charm-name': 'test-charm-name-3'},
-        {'charm-name': 'test-charm-name-4', 'api': 4},
-        {'charm-name': 'test-charm-name-5', 'library-name': 'test-lib-name-5'},
-        {'charm-name': 'test-charm-name-6', 'library-name': 'test-lib-name-6', 'api': 6},
+        {"library-id": "test-lib-id-1"},
+        {"library-id": "test-lib-id-2", "api": 2},
+        {"charm-name": "test-charm-name-3"},
+        {"charm-name": "test-charm-name-4", "api": 4},
+        {"charm-name": "test-charm-name-5", "library-name": "test-lib-name-5"},
+        {
+            "charm-name": "test-charm-name-6",
+            "library-name": "test-lib-name-6",
+            "api": 6,
+        },
     ]
     assert client_mock.mock_calls == [
-        call.post('/v1/charm/libraries/bulk', payload),
+        call.post("/v1/charm/libraries/bulk", payload),
     ]
 
 
 # -- tests for list resources
 
+
 def test_list_resources_ok(client_mock, config):
     """One resource ok."""
     store = Store(config.charmhub)
-    client_mock.get.return_value = {'resources': [
-        {
-            'name': 'testresource',
-            'optional': True,
-            'revision': 9,
-            'type': 'file',
-        },
-    ]}
+    client_mock.get.return_value = {
+        "resources": [
+            {
+                "name": "testresource",
+                "optional": True,
+                "revision": 9,
+                "type": "file",
+            },
+        ]
+    }
 
-    result = store.list_resources('some-name')
+    result = store.list_resources("some-name")
 
-    assert client_mock.mock_calls == [
-        call.get('/v1/charm/some-name/resources')
-    ]
+    assert client_mock.mock_calls == [call.get("/v1/charm/some-name/resources")]
 
     (item,) = result
-    assert item.name == 'testresource'
+    assert item.name == "testresource"
     assert item.optional
     assert item.revision == 9
-    assert item.resource_type == 'file'
+    assert item.resource_type == "file"
 
 
 def test_list_resources_empty(client_mock, config):
     """No resources listed."""
     store = Store(config.charmhub)
-    client_mock.get.return_value = {'resources': []}
+    client_mock.get.return_value = {"resources": []}
 
-    result = store.list_resources('some-name')
+    result = store.list_resources("some-name")
 
-    assert client_mock.mock_calls == [
-        call.get('/v1/charm/some-name/resources')
-    ]
+    assert client_mock.mock_calls == [call.get("/v1/charm/some-name/resources")]
     assert result == []
 
 
 def test_list_resources_several(client_mock, config):
     """Several items returned."""
-    client_mock.get.return_value = {'resources': [
-        {
-            'name': 'testresource1',
-            'optional': True,
-            'revision': 123,
-            'type': 'file',
-        }, {
-            'name': 'testresource2',
-            'optional': False,
-            'revision': 678,
-            'type': 'file',
-        }
-    ]}
+    client_mock.get.return_value = {
+        "resources": [
+            {
+                "name": "testresource1",
+                "optional": True,
+                "revision": 123,
+                "type": "file",
+            },
+            {
+                "name": "testresource2",
+                "optional": False,
+                "revision": 678,
+                "type": "file",
+            },
+        ]
+    }
 
     store = Store(config.charmhub)
-    result = store.list_resources('some-name')
+    result = store.list_resources("some-name")
 
     (item1, item2) = result
 
-    assert item1.name == 'testresource1'
+    assert item1.name == "testresource1"
     assert item1.optional is True
     assert item1.revision == 123
-    assert item1.resource_type == 'file'
+    assert item1.resource_type == "file"
 
-    assert item2.name == 'testresource2'
+    assert item2.name == "testresource2"
     assert item2.optional is False
     assert item2.revision == 678
-    assert item2.resource_type == 'file'
+    assert item2.resource_type == "file"
 
 
 # -- tests for list resource revisions
 
+
 def test_list_resource_revisions_ok(client_mock, config):
     """One resource revision ok."""
     store = Store(config.charmhub)
-    client_mock.get.return_value = {'revisions': [
-        {
-            'created-at': '2021-02-11T13:43:22.396606',
-            'name': 'otherstuff',
-            'revision': 1,
-            'sha256': '1bf0399c2de1240777ba73785f1ff1de5331f12853765a0',
-            'sha3-384': 'deb9369cb2b9e86ad44160e93da43d240e6388c5dc67b8e2a5a3c2a36a26fe4c89',
-            'sha384': 'eaaba6aa119da415e6ad778358a8530c47fefbe3ceced258e8c25530107dc7908e',
-            'sha512': 'b8cfe885d49285d8546885167a72fd56ea23480e17c9cdd8e06b45239d79b774c6d6fc09d',
-            'size': 500
-        },
-    ]}
+    client_mock.get.return_value = {
+        "revisions": [
+            {
+                "created-at": "2021-02-11T13:43:22.396606",
+                "name": "otherstuff",
+                "revision": 1,
+                "sha256": "1bf0399c2de1240777ba73785f1ff1de5331f12853765a0",
+                "sha3-384": "deb9369cb2b9e86ad44160e93da43d240e6388c5dc67b8e2a5a3c2a36a26fe4c89",
+                "sha384": "eaaba6aa119da415e6ad778358a8530c47fefbe3ceced258e8c25530107dc7908e",
+                "sha512": "b8cfe885d49285d8546885167a72fd56ea23480e17c9cdd8e06b45239d79b774c6d6fc09d",
+                "size": 500,
+            },
+        ]
+    }
 
-    result = store.list_resource_revisions('charm-name', 'resource-name')
+    result = store.list_resource_revisions("charm-name", "resource-name")
 
     assert client_mock.mock_calls == [
-        call.get('/v1/charm/charm-name/resources/resource-name/revisions')
+        call.get("/v1/charm/charm-name/resources/resource-name/revisions")
     ]
 
     (item,) = result
     assert item.revision == 1
-    assert item.created_at == parser.parse('2021-02-11T13:43:22.396606')
+    assert item.created_at == parser.parse("2021-02-11T13:43:22.396606")
     assert item.size == 500
 
 
 def test_list_resource_revisions_empty(client_mock, config):
     """No resource revisions listed."""
     store = Store(config.charmhub)
-    client_mock.get.return_value = {'revisions': []}
+    client_mock.get.return_value = {"revisions": []}
 
-    result = store.list_resource_revisions('charm-name', 'resource-name')
+    result = store.list_resource_revisions("charm-name", "resource-name")
 
     assert client_mock.mock_calls == [
-        call.get('/v1/charm/charm-name/resources/resource-name/revisions')
+        call.get("/v1/charm/charm-name/resources/resource-name/revisions")
     ]
     assert result == []
 
 
 def test_list_resource_revisions_several(client_mock, config):
     """Several items returned."""
-    client_mock.get.return_value = {'revisions': [
-        {
-            'created-at': '2021-02-11T13:43:22.396606',
-            'name': 'otherstuff',
-            'revision': 1,
-            'sha256': '1bf0399c2de1240777ba73785f1ff1de5331f12853765a0',
-            'sha3-384': 'deb9369cb2b9e86ad44160e93da43d240e6388c5dc67b8e2a5a3c2a36a26fe4c89',
-            'sha384': 'eaaba6aa119da415e6ad778358a8530c47fefbe3ceced258e8c25530107dc7908e',
-            'sha512': 'b8cfe885d49285d8546885167a72fd56ea23480e17c9cdd8e06b45239d79b774c6d6fc09d',
-            'size': 500
-        }, {
-            'created-at': '2021-02-11T14:23:55.659148',
-            'name': 'otherstuff',
-            'revision': 2,
-            'sha256': '73785f1ff1de5331f12853765a01bf0399c2de1240777ba',
-            'sha3-384': '60e93da43d240e6388c5dc67b8e2a5a3c2a36a26fe4c89deb9369cb2b5e86ad441',
-            'sha384': '778358a8530c47fefbe3ceced258e8c25530107dc7908eeaaba6aa119dad15e6ad',
-            'sha512': '05167a72fd56ea23480e17c9cdd8e06b45239d79b774c6d6fc09db8cfe885d49285d8547c',
-            'size': 420,
-        },
-    ]}
+    client_mock.get.return_value = {
+        "revisions": [
+            {
+                "created-at": "2021-02-11T13:43:22.396606",
+                "name": "otherstuff",
+                "revision": 1,
+                "sha256": "1bf0399c2de1240777ba73785f1ff1de5331f12853765a0",
+                "sha3-384": "deb9369cb2b9e86ad44160e93da43d240e6388c5dc67b8e2a5a3c2a36a26fe4c89",
+                "sha384": "eaaba6aa119da415e6ad778358a8530c47fefbe3ceced258e8c25530107dc7908e",
+                "sha512": "b8cfe885d49285d8546885167a72fd56ea23480e17c9cdd8e06b45239d79b774c6d6fc09d",
+                "size": 500,
+            },
+            {
+                "created-at": "2021-02-11T14:23:55.659148",
+                "name": "otherstuff",
+                "revision": 2,
+                "sha256": "73785f1ff1de5331f12853765a01bf0399c2de1240777ba",
+                "sha3-384": "60e93da43d240e6388c5dc67b8e2a5a3c2a36a26fe4c89deb9369cb2b5e86ad441",
+                "sha384": "778358a8530c47fefbe3ceced258e8c25530107dc7908eeaaba6aa119dad15e6ad",
+                "sha512": "05167a72fd56ea23480e17c9cdd8e06b45239d79b774c6d6fc09db8cfe885d49285d8547c",
+                "size": 420,
+            },
+        ]
+    }
 
     store = Store(config.charmhub)
-    result = store.list_resource_revisions('charm-name', 'resource-name')
+    result = store.list_resource_revisions("charm-name", "resource-name")
 
     (item1, item2) = result
 
     assert item1.revision == 1
-    assert item1.created_at == parser.parse('2021-02-11T13:43:22.396606')
+    assert item1.created_at == parser.parse("2021-02-11T13:43:22.396606")
     assert item1.size == 500
 
     assert item2.revision == 2
-    assert item2.created_at == parser.parse('2021-02-11T14:23:55.659148')
+    assert item2.created_at == parser.parse("2021-02-11T14:23:55.659148")
     assert item2.size == 420

--- a/tests/commands/test_store_api.py
+++ b/tests/commands/test_store_api.py
@@ -1119,7 +1119,9 @@ def test_list_resource_revisions_ok(client_mock, config):
                 "sha256": "1bf0399c2de1240777ba73785f1ff1de5331f12853765a0",
                 "sha3-384": "deb9369cb2b9e86ad44160e93da43d240e6388c5dc67b8e2a5a3c2a36a26fe4c89",
                 "sha384": "eaaba6aa119da415e6ad778358a8530c47fefbe3ceced258e8c25530107dc7908e",
-                "sha512": "b8cfe885d49285d8546885167a72fd56ea23480e17c9cdd8e06b45239d79b774c6d6fc09d",
+                "sha512": (
+                    "b8cfe885d49285d8546885167a72fd56ea23480e17c9cdd8e06b45239d79b774c6d6fc09d"
+                ),
                 "size": 500,
             },
         ]
@@ -1161,7 +1163,9 @@ def test_list_resource_revisions_several(client_mock, config):
                 "sha256": "1bf0399c2de1240777ba73785f1ff1de5331f12853765a0",
                 "sha3-384": "deb9369cb2b9e86ad44160e93da43d240e6388c5dc67b8e2a5a3c2a36a26fe4c89",
                 "sha384": "eaaba6aa119da415e6ad778358a8530c47fefbe3ceced258e8c25530107dc7908e",
-                "sha512": "b8cfe885d49285d8546885167a72fd56ea23480e17c9cdd8e06b45239d79b774c6d6fc09d",
+                "sha512": (
+                    "b8cfe885d49285d8546885167a72fd56ea23480e17c9cdd8e06b45239d79b774c6d6fc09d"
+                ),
                 "size": 500,
             },
             {
@@ -1171,7 +1175,9 @@ def test_list_resource_revisions_several(client_mock, config):
                 "sha256": "73785f1ff1de5331f12853765a01bf0399c2de1240777ba",
                 "sha3-384": "60e93da43d240e6388c5dc67b8e2a5a3c2a36a26fe4c89deb9369cb2b5e86ad441",
                 "sha384": "778358a8530c47fefbe3ceced258e8c25530107dc7908eeaaba6aa119dad15e6ad",
-                "sha512": "05167a72fd56ea23480e17c9cdd8e06b45239d79b774c6d6fc09db8cfe885d49285d8547c",
+                "sha512": (
+                    "05167a72fd56ea23480e17c9cdd8e06b45239d79b774c6d6fc09db8cfe885d49285d8547c"
+                ),
                 "size": 420,
             },
         ]

--- a/tests/commands/test_store_client.py
+++ b/tests/commands/test_store_client.py
@@ -41,32 +41,43 @@ from charmcraft.utils import OSPlatform
 
 # --- General tests
 
+
 def test_useragent_linux(monkeypatch):
     """Construct a user-agent as a patched Linux machine"""
     monkeypatch.setenv("TRAVIS_TESTING", "1")
-    os_platform = OSPlatform(system="Arch Linux", release="5.10.10-arch1-1", machine="x86_64")
-    with patch('charmcraft.commands.store.client.__version__', '1.2.3'), \
-            patch('charmcraft.utils.get_os_platform', return_value=os_platform), \
-            patch('platform.system', return_value='Linux'), \
-            patch('platform.machine', return_value='x86_64'), \
-            patch('platform.python_version', return_value='3.9.1'):
+    os_platform = OSPlatform(
+        system="Arch Linux", release="5.10.10-arch1-1", machine="x86_64"
+    )
+    with patch("charmcraft.commands.store.client.__version__", "1.2.3"), patch(
+        "charmcraft.utils.get_os_platform", return_value=os_platform
+    ), patch("platform.system", return_value="Linux"), patch(
+        "platform.machine", return_value="x86_64"
+    ), patch(
+        "platform.python_version", return_value="3.9.1"
+    ):
         ua = build_user_agent()
-    assert ua == "charmcraft/1.2.3 (testing) Arch Linux/5.10.10-arch1-1 (x86_64) python/3.9.1"
+    assert (
+        ua
+        == "charmcraft/1.2.3 (testing) Arch Linux/5.10.10-arch1-1 (x86_64) python/3.9.1"
+    )
 
 
 def test_useragent_windows(monkeypatch):
     """Construct a user-agent as a patched Windows machine"""
     monkeypatch.setenv("TRAVIS_TESTING", "1")
-    with patch('charmcraft.commands.store.client.__version__', '1.2.3'), \
-            patch('platform.system', return_value='Windows'), \
-            patch('platform.release', return_value='10'), \
-            patch('platform.machine', return_value='AMD64'), \
-            patch('platform.python_version', return_value='3.9.1'):
+    with patch("charmcraft.commands.store.client.__version__", "1.2.3"), patch(
+        "platform.system", return_value="Windows"
+    ), patch("platform.release", return_value="10"), patch(
+        "platform.machine", return_value="AMD64"
+    ), patch(
+        "platform.python_version", return_value="3.9.1"
+    ):
         ua = build_user_agent()
     assert ua == "charmcraft/1.2.3 (testing) Windows/10 (AMD64) python/3.9.1"
 
 
 # --- AuthHolder tests
+
 
 @pytest.fixture
 def auth_holder(tmp_path):
@@ -80,42 +91,58 @@ def auth_holder(tmp_path):
     """
 
     ah = _AuthHolder()
-    ah._cookiejar_filepath = str(tmp_path / 'test.credentials')
+    ah._cookiejar_filepath = str(tmp_path / "test.credentials")
 
-    with patch('webbrowser.open'):
+    with patch("webbrowser.open"):
         yield ah
 
 
-def get_cookie(value='test'):
+def get_cookie(value="test"):
     """Helper to create a cookie, which is quite long."""
     return Cookie(
-        version=0, name='test-macaroon', value=value, port=None, port_specified=False,
-        domain='snapcraft.io', domain_specified=True, domain_initial_dot=False, path='/',
-        path_specified=True, secure=True, expires=2595425286, discard=False, comment=None,
-        comment_url=None, rest=None, rfc2109=False)
+        version=0,
+        name="test-macaroon",
+        value=value,
+        port=None,
+        port_specified=False,
+        domain="snapcraft.io",
+        domain_specified=True,
+        domain_initial_dot=False,
+        path="/",
+        path_specified=True,
+        secure=True,
+        expires=2595425286,
+        discard=False,
+        comment=None,
+        comment_url=None,
+        rest=None,
+        rfc2109=False,
+    )
 
 
 def test_authholder_cookiejar_filepath():
     """Builds the cookiejar filepath in user's config directory."""
-    with patch('appdirs.user_config_dir') as mock:
-        mock.return_value = 'testpath'
+    with patch("appdirs.user_config_dir") as mock:
+        mock.return_value = "testpath"
         ah = _AuthHolder()
 
-    assert ah._cookiejar_filepath == 'testpath'
-    mock.assert_called_once_with('charmcraft.credentials')
+    assert ah._cookiejar_filepath == "testpath"
+    mock.assert_called_once_with("charmcraft.credentials")
 
 
 def test_authholder_clear_credentials_ok(auth_holder, caplog):
     """Clear credentials removes the file."""
     caplog.set_level(logging.DEBUG, logger="charmcraft.commands")
 
-    with open(auth_holder._cookiejar_filepath, 'wb') as fh:
-        fh.write(b'fake credentials')
+    with open(auth_holder._cookiejar_filepath, "wb") as fh:
+        fh.write(b"fake credentials")
 
     auth_holder.clear_credentials()
 
     assert not os.path.exists(auth_holder._cookiejar_filepath)
-    expected = "Credentials cleared: file {!r} removed".format(auth_holder._cookiejar_filepath)
+    expected = "Credentials cleared: file {!r} removed".format(
+        auth_holder._cookiejar_filepath
+    )
     assert [expected] == [rec.message for rec in caplog.records]
 
 
@@ -127,7 +154,8 @@ def test_authholder_clear_credentials_missing(auth_holder, caplog):
 
     assert not os.path.exists(auth_holder._cookiejar_filepath)
     expected = "Credentials file not found to be removed: {!r}".format(
-        auth_holder._cookiejar_filepath)
+        auth_holder._cookiejar_filepath
+    )
     assert [expected] == [rec.message for rec in caplog.records]
 
 
@@ -144,7 +172,9 @@ def test_authholder_credentials_load_file_present_ok(auth_holder):
     # check credentials
     loaded_cookies = list(auth_holder._cookiejar)
     assert len(loaded_cookies) == 1
-    assert loaded_cookies[0].value == fake_cookie.value  # compare the value as no __eq__ in Cookie
+    assert (
+        loaded_cookies[0].value == fake_cookie.value
+    )  # compare the value as no __eq__ in Cookie
     assert isinstance(auth_holder._cookiejar, MozillaCookieJar)
     assert auth_holder._old_cookies == list(auth_holder._cookiejar)
 
@@ -160,8 +190,8 @@ def test_authholder_credentials_load_file_present_problem(auth_holder, caplog):
     """Support the file to be corrupt (starts blank)."""
     caplog.set_level(logging.WARNING, logger="charmcraft.commands")
 
-    with open(auth_holder._cookiejar_filepath, 'wb') as fh:
-        fh.write(b'this surely is not a valid cookie format :p')
+    with open(auth_holder._cookiejar_filepath, "wb") as fh:
+        fh.write(b"this surely is not a valid cookie format :p")
 
     auth_holder._load_credentials()
 
@@ -175,7 +205,9 @@ def test_authholder_credentials_load_file_missing(auth_holder, caplog):
 
     auth_holder._load_credentials()
 
-    expected = "Credentials file not found: {!r}".format(auth_holder._cookiejar_filepath)
+    expected = "Credentials file not found: {!r}".format(
+        auth_holder._cookiejar_filepath
+    )
     assert [expected] == [rec.message for rec in caplog.records]
     assert auth_holder._old_cookies == []
 
@@ -190,7 +222,7 @@ def test_authholder_credentials_save_notreally(auth_holder):
 
     auth_holder._load_credentials()
 
-    with patch.object(auth_holder._cookiejar, 'save') as mock:
+    with patch.object(auth_holder._cookiejar, "save") as mock:
         auth_holder._save_credentials_if_changed()
     assert mock.call_count == 0
 
@@ -206,35 +238,35 @@ def test_authholder_credentials_save_reallysave(auth_holder):
     # make auth holder to have those credentials loaded, and also load them ourselves for
     # later comparison
     auth_holder._load_credentials()
-    with open(auth_holder._cookiejar_filepath, 'rb') as fh:
+    with open(auth_holder._cookiejar_filepath, "rb") as fh:
         prv_file_content = fh.read()
 
     # set a different credential in the auth_holder (mimickin that the user authenticated
     # while doing the request)
-    other_cookie = get_cookie(value='different')
+    other_cookie = get_cookie(value="different")
     auth_holder._cookiejar.set_cookie(other_cookie)
 
     # call the tested method and ensure that file changed!
     auth_holder._save_credentials_if_changed()
-    with open(auth_holder._cookiejar_filepath, 'rb') as fh:
+    with open(auth_holder._cookiejar_filepath, "rb") as fh:
         new_file_content = fh.read()
     assert new_file_content != prv_file_content
 
     # call the tested method again, to verify that it was calling save on the cookiejar (and
     # not that the file changed as other side effect)
-    with patch.object(auth_holder._cookiejar, 'save') as mock:
+    with patch.object(auth_holder._cookiejar, "save") as mock:
         auth_holder._save_credentials_if_changed()
     assert mock.call_count == 1
 
 
 def test_authholder_credentials_save_createsdir(auth_holder, tmp_path):
     """Save creates the directory if not there."""
-    weird_filepath = tmp_path / 'not_created_dir' / 'deep' / 'credentials'
+    weird_filepath = tmp_path / "not_created_dir" / "deep" / "credentials"
     auth_holder._cookiejar_filepath = str(weird_filepath)
     auth_holder._load_credentials()
 
     # set a cookie and ask for saving it
-    auth_holder._cookiejar.set_cookie(get_cookie(value='different'))
+    auth_holder._cookiejar.set_cookie(get_cookie(value="different"))
     auth_holder._save_credentials_if_changed()
 
     # file should be there, and have the right permissions
@@ -249,14 +281,14 @@ def test_authholder_request_simple(auth_holder):
     fake_cookiejar.set_cookie(get_cookie())
     fake_cookiejar.save()
 
-    other_cookie = get_cookie(value='different')
+    other_cookie = get_cookie(value="different")
 
     def fake_request(self, method, url, json, headers):
         # check it was properly called
-        assert method == 'testmethod'
-        assert url == 'testurl'
-        assert json == 'testbody'
-        assert headers == {'User-Agent': build_user_agent()}
+        assert method == "testmethod"
+        assert url == "testurl"
+        assert json == "testbody"
+        assert headers == {"User-Agent": build_user_agent()}
 
         # check credentials were loaded at this time
         assert auth_holder._cookiejar is not None
@@ -264,13 +296,13 @@ def test_authholder_request_simple(auth_holder):
         # modify the credentials, to simulate that a re-auth happened while the request
         auth_holder._cookiejar.set_cookie(other_cookie)
 
-        return 'raw request response'
+        return "raw request response"
 
-    with patch('macaroonbakery.httpbakery.Client.request', fake_request):
-        resp = auth_holder.request('testmethod', 'testurl', 'testbody')
+    with patch("macaroonbakery.httpbakery.Client.request", fake_request):
+        resp = auth_holder.request("testmethod", "testurl", "testbody")
 
     # verify response (the calling checks were done above in fake_request helper)
-    assert resp == 'raw request response'
+    assert resp == "raw request response"
 
     # check the credentials were saved (that were properly loaded was also check in above's helper)
     new_cookiejar = MozillaCookieJar(auth_holder._cookiejar_filepath)
@@ -289,8 +321,8 @@ def test_authholder_request_credentials_already_loaded(auth_holder):
     auth_holder._load_credentials()
     auth_holder._load_credentials = None
 
-    with patch('macaroonbakery.httpbakery.Client.request'):
-        auth_holder.request('testmethod', 'testurl', 'testbody')
+    with patch("macaroonbakery.httpbakery.Client.request"):
+        auth_holder.request("testmethod", "testurl", "testbody")
 
 
 def test_authholder_request_interaction_error(auth_holder):
@@ -300,14 +332,17 @@ def test_authholder_request_interaction_error(auth_holder):
     fake_cookiejar.set_cookie(get_cookie())
     fake_cookiejar.save()
 
-    with patch('macaroonbakery.httpbakery.Client.request') as mock:
-        mock.side_effect = httpbakery.InteractionError('bad auth!!')
-        expected = "Authentication failure: cannot start interactive session: bad auth!!"
+    with patch("macaroonbakery.httpbakery.Client.request") as mock:
+        mock.side_effect = httpbakery.InteractionError("bad auth!!")
+        expected = (
+            "Authentication failure: cannot start interactive session: bad auth!!"
+        )
         with pytest.raises(CommandError, match=expected):
-            auth_holder.request('testmethod', 'testurl', 'testbody')
+            auth_holder.request("testmethod", "testurl", "testbody")
 
 
 # --- Client tests
+
 
 class FakeResponse:
     def __init__(self, content, status_code):
@@ -324,20 +359,22 @@ class FakeResponse:
 
 def test_client_get():
     """Passes the correct method."""
-    with patch('charmcraft.commands.store.client._AuthHolder') as mock_auth:
-        client = Client('http://api.test', 'http://storage.test')
-    client.get('/somepath')
+    with patch("charmcraft.commands.store.client._AuthHolder") as mock_auth:
+        client = Client("http://api.test", "http://storage.test")
+    client.get("/somepath")
 
-    mock_auth().request.assert_called_once_with('GET', 'http://api.test/somepath', None)
+    mock_auth().request.assert_called_once_with("GET", "http://api.test/somepath", None)
 
 
 def test_client_post():
     """Passes the correct method."""
-    with patch('charmcraft.commands.store.client._AuthHolder') as mock_auth:
-        client = Client('http://api.test', 'http://storage.test')
-    client.post('/somepath', 'somebody')
+    with patch("charmcraft.commands.store.client._AuthHolder") as mock_auth:
+        client = Client("http://api.test", "http://storage.test")
+    client.post("/somepath", "somebody")
 
-    mock_auth().request.assert_called_once_with('POST', 'http://api.test/somepath', 'somebody')
+    mock_auth().request.assert_called_once_with(
+        "POST", "http://api.test/somepath", "somebody"
+    )
 
 
 def test_client_hit_success_simple(caplog):
@@ -346,12 +383,12 @@ def test_client_hit_success_simple(caplog):
 
     response_value = {"foo": "bar"}
     fake_response = FakeResponse(content=json.dumps(response_value), status_code=200)
-    with patch('charmcraft.commands.store.client._AuthHolder') as mock_auth:
+    with patch("charmcraft.commands.store.client._AuthHolder") as mock_auth:
         mock_auth().request.return_value = fake_response
-        client = Client('http://api.test', 'http://storage.test')
-    result = client._hit('GET', '/somepath')
+        client = Client("http://api.test", "http://storage.test")
+    result = client._hit("GET", "/somepath")
 
-    mock_auth().request.assert_called_once_with('GET', 'http://api.test/somepath', None)
+    mock_auth().request.assert_called_once_with("GET", "http://api.test/somepath", None)
     assert result == response_value
     expected = [
         "Hitting the store: GET http://api.test/somepath None",
@@ -362,10 +399,12 @@ def test_client_hit_success_simple(caplog):
 
 def test_client_hit_url_extra_slash():
     """The configured api url is ok even with an extra slash."""
-    with patch('charmcraft.commands.store.client._AuthHolder') as mock_auth:
-        client = Client("https://local.test:1234/", 'http://storage.test')
-    client._hit('GET', '/somepath')
-    mock_auth().request.assert_called_once_with('GET', 'https://local.test:1234/somepath', None)
+    with patch("charmcraft.commands.store.client._AuthHolder") as mock_auth:
+        client = Client("https://local.test:1234/", "http://storage.test")
+    client._hit("GET", "/somepath")
+    mock_auth().request.assert_called_once_with(
+        "GET", "https://local.test:1234/somepath", None
+    )
 
 
 def test_client_hit_success_withbody(caplog):
@@ -374,12 +413,14 @@ def test_client_hit_success_withbody(caplog):
 
     response_value = {"foo": "bar"}
     fake_response = FakeResponse(content=json.dumps(response_value), status_code=200)
-    with patch('charmcraft.commands.store.client._AuthHolder') as mock_auth:
+    with patch("charmcraft.commands.store.client._AuthHolder") as mock_auth:
         mock_auth().request.return_value = fake_response
-        client = Client('http://api.test', 'http://storage.test')
-    result = client._hit('POST', '/somepath', 'somebody')
+        client = Client("http://api.test", "http://storage.test")
+    result = client._hit("POST", "/somepath", "somebody")
 
-    mock_auth().request.assert_called_once_with('POST', 'http://api.test/somepath', 'somebody')
+    mock_auth().request.assert_called_once_with(
+        "POST", "http://api.test/somepath", "somebody"
+    )
     assert result == response_value
     expected = [
         "Hitting the store: POST http://api.test/somepath somebody",
@@ -392,18 +433,18 @@ def test_client_hit_failure():
     """Hits the server, got a failure."""
     response_value = "raw data"
     fake_response = FakeResponse(content=response_value, status_code=404)
-    with patch('charmcraft.commands.store.client._AuthHolder') as mock_auth:
+    with patch("charmcraft.commands.store.client._AuthHolder") as mock_auth:
         mock_auth().request.return_value = fake_response
-        client = Client('http://api.test', 'http://storage.test')
+        client = Client("http://api.test", "http://storage.test")
 
     expected = r"Failure working with the Store: \[404\] 'raw data'"
     with pytest.raises(CommandError, match=expected):
-        client._hit('GET', '/somepath')
+        client._hit("GET", "/somepath")
 
 
 def test_client_clear_credentials():
-    with patch('charmcraft.commands.store.client._AuthHolder') as mock_auth:
-        client = Client('http://api.test', 'http://storage.test')
+    with patch("charmcraft.commands.store.client._AuthHolder") as mock_auth:
+        client = Client("http://api.test", "http://storage.test")
     client.clear_credentials()
 
     mock_auth().clear_credentials.assert_called_once_with()
@@ -411,35 +452,49 @@ def test_client_clear_credentials():
 
 def test_client_errorparsing_complete():
     """Build the error message using original message and code."""
-    content = json.dumps({"error-list": [{'message': 'error message', 'code': 'test-error'}]})
+    content = json.dumps(
+        {"error-list": [{"message": "error message", "code": "test-error"}]}
+    )
     response = FakeResponse(content=content, status_code=404)
-    result = Client('http://api.test', 'http://storage.test')._parse_store_error(response)
+    result = Client("http://api.test", "http://storage.test")._parse_store_error(
+        response
+    )
     assert result == "Store failure! error message [code: test-error]"
 
 
 def test_client_errorparsing_no_code():
     """Build the error message using original message (even when code in None)."""
-    content = json.dumps({"error-list": [{'message': 'error message', 'code': None}]})
+    content = json.dumps({"error-list": [{"message": "error message", "code": None}]})
     response = FakeResponse(content=content, status_code=404)
-    result = Client('http://api.test', 'http://storage.test')._parse_store_error(response)
+    result = Client("http://api.test", "http://storage.test")._parse_store_error(
+        response
+    )
     assert result == "Store failure! error message"
 
 
 def test_client_errorparsing_multiple():
     """Build the error message coumpounding the different received ones."""
-    content = json.dumps({"error-list": [
-        {'message': 'error 1', 'code': 'test-error-1'},
-        {'message': 'error 2', 'code': None},
-    ]})
+    content = json.dumps(
+        {
+            "error-list": [
+                {"message": "error 1", "code": "test-error-1"},
+                {"message": "error 2", "code": None},
+            ]
+        }
+    )
     response = FakeResponse(content=content, status_code=404)
-    result = Client('http://api.test', 'http://storage.test')._parse_store_error(response)
+    result = Client("http://api.test", "http://storage.test")._parse_store_error(
+        response
+    )
     assert result == "Store failure! error 1 [code: test-error-1]; error 2"
 
 
 def test_client_errorparsing_nojson():
     """Produce a default message if response is not a json."""
-    response = FakeResponse(content='this is not a json', status_code=404)
-    result = Client('http://api.test', 'http://storage.test')._parse_store_error(response)
+    response = FakeResponse(content="this is not a json", status_code=404)
+    result = Client("http://api.test", "http://storage.test")._parse_store_error(
+        response
+    )
     assert result == "Failure working with the Store: [404] 'this is not a json'"
 
 
@@ -447,7 +502,9 @@ def test_client_errorparsing_no_errors_inside():
     """Produce a default message if response has no errors list."""
     content = json.dumps({"another-error-key": "stuff"})
     response = FakeResponse(content=content, status_code=404)
-    result = Client('http://api.test', 'http://storage.test')._parse_store_error(response)
+    result = Client("http://api.test", "http://storage.test")._parse_store_error(
+        response
+    )
     assert result == "Failure working with the Store: [404] " + repr(content)
 
 
@@ -455,15 +512,19 @@ def test_client_errorparsing_empty_errors():
     """Produce a default message if error list is empty."""
     content = json.dumps({"error-list": []})
     response = FakeResponse(content=content, status_code=404)
-    result = Client('http://api.test', 'http://storage.test')._parse_store_error(response)
+    result = Client("http://api.test", "http://storage.test")._parse_store_error(
+        response
+    )
     assert result == "Failure working with the Store: [404] " + repr(content)
 
 
 def test_client_errorparsing_bad_structure():
     """Produce a default message if error list has a bad format."""
-    content = json.dumps({"error-list": ['whatever']})
+    content = json.dumps({"error-list": ["whatever"]})
     response = FakeResponse(content=content, status_code=404)
-    result = Client('http://api.test', 'http://storage.test')._parse_store_error(response)
+    result = Client("http://api.test", "http://storage.test")._parse_store_error(
+        response
+    )
     assert result == "Failure working with the Store: [404] " + repr(content)
 
 
@@ -472,15 +533,17 @@ def test_client_push_simple_ok(caplog, tmp_path, capsys):
     caplog.set_level(logging.DEBUG, logger="charmcraft.commands")
 
     # fake some bytes to push
-    test_filepath = tmp_path / 'supercharm.bin'
-    with test_filepath.open('wb') as fh:
+    test_filepath = tmp_path / "supercharm.bin"
+    with test_filepath.open("wb") as fh:
         fh.write(b"abcdefgh")
 
     def fake_pusher(monitor, storage_base_url):
         """Push bytes in sequence, doing verifications in the middle."""
-        assert storage_base_url == 'http://storage.test'
+        assert storage_base_url == "http://storage.test"
 
-        total_to_push = monitor.len  # not only the saved bytes, but also headers and stuff
+        total_to_push = (
+            monitor.len
+        )  # not only the saved bytes, but also headers and stuff
 
         # one batch
         monitor.read(20)
@@ -494,16 +557,16 @@ def test_client_push_simple_ok(caplog, tmp_path, capsys):
 
         # check monitor is properly built
         assert isinstance(monitor.encoder, MultipartEncoder)
-        filename, fh, ctype = monitor.encoder.fields['binary']
-        assert filename == 'supercharm.bin'
+        filename, fh, ctype = monitor.encoder.fields["binary"]
+        assert filename == "supercharm.bin"
         assert fh.name == str(test_filepath)
         assert ctype == "application/octet-stream"
 
-        content = json.dumps(dict(successful=True, upload_id='test-upload-id'))
+        content = json.dumps(dict(successful=True, upload_id="test-upload-id"))
         return FakeResponse(content=content, status_code=200)
 
-    with patch('charmcraft.commands.store.client._storage_push', fake_pusher):
-        Client('http://api.test', 'http://storage.test').push(test_filepath)
+    with patch("charmcraft.commands.store.client._storage_push", fake_pusher):
+        Client("http://api.test", "http://storage.test").push(test_filepath)
 
     # check proper logs
     expected = [
@@ -515,85 +578,96 @@ def test_client_push_simple_ok(caplog, tmp_path, capsys):
 
 def test_client_push_configured_url_simple(tmp_path, capsys):
     """The storage server can be configured."""
+
     def fake_pusher(monitor, storage_base_url):
         """Check the received URL."""
         assert storage_base_url == "https://local.test:1234"
 
-        content = json.dumps(dict(successful=True, upload_id='test-upload-id'))
+        content = json.dumps(dict(successful=True, upload_id="test-upload-id"))
         return FakeResponse(content=content, status_code=200)
 
-    test_filepath = tmp_path / 'supercharm.bin'
+    test_filepath = tmp_path / "supercharm.bin"
     test_filepath.write_text("abcdefgh")
-    with patch('charmcraft.commands.store.client._storage_push', fake_pusher):
-        Client('http://api.test', 'https://local.test:1234/').push(test_filepath)
+    with patch("charmcraft.commands.store.client._storage_push", fake_pusher):
+        Client("http://api.test", "https://local.test:1234/").push(test_filepath)
 
 
 def test_client_push_configured_url_extra_slash(caplog, tmp_path, capsys):
     """The configured storage url is ok even with an extra slash."""
+
     def fake_pusher(monitor, storage_base_url):
         """Check the received URL."""
         assert storage_base_url == "https://local.test:1234"
 
-        content = json.dumps(dict(successful=True, upload_id='test-upload-id'))
+        content = json.dumps(dict(successful=True, upload_id="test-upload-id"))
         return FakeResponse(content=content, status_code=200)
 
-    test_filepath = tmp_path / 'supercharm.bin'
+    test_filepath = tmp_path / "supercharm.bin"
     test_filepath.write_text("abcdefgh")
-    with patch('charmcraft.commands.store.client._storage_push', fake_pusher):
-        Client('http://api.test', 'https://local.test:1234/').push(test_filepath)
+    with patch("charmcraft.commands.store.client._storage_push", fake_pusher):
+        Client("http://api.test", "https://local.test:1234/").push(test_filepath)
 
 
 def test_client_push_response_not_ok(tmp_path):
     """Didn't get a 200 from the Storage."""
     # fake some bytes to push
-    test_filepath = tmp_path / 'supercharm.bin'
-    with test_filepath.open('wb') as fh:
+    test_filepath = tmp_path / "supercharm.bin"
+    with test_filepath.open("wb") as fh:
         fh.write(b"abcdefgh")
 
-    with patch('charmcraft.commands.store.client._storage_push') as mock:
-        mock.return_value = FakeResponse(content='had a problem', status_code=500)
+    with patch("charmcraft.commands.store.client._storage_push") as mock:
+        mock.return_value = FakeResponse(content="had a problem", status_code=500)
         with pytest.raises(CommandError) as cm:
-            Client('http://api.test', 'http://storage.test').push(test_filepath)
+            Client("http://api.test", "http://storage.test").push(test_filepath)
         assert str(cm.value) == "Failure while pushing file: [500] 'had a problem'"
 
 
 def test_client_push_response_unsuccessful(tmp_path):
     """Didn't get a 200 from the Storage."""
     # fake some bytes to push
-    test_filepath = tmp_path / 'supercharm.bin'
-    with test_filepath.open('wb') as fh:
+    test_filepath = tmp_path / "supercharm.bin"
+    with test_filepath.open("wb") as fh:
         fh.write(b"abcdefgh")
 
-    with patch('charmcraft.commands.store.client._storage_push') as mock:
+    with patch("charmcraft.commands.store.client._storage_push") as mock:
         raw_content = dict(successful=False, upload_id=None)
-        mock.return_value = FakeResponse(content=json.dumps(raw_content), status_code=200)
+        mock.return_value = FakeResponse(
+            content=json.dumps(raw_content), status_code=200
+        )
         with pytest.raises(CommandError) as cm:
-            Client('http://api.test', 'http://storage.test').push(test_filepath)
-        expected = "Server error while pushing file: {'successful': False, 'upload_id': None}"
+            Client("http://api.test", "http://storage.test").push(test_filepath)
+        expected = (
+            "Server error while pushing file: {'successful': False, 'upload_id': None}"
+        )
         assert str(cm.value) == expected
 
 
 def test_storage_push_succesful():
     """Bytes are properly pushed to the Storage."""
-    test_monitor = MultipartEncoderMonitor(MultipartEncoder(
-        fields={"binary": ("filename", 'somefile', "application/octet-stream")}))
+    test_monitor = MultipartEncoderMonitor(
+        MultipartEncoder(
+            fields={"binary": ("filename", "somefile", "application/octet-stream")}
+        )
+    )
 
-    with patch('requests.Session') as mock:
-        _storage_push(test_monitor, 'http://test.url:0000')
+    with patch("requests.Session") as mock:
+        _storage_push(test_monitor, "http://test.url:0000")
     cm_session_mock = mock().__enter__()
 
     # check request was properly called
-    url = 'http://test.url:0000/unscanned-upload/'
+    url = "http://test.url:0000/unscanned-upload/"
     headers = {
-        'Content-Type': test_monitor.content_type,
-        'Accept': 'application/json',
-        'User-Agent': build_user_agent(),
+        "Content-Type": test_monitor.content_type,
+        "Accept": "application/json",
+        "User-Agent": build_user_agent(),
     }
-    cm_session_mock.post.assert_called_once_with(url, headers=headers, data=test_monitor)
+    cm_session_mock.post.assert_called_once_with(
+        url, headers=headers, data=test_monitor
+    )
 
     # check the retries were properly setup
     (protocol, adapter), _ = cm_session_mock.mount.call_args
-    assert protocol == 'https://'
+    assert protocol == "https://"
     assert isinstance(adapter, HTTPAdapter)
     assert adapter.max_retries.backoff_factor == 2
     assert adapter.max_retries.total == 5
@@ -602,12 +676,15 @@ def test_storage_push_succesful():
 
 def test_storage_push_network_error():
     """A generic network error happened."""
-    test_monitor = MultipartEncoderMonitor(MultipartEncoder(
-        fields={"binary": ("filename", 'somefile', "application/octet-stream")}))
+    test_monitor = MultipartEncoderMonitor(
+        MultipartEncoder(
+            fields={"binary": ("filename", "somefile", "application/octet-stream")}
+        )
+    )
 
-    with patch('requests.Session.post') as mock:
+    with patch("requests.Session.post") as mock:
         mock.side_effect = RequestException("naughty error")
         with pytest.raises(CommandError) as cm:
-            _storage_push(test_monitor, 'http://test.url:0000')
+            _storage_push(test_monitor, "http://test.url:0000")
         expected = "Network error when pushing file: RequestException('naughty error')"
         assert str(cm.value) == expected

--- a/tests/commands/test_store_commands.py
+++ b/tests/commands/test_store_commands.py
@@ -380,9 +380,8 @@ def test_get_name_charm_bad_metadata(tmp_path, yaml_content):
     with pytest.raises(CommandError) as cm:
         get_name_from_zip(bad_zip)
     assert str(cm.value) == (
-        "Bad 'metadata.yaml' file inside charm zip '{}': must be a valid YAML with a 'name' key.".format(
-            bad_zip
-        )
+        "Bad 'metadata.yaml' file inside charm zip "
+        "'{}': must be a valid YAML with a 'name' key.".format(bad_zip)
     )
 
 
@@ -411,9 +410,8 @@ def test_get_name_bundle_bad_data(tmp_path, yaml_content):
     with pytest.raises(CommandError) as cm:
         get_name_from_zip(bad_zip)
     assert str(cm.value) == (
-        "Bad 'bundle.yaml' file inside bundle zip '{}': must be a valid YAML with a 'name' key.".format(
-            bad_zip
-        )
+        "Bad 'bundle.yaml' file inside bundle zip '{}': "
+        "must be a valid YAML with a 'name' key.".format(bad_zip)
     )
 
 

--- a/tests/commands/test_store_commands.py
+++ b/tests/commands/test_store_commands.py
@@ -90,7 +90,7 @@ def store_mock():
         assert config == CharmhubConfig()
         return store_mock
 
-    with patch('charmcraft.commands.store.Store', validate_config):
+    with patch("charmcraft.commands.store.Store", validate_config):
         yield store_mock
 
 
@@ -111,13 +111,14 @@ def add_cleanup():
 
 # -- tests for helpers
 
+
 def test_get_name_from_metadata_ok(tmp_path, monkeypatch):
     """The metadata file is valid yaml, but there is no name."""
     monkeypatch.chdir(tmp_path)
 
     # put a valid metadata
-    metadata_file = tmp_path / 'metadata.yaml'
-    with metadata_file.open('wb') as fh:
+    metadata_file = tmp_path / "metadata.yaml"
+    with metadata_file.open("wb") as fh:
         fh.write(b"name: test-name")
 
     result = get_name_from_metadata()
@@ -136,8 +137,8 @@ def test_get_name_from_metadata_bad_content_garbage(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
 
     # put a broken metadata
-    metadata_file = tmp_path / 'metadata.yaml'
-    with metadata_file.open('wb') as fh:
+    metadata_file = tmp_path / "metadata.yaml"
+    with metadata_file.open("wb") as fh:
         fh.write(b"\b00\bff -- not a realy yaml stuff")
 
     result = get_name_from_metadata()
@@ -149,8 +150,8 @@ def test_get_name_from_metadata_bad_content_no_name(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
 
     # put a broken metadata
-    metadata_file = tmp_path / 'metadata.yaml'
-    with metadata_file.open('wb') as fh:
+    metadata_file = tmp_path / "metadata.yaml"
+    with metadata_file.open("wb") as fh:
         fh.write(b"{}")
 
     result = get_name_from_metadata()
@@ -163,9 +164,9 @@ def test_get_name_from_metadata_bad_content_no_name(tmp_path, monkeypatch):
 def test_login(caplog, store_mock, config):
     """Simple login case."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
-    store_mock.whoami.return_value = User(name='John Doe', username='jdoe', userid='-1')
+    store_mock.whoami.return_value = User(name="John Doe", username="jdoe", userid="-1")
 
-    LoginCommand('group', config).run(noargs)
+    LoginCommand("group", config).run(noargs)
 
     assert store_mock.mock_calls == [
         call.login(),
@@ -178,7 +179,7 @@ def test_logout(caplog, store_mock, config):
     """Simple logout case."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
-    LogoutCommand('group', config).run(noargs)
+    LogoutCommand("group", config).run(noargs)
 
     assert store_mock.mock_calls == [
         call.logout(),
@@ -190,18 +191,18 @@ def test_whoami(caplog, store_mock, config):
     """Simple whoami case."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
-    store_response = User(name='John Doe', username='jdoe', userid='-1')
+    store_response = User(name="John Doe", username="jdoe", userid="-1")
     store_mock.whoami.return_value = store_response
 
-    WhoamiCommand('group', config).run(noargs)
+    WhoamiCommand("group", config).run(noargs)
 
     assert store_mock.mock_calls == [
         call.whoami(),
     ]
     expected = [
-        'name:      John Doe',
-        'username:  jdoe',
-        'id:        -1',
+        "name:      John Doe",
+        "username:  jdoe",
+        "id:        -1",
     ]
     assert expected == [rec.message for rec in caplog.records]
 
@@ -213,11 +214,11 @@ def test_register_charm_name(caplog, store_mock, config):
     """Simple register_name case for a charm."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
-    args = Namespace(name='testname')
-    RegisterCharmNameCommand('group', config).run(args)
+    args = Namespace(name="testname")
+    RegisterCharmNameCommand("group", config).run(args)
 
     assert store_mock.mock_calls == [
-        call.register_name('testname', EntityType.charm),
+        call.register_name("testname", EntityType.charm),
     ]
     expected = "You are now the publisher of charm 'testname' in Charmhub."
     assert [expected] == [rec.message for rec in caplog.records]
@@ -227,11 +228,11 @@ def test_register_bundle_name(caplog, store_mock, config):
     """Simple register_name case for a bundl."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
-    args = Namespace(name='testname')
-    RegisterBundleNameCommand('group', config).run(args)
+    args = Namespace(name="testname")
+    RegisterBundleNameCommand("group", config).run(args)
 
     assert store_mock.mock_calls == [
-        call.register_name('testname', EntityType.bundle),
+        call.register_name("testname", EntityType.bundle),
     ]
     expected = "You are now the publisher of bundle 'testname' in Charmhub."
     assert [expected] == [rec.message for rec in caplog.records]
@@ -244,7 +245,7 @@ def test_list_registered_empty(caplog, store_mock, config):
     store_response = []
     store_mock.list_registered_names.return_value = store_response
 
-    ListNamesCommand('group', config).run(noargs)
+    ListNamesCommand("group", config).run(noargs)
 
     assert store_mock.mock_calls == [
         call.list_registered_names(),
@@ -258,11 +259,11 @@ def test_list_registered_one_private(caplog, store_mock, config):
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
     store_response = [
-        Entity(entity_type='charm', name='charm', private=True, status='status'),
+        Entity(entity_type="charm", name="charm", private=True, status="status"),
     ]
     store_mock.list_registered_names.return_value = store_response
 
-    ListNamesCommand('group', config).run(noargs)
+    ListNamesCommand("group", config).run(noargs)
 
     assert store_mock.mock_calls == [
         call.list_registered_names(),
@@ -279,11 +280,11 @@ def test_list_registered_one_public(caplog, store_mock, config):
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
     store_response = [
-        Entity(entity_type='charm', name='charm', private=False, status='status'),
+        Entity(entity_type="charm", name="charm", private=False, status="status"),
     ]
     store_mock.list_registered_names.return_value = store_response
 
-    ListNamesCommand('group', config).run(noargs)
+    ListNamesCommand("group", config).run(noargs)
 
     assert store_mock.mock_calls == [
         call.list_registered_names(),
@@ -300,14 +301,25 @@ def test_list_registered_several(caplog, store_mock, config):
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
     store_response = [
-        Entity(entity_type='charm', name='charm1', private=True, status='simple status'),
-        Entity(entity_type='charm', name='charm2-long-name', private=False, status='other'),
-        Entity(entity_type='charm', name='charm3', private=True, status='super long status'),
-        Entity(entity_type='bundle', name='somebundle', private=False, status='bundle status'),
+        Entity(
+            entity_type="charm", name="charm1", private=True, status="simple status"
+        ),
+        Entity(
+            entity_type="charm", name="charm2-long-name", private=False, status="other"
+        ),
+        Entity(
+            entity_type="charm", name="charm3", private=True, status="super long status"
+        ),
+        Entity(
+            entity_type="bundle",
+            name="somebundle",
+            private=False,
+            status="bundle status",
+        ),
     ]
     store_mock.list_registered_names.return_value = store_response
 
-    ListNamesCommand('group', config).run(noargs)
+    ListNamesCommand("group", config).run(noargs)
 
     assert store_mock.mock_calls == [
         call.list_registered_names(),
@@ -324,17 +336,18 @@ def test_list_registered_several(caplog, store_mock, config):
 
 # -- tests for upload command
 
+
 def _build_zip_with_yaml(zippath, filename, *, content=None, raw_yaml=None):
     """Create a yaml named 'filename' with given content, inside a zip file in 'zippath'."""
     if raw_yaml is None:
-        raw_yaml = yaml.dump(content).encode('ascii')
-    with zipfile.ZipFile(str(zippath), 'w') as zf:
+        raw_yaml = yaml.dump(content).encode("ascii")
+    with zipfile.ZipFile(str(zippath), "w") as zf:
         zf.writestr(filename, raw_yaml)
 
 
 def test_get_name_bad_zip(tmp_path):
     """Get the name from a bad zip file."""
-    bad_zip = tmp_path / 'badstuff.zip'
+    bad_zip = tmp_path / "badstuff.zip"
     bad_zip.write_text("I'm not really a zip file")
 
     with pytest.raises(CommandError) as cm:
@@ -344,74 +357,85 @@ def test_get_name_bad_zip(tmp_path):
 
 def test_get_name_charm_ok(tmp_path):
     """Get the name from a charm file, all ok."""
-    test_zip = tmp_path / 'some.zip'
-    test_name = 'whatever'
-    _build_zip_with_yaml(test_zip, 'metadata.yaml', content={'name': test_name})
+    test_zip = tmp_path / "some.zip"
+    test_name = "whatever"
+    _build_zip_with_yaml(test_zip, "metadata.yaml", content={"name": test_name})
 
     name = get_name_from_zip(test_zip)
     assert name == test_name
 
 
-@pytest.mark.parametrize('yaml_content', [
-    b'=',  # invalid yaml
-    b'foo: bar',  # missing 'name'
-])
+@pytest.mark.parametrize(
+    "yaml_content",
+    [
+        b"=",  # invalid yaml
+        b"foo: bar",  # missing 'name'
+    ],
+)
 def test_get_name_charm_bad_metadata(tmp_path, yaml_content):
     """Get the name from a charm file, but with a wrong metadata.yaml."""
-    bad_zip = tmp_path / 'badstuff.zip'
-    _build_zip_with_yaml(bad_zip, 'metadata.yaml', raw_yaml=yaml_content)
+    bad_zip = tmp_path / "badstuff.zip"
+    _build_zip_with_yaml(bad_zip, "metadata.yaml", raw_yaml=yaml_content)
 
     with pytest.raises(CommandError) as cm:
         get_name_from_zip(bad_zip)
     assert str(cm.value) == (
-        "Bad 'metadata.yaml' file inside charm zip '{}': must be a valid YAML with a 'name' key."
-        .format(bad_zip))
+        "Bad 'metadata.yaml' file inside charm zip '{}': must be a valid YAML with a 'name' key.".format(
+            bad_zip
+        )
+    )
 
 
 def test_get_name_bundle_ok(tmp_path):
     """Get the name from a bundle file, all ok."""
-    test_zip = tmp_path / 'some.zip'
-    test_name = 'whatever'
-    _build_zip_with_yaml(test_zip, 'bundle.yaml', content={'name': test_name})
+    test_zip = tmp_path / "some.zip"
+    test_name = "whatever"
+    _build_zip_with_yaml(test_zip, "bundle.yaml", content={"name": test_name})
 
     name = get_name_from_zip(test_zip)
     assert name == test_name
 
 
-@pytest.mark.parametrize('yaml_content', [
-    b'=',  # invalid yaml
-    b'foo: bar',  # missing 'name'
-])
+@pytest.mark.parametrize(
+    "yaml_content",
+    [
+        b"=",  # invalid yaml
+        b"foo: bar",  # missing 'name'
+    ],
+)
 def test_get_name_bundle_bad_data(tmp_path, yaml_content):
     """Get the name from a bundle file, but with a bad bundle.yaml."""
-    bad_zip = tmp_path / 'badstuff.zip'
-    _build_zip_with_yaml(bad_zip, 'bundle.yaml', raw_yaml=yaml_content)
+    bad_zip = tmp_path / "badstuff.zip"
+    _build_zip_with_yaml(bad_zip, "bundle.yaml", raw_yaml=yaml_content)
 
     with pytest.raises(CommandError) as cm:
         get_name_from_zip(bad_zip)
     assert str(cm.value) == (
-        "Bad 'bundle.yaml' file inside bundle zip '{}': must be a valid YAML with a 'name' key."
-        .format(bad_zip))
+        "Bad 'bundle.yaml' file inside bundle zip '{}': must be a valid YAML with a 'name' key.".format(
+            bad_zip
+        )
+    )
 
 
 def test_get_name_nor_charm_nor_bundle(tmp_path):
     """Get the name from a zip that has no metadata.yaml nor bundle.yaml."""
-    bad_zip = tmp_path / 'badstuff.zip'
-    _build_zip_with_yaml(bad_zip, 'whatever.yaml', content={})
+    bad_zip = tmp_path / "badstuff.zip"
+    _build_zip_with_yaml(bad_zip, "whatever.yaml", content={})
 
     with pytest.raises(CommandError) as cm:
         get_name_from_zip(bad_zip)
     assert str(cm.value) == (
         "The indicated zip file '{}' is not a charm ('metadata.yaml' not found) nor a bundle "
-        "('bundle.yaml' not found).".format(bad_zip))
+        "('bundle.yaml' not found).".format(bad_zip)
+    )
 
 
 def test_upload_parameters_filepath_type(config):
     """The filepath parameter implies a set of validations."""
-    cmd = UploadCommand('group', config)
+    cmd = UploadCommand("group", config)
     parser = ArgumentParser()
     cmd.fill_parser(parser)
-    (action,) = [action for action in parser._actions if action.dest == 'filepath']
+    (action,) = [action for action in parser._actions if action.dest == "filepath"]
     assert action.type is useful_filepath
 
 
@@ -422,14 +446,12 @@ def test_upload_call_ok(caplog, store_mock, config, tmp_path):
     store_response = Uploaded(ok=True, status=200, revision=7, errors=[])
     store_mock.upload.return_value = store_response
 
-    test_charm = tmp_path / 'mystuff.charm'
-    _build_zip_with_yaml(test_charm, 'metadata.yaml', content={'name': 'mycharm'})
+    test_charm = tmp_path / "mystuff.charm"
+    _build_zip_with_yaml(test_charm, "metadata.yaml", content={"name": "mycharm"})
     args = Namespace(filepath=test_charm, release=[])
-    UploadCommand('group', config).run(args)
+    UploadCommand("group", config).run(args)
 
-    assert store_mock.mock_calls == [
-        call.upload('mycharm', test_charm)
-    ]
+    assert store_mock.mock_calls == [call.upload("mycharm", test_charm)]
     expected = "Revision 7 of 'mycharm' created"
     assert [expected] == [rec.message for rec in caplog.records]
 
@@ -439,20 +461,18 @@ def test_upload_call_error(caplog, store_mock, config, tmp_path):
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
     errors = [
-        Error(message="text 1", code='missing-stuff'),
-        Error(message="other long error text", code='broken'),
+        Error(message="text 1", code="missing-stuff"),
+        Error(message="other long error text", code="broken"),
     ]
     store_response = Uploaded(ok=False, status=400, revision=None, errors=errors)
     store_mock.upload.return_value = store_response
 
-    test_charm = tmp_path / 'mystuff.charm'
-    _build_zip_with_yaml(test_charm, 'metadata.yaml', content={'name': 'mycharm'})
+    test_charm = tmp_path / "mystuff.charm"
+    _build_zip_with_yaml(test_charm, "metadata.yaml", content={"name": "mycharm"})
     args = Namespace(filepath=test_charm, release=[])
-    UploadCommand('group', config).run(args)
+    UploadCommand("group", config).run(args)
 
-    assert store_mock.mock_calls == [
-        call.upload('mycharm', test_charm)
-    ]
+    assert store_mock.mock_calls == [call.upload("mycharm", test_charm)]
     expected = [
         "Upload failed with status 400:",
         "- missing-stuff: text 1",
@@ -468,14 +488,14 @@ def test_upload_call_ok_including_release(caplog, store_mock, config, tmp_path):
     store_response = Uploaded(ok=True, status=200, revision=7, errors=[])
     store_mock.upload.return_value = store_response
 
-    test_charm = tmp_path / 'mystuff.charm'
-    _build_zip_with_yaml(test_charm, 'metadata.yaml', content={'name': 'mycharm'})
-    args = Namespace(filepath=test_charm, release=['edge'])
-    UploadCommand('group', config).run(args)
+    test_charm = tmp_path / "mystuff.charm"
+    _build_zip_with_yaml(test_charm, "metadata.yaml", content={"name": "mycharm"})
+    args = Namespace(filepath=test_charm, release=["edge"])
+    UploadCommand("group", config).run(args)
 
     assert store_mock.mock_calls == [
-        call.upload('mycharm', test_charm),
-        call.release('mycharm', 7, ['edge']),
+        call.upload("mycharm", test_charm),
+        call.release("mycharm", 7, ["edge"]),
     ]
     expected = [
         "Revision 7 of 'mycharm' created",
@@ -484,21 +504,23 @@ def test_upload_call_ok_including_release(caplog, store_mock, config, tmp_path):
     assert expected == [rec.message for rec in caplog.records]
 
 
-def test_upload_call_ok_including_release_multiple(caplog, store_mock, config, tmp_path):
+def test_upload_call_ok_including_release_multiple(
+    caplog, store_mock, config, tmp_path
+):
     """Upload with release to two channels included, success result."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
     store_response = Uploaded(ok=True, status=200, revision=7, errors=[])
     store_mock.upload.return_value = store_response
 
-    test_charm = tmp_path / 'mystuff.charm'
-    _build_zip_with_yaml(test_charm, 'metadata.yaml', content={'name': 'mycharm'})
-    args = Namespace(filepath=test_charm, release=['edge', 'stable'])
-    UploadCommand('group', config).run(args)
+    test_charm = tmp_path / "mystuff.charm"
+    _build_zip_with_yaml(test_charm, "metadata.yaml", content={"name": "mycharm"})
+    args = Namespace(filepath=test_charm, release=["edge", "stable"])
+    UploadCommand("group", config).run(args)
 
     assert store_mock.mock_calls == [
-        call.upload('mycharm', test_charm),
-        call.release('mycharm', 7, ['edge', 'stable']),
+        call.upload("mycharm", test_charm),
+        call.release("mycharm", 7, ["edge", "stable"]),
     ]
     expected = [
         "Revision 7 of 'mycharm' created",
@@ -511,39 +533,38 @@ def test_upload_call_error_including_release(caplog, store_mock, config, tmp_pat
     """Upload with a realsea but the upload went wrong, so no release."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
-    errors = [Error(message="text", code='problem')]
+    errors = [Error(message="text", code="problem")]
     store_response = Uploaded(ok=False, status=400, revision=None, errors=errors)
     store_mock.upload.return_value = store_response
 
-    test_charm = tmp_path / 'mystuff.charm'
-    _build_zip_with_yaml(test_charm, 'metadata.yaml', content={'name': 'mycharm'})
-    args = Namespace(filepath=test_charm, release=['edge'])
-    UploadCommand('group', config).run(args)
+    test_charm = tmp_path / "mystuff.charm"
+    _build_zip_with_yaml(test_charm, "metadata.yaml", content={"name": "mycharm"})
+    args = Namespace(filepath=test_charm, release=["edge"])
+    UploadCommand("group", config).run(args)
 
     # check the upload was attempted, but not the release!
-    assert store_mock.mock_calls == [
-        call.upload('mycharm', test_charm)
-    ]
+    assert store_mock.mock_calls == [call.upload("mycharm", test_charm)]
 
 
 def test_upload_charm_with_init_template_todo_token(tmp_path, config):
     """Avoid uploading a charm that is not really ready to be shown to the world."""
     # create a charm zip file all valid but with files having the token from
     # the templates used by 'init' command
-    test_charm = tmp_path / 'mystuff.charm'
-    with zipfile.ZipFile(str(test_charm), 'w') as zf:
-        zf.writestr('metadata.yaml', yaml.dump({'name': 'mycharm'}).encode('ascii'))
-        zf.writestr('somefile.cfg', b"# TEMPLATE-TODO: please take a look to this.")
-        zf.writestr('file_ok.cfg', b"This is fine :).")
-        zf.writestr('othertainted.txt', b"# TEMPLATE-TODO: need to fix.")
+    test_charm = tmp_path / "mystuff.charm"
+    with zipfile.ZipFile(str(test_charm), "w") as zf:
+        zf.writestr("metadata.yaml", yaml.dump({"name": "mycharm"}).encode("ascii"))
+        zf.writestr("somefile.cfg", b"# TEMPLATE-TODO: please take a look to this.")
+        zf.writestr("file_ok.cfg", b"This is fine :).")
+        zf.writestr("othertainted.txt", b"# TEMPLATE-TODO: need to fix.")
 
     args = Namespace(filepath=test_charm, release=[])
     expected_msg = (
         "Cannot upload the charm as it include the following files with a leftover "
         "TEMPLATE-TODO token from when the project was created using the 'init' "
-        "command: somefile.cfg, othertainted.txt")
+        "command: somefile.cfg, othertainted.txt"
+    )
     with pytest.raises(CommandError, match=expected_msg):
-        UploadCommand('group', config).run(args)
+        UploadCommand("group", config).run(args)
 
 
 # -- tests for list revisions command
@@ -555,16 +576,20 @@ def test_revisions_simple(caplog, store_mock, config):
 
     store_response = [
         Revision(
-            revision=1, version='v1', created_at=datetime.datetime(2020, 7, 3, 20, 30, 40),
-            status='accepted', errors=[]),
+            revision=1,
+            version="v1",
+            created_at=datetime.datetime(2020, 7, 3, 20, 30, 40),
+            status="accepted",
+            errors=[],
+        ),
     ]
     store_mock.list_revisions.return_value = store_response
 
-    args = Namespace(name='testcharm')
-    ListRevisionsCommand('group', config).run(args)
+    args = Namespace(name="testcharm")
+    ListRevisionsCommand("group", config).run(args)
 
     assert store_mock.mock_calls == [
-        call.list_revisions('testcharm'),
+        call.list_revisions("testcharm"),
     ]
     expected = [
         "Revision    Version    Created at    Status",
@@ -580,8 +605,8 @@ def test_revisions_empty(caplog, store_mock, config):
     store_response = []
     store_mock.list_revisions.return_value = store_response
 
-    args = Namespace(name='testcharm')
-    ListRevisionsCommand('group', config).run(args)
+    args = Namespace(name="testcharm")
+    ListRevisionsCommand("group", config).run(args)
 
     expected = [
         "No revisions found.",
@@ -597,14 +622,20 @@ def test_revisions_ordered_by_revision(caplog, store_mock, config):
     # we really assert later that it was used for ordering
     tstamp = datetime.datetime(2020, 7, 3, 20, 30, 40)
     store_response = [
-        Revision(revision=1, version='v1', created_at=tstamp, status='accepted', errors=[]),
-        Revision(revision=3, version='v1', created_at=tstamp, status='accepted', errors=[]),
-        Revision(revision=2, version='v1', created_at=tstamp, status='accepted', errors=[]),
+        Revision(
+            revision=1, version="v1", created_at=tstamp, status="accepted", errors=[]
+        ),
+        Revision(
+            revision=3, version="v1", created_at=tstamp, status="accepted", errors=[]
+        ),
+        Revision(
+            revision=2, version="v1", created_at=tstamp, status="accepted", errors=[]
+        ),
     ]
     store_mock.list_revisions.return_value = store_response
 
-    args = Namespace(name='testcharm')
-    ListRevisionsCommand('group', config).run(args)
+    args = Namespace(name="testcharm")
+    ListRevisionsCommand("group", config).run(args)
 
     expected = [
         "Revision    Version    Created at    Status",
@@ -621,13 +652,17 @@ def test_revisions_version_null(caplog, store_mock, config):
 
     store_response = [
         Revision(
-            revision=1, version=None, created_at=datetime.datetime(2020, 7, 3, 20, 30, 40),
-            status='accepted', errors=[]),
+            revision=1,
+            version=None,
+            created_at=datetime.datetime(2020, 7, 3, 20, 30, 40),
+            status="accepted",
+            errors=[],
+        ),
     ]
     store_mock.list_revisions.return_value = store_response
 
-    args = Namespace(name='testcharm')
-    ListRevisionsCommand('group', config).run(args)
+    args = Namespace(name="testcharm")
+    ListRevisionsCommand("group", config).run(args)
 
     expected = [
         "Revision    Version    Created at    Status",
@@ -642,13 +677,17 @@ def test_revisions_errors_simple(caplog, store_mock, config):
 
     store_response = [
         Revision(
-            revision=1, version=None, created_at=datetime.datetime(2020, 7, 3, 20, 30, 40),
-            status='rejected', errors=[Error(message="error text", code='broken')]),
+            revision=1,
+            version=None,
+            created_at=datetime.datetime(2020, 7, 3, 20, 30, 40),
+            status="rejected",
+            errors=[Error(message="error text", code="broken")],
+        ),
     ]
     store_mock.list_revisions.return_value = store_response
 
-    args = Namespace(name='testcharm')
-    ListRevisionsCommand('group', config).run(args)
+    args = Namespace(name="testcharm")
+    ListRevisionsCommand("group", config).run(args)
 
     expected = [
         "Revision    Version    Created at    Status",
@@ -663,16 +702,20 @@ def test_revisions_errors_multiple(caplog, store_mock, config):
 
     store_response = [
         Revision(
-            revision=1, version=None, created_at=datetime.datetime(2020, 7, 3, 20, 30, 40),
-            status='rejected', errors=[
-                Error(message="text 1", code='missing-stuff'),
-                Error(message="other long error text", code='broken'),
-            ]),
+            revision=1,
+            version=None,
+            created_at=datetime.datetime(2020, 7, 3, 20, 30, 40),
+            status="rejected",
+            errors=[
+                Error(message="text 1", code="missing-stuff"),
+                Error(message="other long error text", code="broken"),
+            ],
+        ),
     ]
     store_mock.list_revisions.return_value = store_response
 
-    args = Namespace(name='testcharm')
-    ListRevisionsCommand('group', config).run(args)
+    args = Namespace(name="testcharm")
+    ListRevisionsCommand("group", config).run(args)
 
     expected = [
         "Revision    Version    Created at    Status",
@@ -688,12 +731,12 @@ def test_release_simple_ok(caplog, store_mock, config):
     """Simple case of releasing a revision ok."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
-    channels = ['somechannel']
-    args = Namespace(name='testcharm', revision=7, channel=channels, resource=[])
-    ReleaseCommand('group', config).run(args)
+    channels = ["somechannel"]
+    args = Namespace(name="testcharm", revision=7, channel=channels, resource=[])
+    ReleaseCommand("group", config).run(args)
 
     assert store_mock.mock_calls == [
-        call.release('testcharm', 7, channels, []),
+        call.release("testcharm", 7, channels, []),
     ]
 
     expected = "Revision 7 of charm 'testcharm' released to somechannel"
@@ -705,10 +748,16 @@ def test_release_simple_multiple_channels(caplog, store_mock, config):
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
     args = Namespace(
-        name='testcharm', revision=7, channel=['channel1', 'channel2', 'channel3'], resource=[])
-    ReleaseCommand('group', config).run(args)
+        name="testcharm",
+        revision=7,
+        channel=["channel1", "channel2", "channel3"],
+        resource=[],
+    )
+    ReleaseCommand("group", config).run(args)
 
-    expected = "Revision 7 of charm 'testcharm' released to channel1, channel2, channel3"
+    expected = (
+        "Revision 7 of charm 'testcharm' released to channel1, channel2, channel3"
+    )
     assert [expected] == [rec.message for rec in caplog.records]
 
 
@@ -716,65 +765,103 @@ def test_release_including_resources(caplog, store_mock, config):
     """Releasing with resources."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
-    r1 = ResourceOption(name='foo', revision=3)
-    r2 = ResourceOption(name='bar', revision=17)
-    args = Namespace(name='testcharm', revision=7, channel=['testchannel'], resource=[r1, r2])
-    ReleaseCommand('group', config).run(args)
+    r1 = ResourceOption(name="foo", revision=3)
+    r2 = ResourceOption(name="bar", revision=17)
+    args = Namespace(
+        name="testcharm", revision=7, channel=["testchannel"], resource=[r1, r2]
+    )
+    ReleaseCommand("group", config).run(args)
 
     assert store_mock.mock_calls == [
-        call.release('testcharm', 7, ['testchannel'], [r1, r2]),
+        call.release("testcharm", 7, ["testchannel"], [r1, r2]),
     ]
 
     expected = (
         "Revision 7 of charm 'testcharm' released to testchannel "
-        "(attaching resources: 'foo' r3, 'bar' r17)")
+        "(attaching resources: 'foo' r3, 'bar' r17)"
+    )
     assert [expected] == [rec.message for rec in caplog.records]
 
 
 def test_release_options_resource(config):
     """The --resource-file option implies a set of validations."""
-    cmd = ReleaseCommand('group', config)
+    cmd = ReleaseCommand("group", config)
     parser = ArgumentParser()
     cmd.fill_parser(parser)
-    (action,) = [action for action in parser._actions if action.dest == 'resource']
+    (action,) = [action for action in parser._actions if action.dest == "resource"]
     assert isinstance(action.type, ResourceOption)
 
 
-@pytest.mark.parametrize('sysargs,expected_parsed', [
-    (['somename', '--channel=stable', '--revision=33'], ('somename', 33, ['stable'], [])),
-    (['somename', '--channel=stable', '-r', '33'], ('somename', 33, ['stable'], [])),
-    (['somename', '-c', 'stable', '--revision=33'], ('somename', 33, ['stable'], [])),
-    (['-c', 'stable', '--revision=33', 'somename'], ('somename', 33, ['stable'], [])),
-    (['-c', 'beta', '--revision=1', '--channel=edge', 'name'], ('name', 1, ['beta', 'edge'], [])),
-    (['somename', '-c=beta', '-r=3', '--resource=foo:15'],
-        ('somename', 3, ['beta'], [ResourceOption('foo', 15)])),
-    (['somename', '-c=beta', '-r=3', '--resource=foo:15', '--resource=bar:99'],
-        ('somename', 3, ['beta'], [ResourceOption('foo', 15), ResourceOption('bar', 99)])),
-])
+@pytest.mark.parametrize(
+    "sysargs,expected_parsed",
+    [
+        (
+            ["somename", "--channel=stable", "--revision=33"],
+            ("somename", 33, ["stable"], []),
+        ),
+        (
+            ["somename", "--channel=stable", "-r", "33"],
+            ("somename", 33, ["stable"], []),
+        ),
+        (
+            ["somename", "-c", "stable", "--revision=33"],
+            ("somename", 33, ["stable"], []),
+        ),
+        (
+            ["-c", "stable", "--revision=33", "somename"],
+            ("somename", 33, ["stable"], []),
+        ),
+        (
+            ["-c", "beta", "--revision=1", "--channel=edge", "name"],
+            ("name", 1, ["beta", "edge"], []),
+        ),
+        (
+            ["somename", "-c=beta", "-r=3", "--resource=foo:15"],
+            ("somename", 3, ["beta"], [ResourceOption("foo", 15)]),
+        ),
+        (
+            ["somename", "-c=beta", "-r=3", "--resource=foo:15", "--resource=bar:99"],
+            (
+                "somename",
+                3,
+                ["beta"],
+                [ResourceOption("foo", 15), ResourceOption("bar", 99)],
+            ),
+        ),
+    ],
+)
 def test_release_parameters_ok(config, sysargs, expected_parsed):
     """Control of different combination of sane parameters."""
-    cmd = ReleaseCommand('group', config)
+    cmd = ReleaseCommand("group", config)
     parser = ArgumentParser()
     cmd.fill_parser(parser)
     try:
         args = parser.parse_args(sysargs)
     except SystemExit:
         pytest.fail("Parsing of {} was not ok.".format(sysargs))
-    attribs = ['name', 'revision', 'channel', 'resource']
+    attribs = ["name", "revision", "channel", "resource"]
     assert args == Namespace(**dict(zip(attribs, expected_parsed)))
 
 
-@pytest.mark.parametrize('sysargs', [
-    ['somename', '--channel=stable', '--revision=foo'],  # revision not an int
-    ['somename', '--channel=stable'],  # missing the revision
-    ['somename', '--revision=1'],  # missing a channel
-    ['somename', '--channel=stable', '--revision=1', '--revision=2'],  # too many revisions
-    ['--channel=stable', '--revision=1'],  # missing the name
-    ['somename', '-c=beta', '-r=3', '--resource=foo15'],  # bad resource format
-])
+@pytest.mark.parametrize(
+    "sysargs",
+    [
+        ["somename", "--channel=stable", "--revision=foo"],  # revision not an int
+        ["somename", "--channel=stable"],  # missing the revision
+        ["somename", "--revision=1"],  # missing a channel
+        [
+            "somename",
+            "--channel=stable",
+            "--revision=1",
+            "--revision=2",
+        ],  # too many revisions
+        ["--channel=stable", "--revision=1"],  # missing the name
+        ["somename", "-c=beta", "-r=3", "--resource=foo15"],  # bad resource format
+    ],
+)
 def test_release_parameters_bad(config, sysargs):
     """Control of different option/parameters combinations that are not valid."""
-    cmd = ReleaseCommand('group', config)
+    cmd = ReleaseCommand("group", config)
     parser = ArgumentParser()
     cmd.fill_parser(parser)
     with pytest.raises(SystemExit):
@@ -783,22 +870,29 @@ def test_release_parameters_bad(config, sysargs):
 
 # -- tests for the status command
 
-def _build_channels(track='latest'):
+
+def _build_channels(track="latest"):
     """Helper to build simple channels structure."""
     channels = []
-    risks = ['stable', 'candidate', 'beta', 'edge']
+    risks = ["stable", "candidate", "beta", "edge"]
     for risk, fback in zip(risks, [None] + risks):
         name = "/".join((track, risk))
         fallback = None if fback is None else "/".join((track, fback))
-        channels.append(Channel(name=name, fallback=fallback, track=track, risk=risk, branch=None))
+        channels.append(
+            Channel(name=name, fallback=fallback, track=track, risk=risk, branch=None)
+        )
     return channels
 
 
 def _build_revision(revno, version):
     """Helper to build a revision."""
     return Revision(
-        revision=revno, version=version, created_at=datetime.datetime(2020, 7, 3, 20, 30, 40),
-        status='accepted', errors=[])
+        revision=revno,
+        version=version,
+        created_at=datetime.datetime(2020, 7, 3, 20, 30, 40),
+        status="accepted",
+        errors=[],
+    )
 
 
 def test_status_simple_ok(caplog, store_mock, config):
@@ -806,24 +900,24 @@ def test_status_simple_ok(caplog, store_mock, config):
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
     channel_map = [
-        Release(revision=7, channel='latest/stable', expires_at=None, resources=[]),
-        Release(revision=7, channel='latest/candidate', expires_at=None, resources=[]),
-        Release(revision=80, channel='latest/beta', expires_at=None, resources=[]),
-        Release(revision=156, channel='latest/edge', expires_at=None, resources=[]),
+        Release(revision=7, channel="latest/stable", expires_at=None, resources=[]),
+        Release(revision=7, channel="latest/candidate", expires_at=None, resources=[]),
+        Release(revision=80, channel="latest/beta", expires_at=None, resources=[]),
+        Release(revision=156, channel="latest/edge", expires_at=None, resources=[]),
     ]
     channels = _build_channels()
     revisions = [
-        _build_revision(revno=7, version='v7'),
-        _build_revision(revno=80, version='2.0'),
-        _build_revision(revno=156, version='git-0db35ea1'),
+        _build_revision(revno=7, version="v7"),
+        _build_revision(revno=80, version="2.0"),
+        _build_revision(revno=156, version="git-0db35ea1"),
     ]
     store_mock.list_releases.return_value = (channel_map, channels, revisions)
 
-    args = Namespace(name='testcharm')
-    StatusCommand('group', config).run(args)
+    args = Namespace(name="testcharm")
+    StatusCommand("group", config).run(args)
 
     assert store_mock.mock_calls == [
-        call.list_releases('testcharm'),
+        call.list_releases("testcharm"),
     ]
 
     expected = [
@@ -841,8 +935,8 @@ def test_status_empty(caplog, store_mock, config):
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
     store_mock.list_releases.return_value = [], [], []
-    args = Namespace(name='testcharm')
-    StatusCommand('group', config).run(args)
+    args = Namespace(name="testcharm")
+    StatusCommand("group", config).run(args)
 
     expected = "Nothing has been released yet."
     assert [expected] == [rec.message for rec in caplog.records]
@@ -853,21 +947,21 @@ def test_status_channels_not_released_with_fallback(caplog, store_mock, config):
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
     channel_map = [
-        Release(revision=7, channel='latest/stable', expires_at=None, resources=[]),
-        Release(revision=80, channel='latest/edge', expires_at=None, resources=[]),
+        Release(revision=7, channel="latest/stable", expires_at=None, resources=[]),
+        Release(revision=80, channel="latest/edge", expires_at=None, resources=[]),
     ]
     channels = _build_channels()
     revisions = [
-        _build_revision(revno=7, version='v7'),
-        _build_revision(revno=80, version='2.0'),
+        _build_revision(revno=7, version="v7"),
+        _build_revision(revno=80, version="2.0"),
     ]
     store_mock.list_releases.return_value = (channel_map, channels, revisions)
 
-    args = Namespace(name='testcharm')
-    StatusCommand('group', config).run(args)
+    args = Namespace(name="testcharm")
+    StatusCommand("group", config).run(args)
 
     assert store_mock.mock_calls == [
-        call.list_releases('testcharm'),
+        call.list_releases("testcharm"),
     ]
 
     expected = [
@@ -885,21 +979,21 @@ def test_status_channels_not_released_without_fallback(caplog, store_mock, confi
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
     channel_map = [
-        Release(revision=5, channel='latest/beta', expires_at=None, resources=[]),
-        Release(revision=12, channel='latest/edge', expires_at=None, resources=[]),
+        Release(revision=5, channel="latest/beta", expires_at=None, resources=[]),
+        Release(revision=12, channel="latest/edge", expires_at=None, resources=[]),
     ]
     channels = _build_channels()
     revisions = [
-        _build_revision(revno=5, version='5.1'),
-        _build_revision(revno=12, version='almostready'),
+        _build_revision(revno=5, version="5.1"),
+        _build_revision(revno=12, version="almostready"),
     ]
     store_mock.list_releases.return_value = (channel_map, channels, revisions)
 
-    args = Namespace(name='testcharm')
-    StatusCommand('group', config).run(args)
+    args = Namespace(name="testcharm")
+    StatusCommand("group", config).run(args)
 
     assert store_mock.mock_calls == [
-        call.list_releases('testcharm'),
+        call.list_releases("testcharm"),
     ]
 
     expected = [
@@ -917,23 +1011,23 @@ def test_status_multiple_tracks(caplog, store_mock, config):
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
     channel_map = [
-        Release(revision=503, channel='latest/stable', expires_at=None, resources=[]),
-        Release(revision=1, channel='2.0/edge', expires_at=None, resources=[]),
+        Release(revision=503, channel="latest/stable", expires_at=None, resources=[]),
+        Release(revision=1, channel="2.0/edge", expires_at=None, resources=[]),
     ]
     channels_latest = _build_channels()
-    channels_track = _build_channels(track='2.0')
+    channels_track = _build_channels(track="2.0")
     channels = channels_latest + channels_track
     revisions = [
-        _build_revision(revno=503, version='7.5.3'),
-        _build_revision(revno=1, version='1'),
+        _build_revision(revno=503, version="7.5.3"),
+        _build_revision(revno=1, version="1"),
     ]
     store_mock.list_releases.return_value = (channel_map, channels, revisions)
 
-    args = Namespace(name='testcharm')
-    StatusCommand('group', config).run(args)
+    args = Namespace(name="testcharm")
+    StatusCommand("group", config).run(args)
 
     assert store_mock.mock_calls == [
-        call.list_releases('testcharm'),
+        call.list_releases("testcharm"),
     ]
 
     expected = [
@@ -955,29 +1049,29 @@ def test_status_tracks_order(caplog, store_mock, config):
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
     channel_map = [
-        Release(revision=1, channel='latest/edge', expires_at=None, resources=[]),
-        Release(revision=2, channel='aaa/edge', expires_at=None, resources=[]),
-        Release(revision=3, channel='2.0/edge', expires_at=None, resources=[]),
-        Release(revision=4, channel='zzz/edge', expires_at=None, resources=[]),
+        Release(revision=1, channel="latest/edge", expires_at=None, resources=[]),
+        Release(revision=2, channel="aaa/edge", expires_at=None, resources=[]),
+        Release(revision=3, channel="2.0/edge", expires_at=None, resources=[]),
+        Release(revision=4, channel="zzz/edge", expires_at=None, resources=[]),
     ]
     channels_latest = _build_channels()
-    channels_track_1 = _build_channels(track='zzz')
-    channels_track_2 = _build_channels(track='2.0')
-    channels_track_3 = _build_channels(track='aaa')
+    channels_track_1 = _build_channels(track="zzz")
+    channels_track_2 = _build_channels(track="2.0")
+    channels_track_3 = _build_channels(track="aaa")
     channels = channels_latest + channels_track_1 + channels_track_2 + channels_track_3
     revisions = [
-        _build_revision(revno=1, version='v1'),
-        _build_revision(revno=2, version='v2'),
-        _build_revision(revno=3, version='v3'),
-        _build_revision(revno=4, version='v4'),
+        _build_revision(revno=1, version="v1"),
+        _build_revision(revno=2, version="v2"),
+        _build_revision(revno=3, version="v3"),
+        _build_revision(revno=4, version="v4"),
     ]
     store_mock.list_releases.return_value = (channel_map, channels, revisions)
 
-    args = Namespace(name='testcharm')
-    StatusCommand('group', config).run(args)
+    args = Namespace(name="testcharm")
+    StatusCommand("group", config).run(args)
 
     assert store_mock.mock_calls == [
-        call.list_releases('testcharm'),
+        call.list_releases("testcharm"),
     ]
 
     expected = [
@@ -1006,29 +1100,37 @@ def test_status_with_one_branch(caplog, store_mock, config):
     """Support having one branch."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
-    tstamp_with_timezone = dateutil.parser.parse('2020-07-03T20:30:40Z')
+    tstamp_with_timezone = dateutil.parser.parse("2020-07-03T20:30:40Z")
     channel_map = [
-        Release(revision=5, channel='latest/beta', expires_at=None, resources=[]),
+        Release(revision=5, channel="latest/beta", expires_at=None, resources=[]),
         Release(
-            revision=12, channel='latest/beta/mybranch',
-            expires_at=tstamp_with_timezone, resources=[]),
+            revision=12,
+            channel="latest/beta/mybranch",
+            expires_at=tstamp_with_timezone,
+            resources=[],
+        ),
     ]
     channels = _build_channels()
     channels.append(
         Channel(
-            name='latest/beta/mybranch', fallback='latest/beta',
-            track='latest', risk='beta', branch='mybranch'))
+            name="latest/beta/mybranch",
+            fallback="latest/beta",
+            track="latest",
+            risk="beta",
+            branch="mybranch",
+        )
+    )
     revisions = [
-        _build_revision(revno=5, version='5.1'),
-        _build_revision(revno=12, version='ver.12'),
+        _build_revision(revno=5, version="5.1"),
+        _build_revision(revno=12, version="ver.12"),
     ]
     store_mock.list_releases.return_value = (channel_map, channels, revisions)
 
-    args = Namespace(name='testcharm')
-    StatusCommand('group', config).run(args)
+    args = Namespace(name="testcharm")
+    StatusCommand("group", config).run(args)
 
     assert store_mock.mock_calls == [
-        call.list_releases('testcharm'),
+        call.list_releases("testcharm"),
     ]
 
     expected = [
@@ -1046,33 +1148,47 @@ def test_status_with_multiple_branches(caplog, store_mock, config):
     """Support having multiple branches."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
-    tstamp = dateutil.parser.parse('2020-07-03T20:30:40Z')
+    tstamp = dateutil.parser.parse("2020-07-03T20:30:40Z")
     channel_map = [
-        Release(revision=5, channel='latest/beta', expires_at=None, resources=[]),
-        Release(revision=12, channel='latest/beta/branch-1', expires_at=tstamp, resources=[]),
-        Release(revision=15, channel='latest/beta/branch-2', expires_at=tstamp, resources=[]),
+        Release(revision=5, channel="latest/beta", expires_at=None, resources=[]),
+        Release(
+            revision=12, channel="latest/beta/branch-1", expires_at=tstamp, resources=[]
+        ),
+        Release(
+            revision=15, channel="latest/beta/branch-2", expires_at=tstamp, resources=[]
+        ),
     ]
     channels = _build_channels()
-    channels.extend([
-        Channel(
-            name='latest/beta/branch-1', fallback='latest/beta',
-            track='latest', risk='beta', branch='branch-1'),
-        Channel(
-            name='latest/beta/branch-2', fallback='latest/beta',
-            track='latest', risk='beta', branch='branch-2'),
-    ])
+    channels.extend(
+        [
+            Channel(
+                name="latest/beta/branch-1",
+                fallback="latest/beta",
+                track="latest",
+                risk="beta",
+                branch="branch-1",
+            ),
+            Channel(
+                name="latest/beta/branch-2",
+                fallback="latest/beta",
+                track="latest",
+                risk="beta",
+                branch="branch-2",
+            ),
+        ]
+    )
     revisions = [
-        _build_revision(revno=5, version='5.1'),
-        _build_revision(revno=12, version='ver.12'),
-        _build_revision(revno=15, version='15.0.0'),
+        _build_revision(revno=5, version="5.1"),
+        _build_revision(revno=12, version="ver.12"),
+        _build_revision(revno=15, version="15.0.0"),
     ]
     store_mock.list_releases.return_value = (channel_map, channels, revisions)
 
-    args = Namespace(name='testcharm')
-    StatusCommand('group', config).run(args)
+    args = Namespace(name="testcharm")
+    StatusCommand("group", config).run(args)
 
     assert store_mock.mock_calls == [
-        call.list_releases('testcharm'),
+        call.list_releases("testcharm"),
     ]
 
     expected = [
@@ -1091,20 +1207,25 @@ def test_status_with_resources(caplog, store_mock, config):
     """Support having multiple branches."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
-    res1 = Resource(name='resource1', optional=True, revision=1, resource_type='file')
-    res2 = Resource(name='resource2', optional=True, revision=54, resource_type='file')
+    res1 = Resource(name="resource1", optional=True, revision=1, resource_type="file")
+    res2 = Resource(name="resource2", optional=True, revision=54, resource_type="file")
     channel_map = [
-        Release(revision=5, channel='latest/candidate', expires_at=None, resources=[res1, res2]),
-        Release(revision=5, channel='latest/beta', expires_at=None, resources=[res1]),
+        Release(
+            revision=5,
+            channel="latest/candidate",
+            expires_at=None,
+            resources=[res1, res2],
+        ),
+        Release(revision=5, channel="latest/beta", expires_at=None, resources=[res1]),
     ]
     channels = _build_channels()
     revisions = [
-        _build_revision(revno=5, version='5.1'),
+        _build_revision(revno=5, version="5.1"),
     ]
     store_mock.list_releases.return_value = (channel_map, channels, revisions)
 
-    args = Namespace(name='testcharm')
-    StatusCommand('group', config).run(args)
+    args = Namespace(name="testcharm")
+    StatusCommand("group", config).run(args)
 
     expected = [
         "Track    Channel    Version    Revision    Resources",
@@ -1120,20 +1241,26 @@ def test_status_with_resources_missing_after_closed_channel(caplog, store_mock, 
     """Specific glitch for a channel without resources after a closed one."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
-    resource = Resource(name='resource', optional=True, revision=1, resource_type='file')
+    resource = Resource(
+        name="resource", optional=True, revision=1, resource_type="file"
+    )
     channel_map = [
-        Release(revision=5, channel='latest/stable', expires_at=None, resources=[resource]),
-        Release(revision=5, channel='latest/beta', expires_at=None, resources=[]),
-        Release(revision=5, channel='latest/edge', expires_at=None, resources=[resource]),
+        Release(
+            revision=5, channel="latest/stable", expires_at=None, resources=[resource]
+        ),
+        Release(revision=5, channel="latest/beta", expires_at=None, resources=[]),
+        Release(
+            revision=5, channel="latest/edge", expires_at=None, resources=[resource]
+        ),
     ]
     channels = _build_channels()
     revisions = [
-        _build_revision(revno=5, version='5.1'),
+        _build_revision(revno=5, version="5.1"),
     ]
     store_mock.list_releases.return_value = (channel_map, channels, revisions)
 
-    args = Namespace(name='testcharm')
-    StatusCommand('group', config).run(args)
+    args = Namespace(name="testcharm")
+    StatusCommand("group", config).run(args)
 
     expected = [
         "Track    Channel    Version    Revision    Resources",
@@ -1149,28 +1276,36 @@ def test_status_with_resources_and_branches(caplog, store_mock, config):
     """Support having multiple branches."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
-    tstamp = dateutil.parser.parse('2020-07-03T20:30:40Z')
-    res1 = Resource(name='testres', optional=True, revision=1, resource_type='file')
-    res2 = Resource(name='testres', optional=True, revision=14, resource_type='file')
+    tstamp = dateutil.parser.parse("2020-07-03T20:30:40Z")
+    res1 = Resource(name="testres", optional=True, revision=1, resource_type="file")
+    res2 = Resource(name="testres", optional=True, revision=14, resource_type="file")
     channel_map = [
+        Release(revision=23, channel="latest/beta", expires_at=None, resources=[res2]),
         Release(
-            revision=23, channel='latest/beta', expires_at=None, resources=[res2]),
-        Release(
-            revision=5, channel='latest/edge/mybranch', expires_at=tstamp, resources=[res1]),
+            revision=5,
+            channel="latest/edge/mybranch",
+            expires_at=tstamp,
+            resources=[res1],
+        ),
     ]
     channels = _build_channels()
     channels.append(
         Channel(
-            name='latest/edge/mybranch', fallback='latest/edge',
-            track='latest', risk='edge', branch='mybranch'))
+            name="latest/edge/mybranch",
+            fallback="latest/edge",
+            track="latest",
+            risk="edge",
+            branch="mybranch",
+        )
+    )
     revisions = [
-        _build_revision(revno=5, version='5.1'),
-        _build_revision(revno=23, version='7.0.0'),
+        _build_revision(revno=5, version="5.1"),
+        _build_revision(revno=23, version="7.0.0"),
     ]
     store_mock.list_releases.return_value = (channel_map, channels, revisions)
 
-    args = Namespace(name='testcharm')
-    StatusCommand('group', config).run(args)
+    args = Namespace(name="testcharm")
+    StatusCommand("group", config).run(args)
 
     expected = [
         "Track    Channel        Version    Revision    Resources      Expires at",
@@ -1185,129 +1320,146 @@ def test_status_with_resources_and_branches(caplog, store_mock, config):
 
 # -- tests for create library command
 
+
 def test_createlib_simple(caplog, store_mock, tmp_path, monkeypatch, config):
     """Happy path with result from the Store."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
     monkeypatch.chdir(tmp_path)
 
-    lib_id = 'test-example-lib-id'
+    lib_id = "test-example-lib-id"
     store_mock.create_library_id.return_value = lib_id
 
-    args = Namespace(name='testlib')
-    with patch('charmcraft.commands.store.get_name_from_metadata') as mock:
-        mock.return_value = 'testcharm'
-        CreateLibCommand('group', config).run(args)
+    args = Namespace(name="testlib")
+    with patch("charmcraft.commands.store.get_name_from_metadata") as mock:
+        mock.return_value = "testcharm"
+        CreateLibCommand("group", config).run(args)
 
     assert store_mock.mock_calls == [
-        call.create_library_id('testcharm', 'testlib'),
+        call.create_library_id("testcharm", "testlib"),
     ]
     expected = [
         "Library charms.testcharm.v0.testlib created with id test-example-lib-id.",
         "Consider 'git add lib/charms/testcharm/v0/testlib.py'.",
     ]
     assert expected == [rec.message for rec in caplog.records]
-    created_lib_file = tmp_path / 'lib' / 'charms' / 'testcharm' / 'v0' / 'testlib.py'
+    created_lib_file = tmp_path / "lib" / "charms" / "testcharm" / "v0" / "testlib.py"
 
-    env = get_templates_environment('charmlibs')
-    expected_newlib_content = env.get_template('new_library.py.j2').render(lib_id=lib_id)
+    env = get_templates_environment("charmlibs")
+    expected_newlib_content = env.get_template("new_library.py.j2").render(
+        lib_id=lib_id
+    )
     assert created_lib_file.read_text() == expected_newlib_content
 
 
 def test_createlib_name_from_metadata_problem(store_mock, config):
     """The metadata wasn't there to get the name."""
-    args = Namespace(name='testlib')
-    with patch('charmcraft.commands.store.get_name_from_metadata') as mock:
+    args = Namespace(name="testlib")
+    with patch("charmcraft.commands.store.get_name_from_metadata") as mock:
         mock.return_value = None
         with pytest.raises(CommandError) as cm:
-            CreateLibCommand('group', config).run(args)
+            CreateLibCommand("group", config).run(args)
         assert str(cm.value) == (
             "Cannot find a valid charm name in metadata.yaml. Check you are in a charm "
-            "directory with metadata.yaml.")
+            "directory with metadata.yaml."
+        )
 
 
-def test_createlib_name_contains_dash(caplog, store_mock, tmp_path, monkeypatch, config):
+def test_createlib_name_contains_dash(
+    caplog, store_mock, tmp_path, monkeypatch, config
+):
     """'-' is valid in charm names but can't be imported"""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
     monkeypatch.chdir(tmp_path)
 
-    lib_id = 'test-example-lib-id'
+    lib_id = "test-example-lib-id"
     store_mock.create_library_id.return_value = lib_id
 
-    args = Namespace(name='testlib')
-    with patch('charmcraft.commands.store.get_name_from_metadata') as mock:
-        mock.return_value = 'test-charm'
-        CreateLibCommand('group', config).run(args)
+    args = Namespace(name="testlib")
+    with patch("charmcraft.commands.store.get_name_from_metadata") as mock:
+        mock.return_value = "test-charm"
+        CreateLibCommand("group", config).run(args)
 
     assert store_mock.mock_calls == [
-        call.create_library_id('test-charm', 'testlib'),
+        call.create_library_id("test-charm", "testlib"),
     ]
     expected = [
         "Library charms.test_charm.v0.testlib created with id test-example-lib-id.",
         "Consider 'git add lib/charms/test_charm/v0/testlib.py'.",
     ]
     assert expected == [rec.message for rec in caplog.records]
-    created_lib_file = tmp_path / 'lib' / 'charms' / 'test_charm' / 'v0' / 'testlib.py'
+    created_lib_file = tmp_path / "lib" / "charms" / "test_charm" / "v0" / "testlib.py"
 
-    env = get_templates_environment('charmlibs')
-    expected_newlib_content = env.get_template('new_library.py.j2').render(lib_id=lib_id)
+    env = get_templates_environment("charmlibs")
+    expected_newlib_content = env.get_template("new_library.py.j2").render(
+        lib_id=lib_id
+    )
     assert created_lib_file.read_text() == expected_newlib_content
 
 
-@pytest.mark.parametrize('lib_name', [
-    'foo.bar',
-    'foo/bar',
-    'Foo',
-    '123foo',
-    '_foo',
-    '',
-])
+@pytest.mark.parametrize(
+    "lib_name",
+    [
+        "foo.bar",
+        "foo/bar",
+        "Foo",
+        "123foo",
+        "_foo",
+        "",
+    ],
+)
 def test_createlib_invalid_name(lib_name, config):
     """Verify that it can not be used with an invalid name."""
     args = Namespace(name=lib_name)
     with pytest.raises(CommandError) as err:
-        CreateLibCommand('group', config).run(args)
+        CreateLibCommand("group", config).run(args)
     assert str(err.value) == (
         "Invalid library name. Must only use lowercase alphanumeric "
-        "characters and underscore, starting with alpha.")
+        "characters and underscore, starting with alpha."
+    )
 
 
 def test_createlib_path_already_there(tmp_path, monkeypatch, config):
     """The intended-to-be-created library is already there."""
     monkeypatch.chdir(tmp_path)
 
-    factory.create_lib_filepath('test-charm-name', 'testlib', api=0)
-    args = Namespace(name='testlib')
-    with patch('charmcraft.commands.store.get_name_from_metadata') as mock:
-        mock.return_value = 'test-charm-name'
+    factory.create_lib_filepath("test-charm-name", "testlib", api=0)
+    args = Namespace(name="testlib")
+    with patch("charmcraft.commands.store.get_name_from_metadata") as mock:
+        mock.return_value = "test-charm-name"
         with pytest.raises(CommandError) as err:
-            CreateLibCommand('group', config).run(args)
+            CreateLibCommand("group", config).run(args)
 
     assert str(err.value) == (
-        "This library already exists: lib/charms/test_charm_name/v0/testlib.py")
+        "This library already exists: lib/charms/test_charm_name/v0/testlib.py"
+    )
 
 
-def test_createlib_path_can_not_write(tmp_path, monkeypatch, store_mock, add_cleanup, config):
+def test_createlib_path_can_not_write(
+    tmp_path, monkeypatch, store_mock, add_cleanup, config
+):
     """Disk error when trying to write the new lib (bad permissions, name too long, whatever)."""
-    lib_dir = tmp_path / 'lib' / 'charms' / 'test_charm_name' / 'v0'
+    lib_dir = tmp_path / "lib" / "charms" / "test_charm_name" / "v0"
     lib_dir.mkdir(parents=True)
     lib_dir.chmod(0o111)
     add_cleanup(lib_dir.chmod, 0o777)
     monkeypatch.chdir(tmp_path)
 
-    args = Namespace(name='testlib')
-    store_mock.create_library_id.return_value = 'lib_id'
+    args = Namespace(name="testlib")
+    store_mock.create_library_id.return_value = "lib_id"
     expected_error = "Error writing the library in .*: PermissionError.*"
-    with patch('charmcraft.commands.store.get_name_from_metadata') as mock:
-        mock.return_value = 'test-charm-name'
+    with patch("charmcraft.commands.store.get_name_from_metadata") as mock:
+        mock.return_value = "test-charm-name"
         with pytest.raises(CommandError, match=expected_error):
-            CreateLibCommand('group', config).run(args)
+            CreateLibCommand("group", config).run(args)
 
 
-def test_createlib_library_template_is_python(caplog, store_mock, tmp_path, monkeypatch):
+def test_createlib_library_template_is_python(
+    caplog, store_mock, tmp_path, monkeypatch
+):
     """Verify that the template used to create a library is valid Python code."""
-    env = get_templates_environment('charmlibs')
-    newlib_content = env.get_template('new_library.py.j2').render(lib_id='test-lib-id')
-    compile(newlib_content, 'test.py', 'exec')
+    env = get_templates_environment("charmlibs")
+    newlib_content = env.get_template("new_library.py.j2").render(lib_id="test-lib-id")
+    compile(newlib_content, "test.py", "exec")
 
 
 # -- tests for publish libraries command
@@ -1318,19 +1470,20 @@ def test_publishlib_simple(caplog, store_mock, tmp_path, monkeypatch, config):
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
     monkeypatch.chdir(tmp_path)
 
-    lib_id = 'test-example-lib-id'
+    lib_id = "test-example-lib-id"
     content, content_hash = factory.create_lib_filepath(
-        'testcharm', 'testlib', api=0, patch=1, lib_id=lib_id)
+        "testcharm", "testlib", api=0, patch=1, lib_id=lib_id
+    )
 
     store_mock.get_libraries_tips.return_value = {}
-    args = Namespace(library='charms.testcharm.v0.testlib')
-    with patch('charmcraft.commands.store.get_name_from_metadata') as mock:
-        mock.return_value = 'testcharm'
-        PublishLibCommand('group', config).run(args)
+    args = Namespace(library="charms.testcharm.v0.testlib")
+    with patch("charmcraft.commands.store.get_name_from_metadata") as mock:
+        mock.return_value = "testcharm"
+        PublishLibCommand("group", config).run(args)
 
     assert store_mock.mock_calls == [
-        call.get_libraries_tips([{'lib_id': lib_id, 'api': 0}]),
-        call.create_library_revision('testcharm', lib_id, 0, 1, content, content_hash),
+        call.get_libraries_tips([{"lib_id": lib_id, "api": 0}]),
+        call.create_library_revision("testcharm", lib_id, 0, 1, content, content_hash),
     ]
     expected = "Library charms.testcharm.v0.testlib sent to the store with version 0.1"
     assert [expected] == [rec.message for rec in caplog.records]
@@ -1341,19 +1494,20 @@ def test_publishlib_contains_dash(caplog, store_mock, tmp_path, monkeypatch, con
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
     monkeypatch.chdir(tmp_path)
 
-    lib_id = 'test-example-lib-id'
+    lib_id = "test-example-lib-id"
     content, content_hash = factory.create_lib_filepath(
-        'test-charm', 'testlib', api=0, patch=1, lib_id=lib_id)
+        "test-charm", "testlib", api=0, patch=1, lib_id=lib_id
+    )
 
     store_mock.get_libraries_tips.return_value = {}
-    args = Namespace(library='charms.test_charm.v0.testlib')
-    with patch('charmcraft.commands.store.get_name_from_metadata') as mock:
-        mock.return_value = 'test-charm'
-        PublishLibCommand('group', config).run(args)
+    args = Namespace(library="charms.test_charm.v0.testlib")
+    with patch("charmcraft.commands.store.get_name_from_metadata") as mock:
+        mock.return_value = "test-charm"
+        PublishLibCommand("group", config).run(args)
 
     assert store_mock.mock_calls == [
-        call.get_libraries_tips([{'lib_id': lib_id, 'api': 0}]),
-        call.create_library_revision('test-charm', lib_id, 0, 1, content, content_hash),
+        call.get_libraries_tips([{"lib_id": lib_id, "api": 0}]),
+        call.create_library_revision("test-charm", lib_id, 0, 1, content, content_hash),
     ]
     expected = "Library charms.test_charm.v0.testlib sent to the store with version 0.1"
     assert [expected] == [rec.message for rec in caplog.records]
@@ -1365,34 +1519,40 @@ def test_publishlib_all(caplog, store_mock, tmp_path, monkeypatch, config):
     monkeypatch.chdir(tmp_path)
 
     c1, h1 = factory.create_lib_filepath(
-        'testcharm-1', 'testlib-a', api=0, patch=1, lib_id='lib_id_1')
+        "testcharm-1", "testlib-a", api=0, patch=1, lib_id="lib_id_1"
+    )
     c2, h2 = factory.create_lib_filepath(
-        'testcharm-1', 'testlib-b', api=0, patch=1, lib_id='lib_id_2')
+        "testcharm-1", "testlib-b", api=0, patch=1, lib_id="lib_id_2"
+    )
     c3, h3 = factory.create_lib_filepath(
-        'testcharm-1', 'testlib-b', api=1, patch=3, lib_id='lib_id_3')
+        "testcharm-1", "testlib-b", api=1, patch=3, lib_id="lib_id_3"
+    )
     factory.create_lib_filepath(
-        'testcharm-2', 'testlib', api=0, patch=1, lib_id='lib_id_4')
+        "testcharm-2", "testlib", api=0, patch=1, lib_id="lib_id_4"
+    )
 
     store_mock.get_libraries_tips.return_value = {}
     args = Namespace(library=None)
-    with patch('charmcraft.commands.store.get_name_from_metadata') as mock:
-        mock.return_value = 'testcharm-1'
-        PublishLibCommand('group', config).run(args)
+    with patch("charmcraft.commands.store.get_name_from_metadata") as mock:
+        mock.return_value = "testcharm-1"
+        PublishLibCommand("group", config).run(args)
 
     assert store_mock.mock_calls == [
-        call.get_libraries_tips([
-            {'lib_id': 'lib_id_1', 'api': 0},
-            {'lib_id': 'lib_id_2', 'api': 0},
-            {'lib_id': 'lib_id_3', 'api': 1},
-        ]),
-        call.create_library_revision('testcharm-1', 'lib_id_1', 0, 1, c1, h1),
-        call.create_library_revision('testcharm-1', 'lib_id_2', 0, 1, c2, h2),
-        call.create_library_revision('testcharm-1', 'lib_id_3', 1, 3, c3, h3),
+        call.get_libraries_tips(
+            [
+                {"lib_id": "lib_id_1", "api": 0},
+                {"lib_id": "lib_id_2", "api": 0},
+                {"lib_id": "lib_id_3", "api": 1},
+            ]
+        ),
+        call.create_library_revision("testcharm-1", "lib_id_1", 0, 1, c1, h1),
+        call.create_library_revision("testcharm-1", "lib_id_2", 0, 1, c2, h2),
+        call.create_library_revision("testcharm-1", "lib_id_3", 1, 3, c3, h3),
     ]
     names = [
-        'charms.testcharm_1.v0.testlib-a',
-        'charms.testcharm_1.v0.testlib-b',
-        'charms.testcharm_1.v1.testlib-b',
+        "charms.testcharm_1.v0.testlib-a",
+        "charms.testcharm_1.v0.testlib-b",
+        "charms.testcharm_1.v1.testlib-b",
     ]
     expected = [
         "Libraries found under lib/charms/testcharm_1: " + str(names),
@@ -1409,213 +1569,273 @@ def test_publishlib_not_found(caplog, store_mock, tmp_path, monkeypatch, config)
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
     monkeypatch.chdir(tmp_path)
 
-    args = Namespace(library='charms.testcharm.v0.testlib')
-    with patch('charmcraft.commands.store.get_name_from_metadata') as mock:
-        mock.return_value = 'testcharm'
+    args = Namespace(library="charms.testcharm.v0.testlib")
+    with patch("charmcraft.commands.store.get_name_from_metadata") as mock:
+        mock.return_value = "testcharm"
         with pytest.raises(CommandError) as cm:
-            PublishLibCommand('group', config).run(args)
+            PublishLibCommand("group", config).run(args)
 
         assert str(cm.value) == (
-            "The specified library was not found at path lib/charms/testcharm/v0/testlib.py.")
+            "The specified library was not found at path lib/charms/testcharm/v0/testlib.py."
+        )
 
 
-def test_publishlib_not_from_current_charm(caplog, store_mock, tmp_path, monkeypatch, config):
+def test_publishlib_not_from_current_charm(
+    caplog, store_mock, tmp_path, monkeypatch, config
+):
     """The indicated library to publish does not belong to this charm."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
     monkeypatch.chdir(tmp_path)
-    factory.create_lib_filepath('testcharm', 'testlib', api=0)
+    factory.create_lib_filepath("testcharm", "testlib", api=0)
 
-    args = Namespace(library='charms.testcharm.v0.testlib')
-    with patch('charmcraft.commands.store.get_name_from_metadata') as mock:
-        mock.return_value = 'charm2'
+    args = Namespace(library="charms.testcharm.v0.testlib")
+    with patch("charmcraft.commands.store.get_name_from_metadata") as mock:
+        mock.return_value = "charm2"
         with pytest.raises(CommandError) as cm:
-            PublishLibCommand('group', config).run(args)
+            PublishLibCommand("group", config).run(args)
 
         assert str(cm.value) == (
-            "The library charms.testcharm.v0.testlib does not belong to this charm 'charm2'.")
+            "The library charms.testcharm.v0.testlib does not belong to this charm 'charm2'."
+        )
 
 
 def test_publishlib_name_from_metadata_problem(store_mock, config):
     """The metadata wasn't there to get the name."""
-    args = Namespace(library='charms.testcharm.v0.testlib')
-    with patch('charmcraft.commands.store.get_name_from_metadata') as mock:
+    args = Namespace(library="charms.testcharm.v0.testlib")
+    with patch("charmcraft.commands.store.get_name_from_metadata") as mock:
         mock.return_value = None
         with pytest.raises(CommandError) as cm:
-            PublishLibCommand('group', config).run(args)
+            PublishLibCommand("group", config).run(args)
 
         assert str(cm.value) == (
             "Can't access name in 'metadata.yaml' file. The 'publish-lib' command needs to "
-            "be executed in a valid project's directory.")
+            "be executed in a valid project's directory."
+        )
 
 
-def test_publishlib_store_is_advanced(caplog, store_mock, tmp_path, monkeypatch, config):
+def test_publishlib_store_is_advanced(
+    caplog, store_mock, tmp_path, monkeypatch, config
+):
     """The store has a higher revision number than what we expect."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
     monkeypatch.chdir(tmp_path)
 
-    lib_id = 'test-example-lib-id'
-    factory.create_lib_filepath('testcharm', 'testlib', api=0, patch=1, lib_id=lib_id)
+    lib_id = "test-example-lib-id"
+    factory.create_lib_filepath("testcharm", "testlib", api=0, patch=1, lib_id=lib_id)
 
     store_mock.get_libraries_tips.return_value = {
         (lib_id, 0): Library(
-            lib_id=lib_id, content=None, content_hash='abc', api=0, patch=2,
-            lib_name='testlib', charm_name='testcharm'),
+            lib_id=lib_id,
+            content=None,
+            content_hash="abc",
+            api=0,
+            patch=2,
+            lib_name="testlib",
+            charm_name="testcharm",
+        ),
     }
-    args = Namespace(library='charms.testcharm.v0.testlib')
-    with patch('charmcraft.commands.store.get_name_from_metadata') as mock:
-        mock.return_value = 'testcharm'
-        PublishLibCommand('group', config).run(args)
+    args = Namespace(library="charms.testcharm.v0.testlib")
+    with patch("charmcraft.commands.store.get_name_from_metadata") as mock:
+        mock.return_value = "testcharm"
+        PublishLibCommand("group", config).run(args)
 
     assert store_mock.mock_calls == [
-        call.get_libraries_tips([{'lib_id': lib_id, 'api': 0}]),
+        call.get_libraries_tips([{"lib_id": lib_id, "api": 0}]),
     ]
     expected = (
         "Library charms.testcharm.v0.testlib is out-of-date locally, Charmhub has version 0.2, "
-        "please fetch the updates before publishing.")
+        "please fetch the updates before publishing."
+    )
     assert [expected] == [rec.message for rec in caplog.records]
 
 
-def test_publishlib_store_is_exactly_behind_ok(caplog, store_mock, tmp_path, monkeypatch, config):
+def test_publishlib_store_is_exactly_behind_ok(
+    caplog, store_mock, tmp_path, monkeypatch, config
+):
     """The store is exactly one revision less than local lib, ok."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
     monkeypatch.chdir(tmp_path)
 
-    lib_id = 'test-example-lib-id'
+    lib_id = "test-example-lib-id"
     content, content_hash = factory.create_lib_filepath(
-        'testcharm', 'testlib', api=0, patch=7, lib_id=lib_id)
+        "testcharm", "testlib", api=0, patch=7, lib_id=lib_id
+    )
 
     store_mock.get_libraries_tips.return_value = {
         (lib_id, 0): Library(
-            lib_id=lib_id, content=None, content_hash='abc', api=0, patch=6,
-            lib_name='testlib', charm_name='testcharm'),
+            lib_id=lib_id,
+            content=None,
+            content_hash="abc",
+            api=0,
+            patch=6,
+            lib_name="testlib",
+            charm_name="testcharm",
+        ),
     }
-    args = Namespace(library='charms.testcharm.v0.testlib')
-    with patch('charmcraft.commands.store.get_name_from_metadata') as mock:
-        mock.return_value = 'testcharm'
-        PublishLibCommand('group', config).run(args)
+    args = Namespace(library="charms.testcharm.v0.testlib")
+    with patch("charmcraft.commands.store.get_name_from_metadata") as mock:
+        mock.return_value = "testcharm"
+        PublishLibCommand("group", config).run(args)
 
     assert store_mock.mock_calls == [
-        call.get_libraries_tips([{'lib_id': lib_id, 'api': 0}]),
-        call.create_library_revision('testcharm', lib_id, 0, 7, content, content_hash),
+        call.get_libraries_tips([{"lib_id": lib_id, "api": 0}]),
+        call.create_library_revision("testcharm", lib_id, 0, 7, content, content_hash),
     ]
     expected = "Library charms.testcharm.v0.testlib sent to the store with version 0.7"
     assert [expected] == [rec.message for rec in caplog.records]
 
 
 def test_publishlib_store_is_exactly_behind_same_hash(
-        caplog, store_mock, tmp_path, monkeypatch, config):
+    caplog, store_mock, tmp_path, monkeypatch, config
+):
     """The store is exactly one revision less than local lib, same hash."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
     monkeypatch.chdir(tmp_path)
 
-    lib_id = 'test-example-lib-id'
+    lib_id = "test-example-lib-id"
     content, content_hash = factory.create_lib_filepath(
-        'testcharm', 'testlib', api=0, patch=7, lib_id=lib_id)
+        "testcharm", "testlib", api=0, patch=7, lib_id=lib_id
+    )
 
     store_mock.get_libraries_tips.return_value = {
         (lib_id, 0): Library(
-            lib_id=lib_id, content=None, content_hash=content_hash, api=0, patch=6,
-            lib_name='testlib', charm_name='testcharm'),
+            lib_id=lib_id,
+            content=None,
+            content_hash=content_hash,
+            api=0,
+            patch=6,
+            lib_name="testlib",
+            charm_name="testcharm",
+        ),
     }
-    args = Namespace(library='charms.testcharm.v0.testlib')
-    with patch('charmcraft.commands.store.get_name_from_metadata') as mock:
-        mock.return_value = 'testcharm'
-        PublishLibCommand('group', config).run(args)
+    args = Namespace(library="charms.testcharm.v0.testlib")
+    with patch("charmcraft.commands.store.get_name_from_metadata") as mock:
+        mock.return_value = "testcharm"
+        PublishLibCommand("group", config).run(args)
 
     assert store_mock.mock_calls == [
-        call.get_libraries_tips([{'lib_id': lib_id, 'api': 0}]),
+        call.get_libraries_tips([{"lib_id": lib_id, "api": 0}]),
     ]
     expected = (
         "Library charms.testcharm.v0.testlib LIBPATCH number was incorrectly incremented, "
-        "Charmhub has the same content in version 0.6.")
+        "Charmhub has the same content in version 0.6."
+    )
     assert [expected] == [rec.message for rec in caplog.records]
 
 
-def test_publishlib_store_is_too_behind(caplog, store_mock, tmp_path, monkeypatch, config):
+def test_publishlib_store_is_too_behind(
+    caplog, store_mock, tmp_path, monkeypatch, config
+):
     """The store is way more behind than what we expected (local lib too high!)."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
     monkeypatch.chdir(tmp_path)
 
-    lib_id = 'test-example-lib-id'
-    factory.create_lib_filepath('testcharm', 'testlib', api=0, patch=4, lib_id=lib_id)
+    lib_id = "test-example-lib-id"
+    factory.create_lib_filepath("testcharm", "testlib", api=0, patch=4, lib_id=lib_id)
 
     store_mock.get_libraries_tips.return_value = {
         (lib_id, 0): Library(
-            lib_id=lib_id, content=None, content_hash='abc', api=0, patch=2,
-            lib_name='testlib', charm_name='testcharm'),
+            lib_id=lib_id,
+            content=None,
+            content_hash="abc",
+            api=0,
+            patch=2,
+            lib_name="testlib",
+            charm_name="testcharm",
+        ),
     }
-    args = Namespace(library='charms.testcharm.v0.testlib')
-    with patch('charmcraft.commands.store.get_name_from_metadata') as mock:
-        mock.return_value = 'testcharm'
-        PublishLibCommand('group', config).run(args)
+    args = Namespace(library="charms.testcharm.v0.testlib")
+    with patch("charmcraft.commands.store.get_name_from_metadata") as mock:
+        mock.return_value = "testcharm"
+        PublishLibCommand("group", config).run(args)
 
     assert store_mock.mock_calls == [
-        call.get_libraries_tips([{'lib_id': lib_id, 'api': 0}]),
+        call.get_libraries_tips([{"lib_id": lib_id, "api": 0}]),
     ]
     expected = (
         "Library charms.testcharm.v0.testlib has a wrong LIBPATCH number, it's too high, Charmhub "
-        "highest version is 0.2.")
+        "highest version is 0.2."
+    )
     assert [expected] == [rec.message for rec in caplog.records]
 
 
 def test_publishlib_store_has_same_revision_same_hash(
-        caplog, store_mock, tmp_path, monkeypatch, config):
+    caplog, store_mock, tmp_path, monkeypatch, config
+):
     """The store has the same revision we want to publish, with the same hash."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
     monkeypatch.chdir(tmp_path)
 
-    lib_id = 'test-example-lib-id'
+    lib_id = "test-example-lib-id"
     content, content_hash = factory.create_lib_filepath(
-        'testcharm', 'testlib', api=0, patch=7, lib_id=lib_id)
+        "testcharm", "testlib", api=0, patch=7, lib_id=lib_id
+    )
 
     store_mock.get_libraries_tips.return_value = {
         (lib_id, 0): Library(
-            lib_id=lib_id, content=None, content_hash=content_hash, api=0, patch=7,
-            lib_name='testlib', charm_name='testcharm'),
+            lib_id=lib_id,
+            content=None,
+            content_hash=content_hash,
+            api=0,
+            patch=7,
+            lib_name="testlib",
+            charm_name="testcharm",
+        ),
     }
-    args = Namespace(library='charms.testcharm.v0.testlib')
-    with patch('charmcraft.commands.store.get_name_from_metadata') as mock:
-        mock.return_value = 'testcharm'
-        PublishLibCommand('group', config).run(args)
+    args = Namespace(library="charms.testcharm.v0.testlib")
+    with patch("charmcraft.commands.store.get_name_from_metadata") as mock:
+        mock.return_value = "testcharm"
+        PublishLibCommand("group", config).run(args)
 
     assert store_mock.mock_calls == [
-        call.get_libraries_tips([{'lib_id': lib_id, 'api': 0}]),
+        call.get_libraries_tips([{"lib_id": lib_id, "api": 0}]),
     ]
     expected = "Library charms.testcharm.v0.testlib is already updated in Charmhub."
     assert [expected] == [rec.message for rec in caplog.records]
 
 
 def test_publishlib_store_has_same_revision_other_hash(
-        caplog, store_mock, tmp_path, monkeypatch, config):
+    caplog, store_mock, tmp_path, monkeypatch, config
+):
     """The store has the same revision we want to publish, but with a different hash."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
     monkeypatch.chdir(tmp_path)
 
-    lib_id = 'test-example-lib-id'
-    factory.create_lib_filepath('testcharm', 'testlib', api=0, patch=7, lib_id=lib_id)
+    lib_id = "test-example-lib-id"
+    factory.create_lib_filepath("testcharm", "testlib", api=0, patch=7, lib_id=lib_id)
 
     store_mock.get_libraries_tips.return_value = {
         (lib_id, 0): Library(
-            lib_id=lib_id, content=None, content_hash='abc', api=0, patch=7,
-            lib_name='testlib', charm_name='testcharm'),
+            lib_id=lib_id,
+            content=None,
+            content_hash="abc",
+            api=0,
+            patch=7,
+            lib_name="testlib",
+            charm_name="testcharm",
+        ),
     }
-    args = Namespace(library='charms.testcharm.v0.testlib')
-    with patch('charmcraft.commands.store.get_name_from_metadata') as mock:
-        mock.return_value = 'testcharm'
-        PublishLibCommand('group', config).run(args)
+    args = Namespace(library="charms.testcharm.v0.testlib")
+    with patch("charmcraft.commands.store.get_name_from_metadata") as mock:
+        mock.return_value = "testcharm"
+        PublishLibCommand("group", config).run(args)
 
     assert store_mock.mock_calls == [
-        call.get_libraries_tips([{'lib_id': lib_id, 'api': 0}]),
+        call.get_libraries_tips([{"lib_id": lib_id, "api": 0}]),
     ]
     expected = (
         "Library charms.testcharm.v0.testlib version 0.7 is the same than in Charmhub but "
-        "content is different")
+        "content is different"
+    )
     assert [expected] == [rec.message for rec in caplog.records]
 
 
 # -- tests for _get_lib_info helper
 
-def _create_lib(extra_content=None, metadata_id=None, metadata_api=None, metadata_patch=None):
+
+def _create_lib(
+    extra_content=None, metadata_id=None, metadata_api=None, metadata_patch=None
+):
     """Helper to create the structures on disk for a given lib.
 
     WARNING: this function has the capability of creating INCORRECT structures on disk.
@@ -1623,8 +1843,8 @@ def _create_lib(extra_content=None, metadata_id=None, metadata_api=None, metadat
     This is specific for the _get_lib_info tests below, other tests should use the
     functionality provided by the factory.
     """
-    base_dir = pathlib.Path('lib')
-    lib_file = base_dir / 'charms' / 'testcharm' / 'v3' / 'testlib.py'
+    base_dir = pathlib.Path("lib")
+    lib_file = base_dir / "charms" / "testcharm" / "v3" / "testlib.py"
     lib_file.parent.mkdir(parents=True, exist_ok=True)
 
     # save the content to that specific file under custom structure
@@ -1636,10 +1856,10 @@ def _create_lib(extra_content=None, metadata_id=None, metadata_api=None, metadat
         metadata_patch = "LIBPATCH = 14"
 
     fields = [metadata_id, metadata_api, metadata_patch]
-    with lib_file.open('wt', encoding='utf8') as fh:
+    with lib_file.open("wt", encoding="utf8") as fh:
         for f in fields:
             if f:
-                fh.write(f + '\n')
+                fh.write(f + "\n")
         if extra_content:
             fh.write(extra_content)
 
@@ -1652,15 +1872,15 @@ def test_getlibinfo_success_simple(tmp_path, monkeypatch):
     test_path = _create_lib()
 
     lib_data = _get_lib_info(lib_path=test_path)
-    assert lib_data.lib_id == 'test-lib-id'
+    assert lib_data.lib_id == "test-lib-id"
     assert lib_data.api == 3
     assert lib_data.patch == 14
     assert lib_data.content_hash is not None
     assert lib_data.content is not None
-    assert lib_data.full_name == 'charms.testcharm.v3.testlib'
+    assert lib_data.full_name == "charms.testcharm.v3.testlib"
     assert lib_data.path == test_path
-    assert lib_data.lib_name == 'testlib'
-    assert lib_data.charm_name == 'testcharm'
+    assert lib_data.lib_name == "testlib"
+    assert lib_data.charm_name == "testcharm"
 
 
 def test_getlibinfo_success_content(tmp_path, monkeypatch):
@@ -1676,57 +1896,75 @@ def test_getlibinfo_success_content(tmp_path, monkeypatch):
 
     lib_data = _get_lib_info(lib_path=test_path)
     assert lib_data.content == test_path.read_text()
-    assert lib_data.content_hash == hashlib.sha256(extra_content.encode('utf8')).hexdigest()
+    assert (
+        lib_data.content_hash
+        == hashlib.sha256(extra_content.encode("utf8")).hexdigest()
+    )
 
 
-@pytest.mark.parametrize('name', [
-    'charms.testcharm.v3.testlib.py',
-    'charms.testcharm.testlib',
-    'testcharm.v2.testlib',
-    'mycharms.testcharm.v2.testlib',
-])
+@pytest.mark.parametrize(
+    "name",
+    [
+        "charms.testcharm.v3.testlib.py",
+        "charms.testcharm.testlib",
+        "testcharm.v2.testlib",
+        "mycharms.testcharm.v2.testlib",
+    ],
+)
 def test_getlibinfo_bad_name(name):
     """Different combinations of a bad library name."""
     with pytest.raises(CommandError) as err:
         _get_lib_info(full_name=name)
     assert str(err.value) == (
-        "Charm library name {!r} must conform to charms.<charm>.vN.<libname>".format(name))
+        "Charm library name {!r} must conform to charms.<charm>.vN.<libname>".format(
+            name
+        )
+    )
 
 
-@pytest.mark.parametrize('path', [
-    'charms/testcharm/v3/testlib',
-    'charms/testcharm/v3/testlib.html',
-    'charms/testcharm/v3/testlib.',
-    'charms/testcharm/testlib.py',
-    'testcharm/v2/testlib.py',
-    'mycharms/testcharm/v2/testlib.py',
-])
+@pytest.mark.parametrize(
+    "path",
+    [
+        "charms/testcharm/v3/testlib",
+        "charms/testcharm/v3/testlib.html",
+        "charms/testcharm/v3/testlib.",
+        "charms/testcharm/testlib.py",
+        "testcharm/v2/testlib.py",
+        "mycharms/testcharm/v2/testlib.py",
+    ],
+)
 def test_getlibinfo_bad_path(path):
     """Different combinations of a bad library path."""
     with pytest.raises(CommandError) as err:
         _get_lib_info(lib_path=pathlib.Path(path))
     assert str(err.value) == (
-        "Charm library path {} must conform to lib/charms/<charm>/vN/<libname>.py"
-        .format(path))
+        "Charm library path {} must conform to lib/charms/<charm>/vN/<libname>.py".format(
+            path
+        )
+    )
 
 
-@pytest.mark.parametrize('name', [
-    'charms.testcharm.v-three.testlib',
-    'charms.testcharm.v-3.testlib',
-    'charms.testcharm.3.testlib',
-    'charms.testcharm.vX.testlib',
-])
+@pytest.mark.parametrize(
+    "name",
+    [
+        "charms.testcharm.v-three.testlib",
+        "charms.testcharm.v-3.testlib",
+        "charms.testcharm.3.testlib",
+        "charms.testcharm.vX.testlib",
+    ],
+)
 def test_getlibinfo_bad_api(name):
     """Different combinations of a bad api in the path/name."""
     with pytest.raises(CommandError) as err:
         _get_lib_info(full_name=name)
     assert str(err.value) == (
-        "The API version in the library path must be 'vN' where N is an integer.")
+        "The API version in the library path must be 'vN' where N is an integer."
+    )
 
 
 def test_getlibinfo_missing_library_from_name():
     """Partial case for when the library is not found in disk, starting from the name."""
-    test_name = 'charms.testcharm.v3.testlib'
+    test_name = "charms.testcharm.v3.testlib"
     # no create lib!
     lib_data = _get_lib_info(full_name=test_name)
     assert lib_data.lib_id is None
@@ -1735,14 +1973,17 @@ def test_getlibinfo_missing_library_from_name():
     assert lib_data.content_hash is None
     assert lib_data.content is None
     assert lib_data.full_name == test_name
-    assert lib_data.path == pathlib.Path('lib') / 'charms' / 'testcharm' / 'v3' / 'testlib.py'
-    assert lib_data.lib_name == 'testlib'
-    assert lib_data.charm_name == 'testcharm'
+    assert (
+        lib_data.path
+        == pathlib.Path("lib") / "charms" / "testcharm" / "v3" / "testlib.py"
+    )
+    assert lib_data.lib_name == "testlib"
+    assert lib_data.charm_name == "testcharm"
 
 
 def test_getlibinfo_missing_library_from_path():
     """Partial case for when the library is not found in disk, starting from the path."""
-    test_path = pathlib.Path('lib') / 'charms' / 'testcharm' / 'v3' / 'testlib.py'
+    test_path = pathlib.Path("lib") / "charms" / "testcharm" / "v3" / "testlib.py"
     # no create lib!
     lib_data = _get_lib_info(lib_path=test_path)
     assert lib_data.lib_id is None
@@ -1750,10 +1991,10 @@ def test_getlibinfo_missing_library_from_path():
     assert lib_data.patch == -1
     assert lib_data.content_hash is None
     assert lib_data.content is None
-    assert lib_data.full_name == 'charms.testcharm.v3.testlib'
+    assert lib_data.full_name == "charms.testcharm.v3.testlib"
     assert lib_data.path == test_path
-    assert lib_data.lib_name == 'testlib'
-    assert lib_data.charm_name == 'testcharm'
+    assert lib_data.lib_name == "testlib"
+    assert lib_data.charm_name == "testcharm"
 
 
 def test_getlibinfo_malformed_metadata_field(tmp_path, monkeypatch):
@@ -1762,7 +2003,9 @@ def test_getlibinfo_malformed_metadata_field(tmp_path, monkeypatch):
     test_path = _create_lib(metadata_id="LIBID = foo = 23")
     with pytest.raises(CommandError) as err:
         _get_lib_info(lib_path=test_path)
-    assert str(err.value) == r"Bad metadata line in {}: b'LIBID = foo = 23\n'".format(test_path)
+    assert str(err.value) == r"Bad metadata line in {}: b'LIBID = foo = 23\n'".format(
+        test_path
+    )
 
 
 def test_getlibinfo_missing_metadata_field(tmp_path, monkeypatch):
@@ -1772,7 +2015,10 @@ def test_getlibinfo_missing_metadata_field(tmp_path, monkeypatch):
     with pytest.raises(CommandError) as err:
         _get_lib_info(lib_path=test_path)
     assert str(err.value) == (
-        "Library {} is missing the mandatory metadata fields: LIBAPI, LIBPATCH.".format(test_path))
+        "Library {} is missing the mandatory metadata fields: LIBAPI, LIBPATCH.".format(
+            test_path
+        )
+    )
 
 
 def test_getlibinfo_api_not_int(tmp_path, monkeypatch):
@@ -1782,7 +2028,10 @@ def test_getlibinfo_api_not_int(tmp_path, monkeypatch):
     with pytest.raises(CommandError) as err:
         _get_lib_info(lib_path=test_path)
     assert str(err.value) == (
-        "Library {} metadata field LIBAPI is not zero or a positive integer.".format(test_path))
+        "Library {} metadata field LIBAPI is not zero or a positive integer.".format(
+            test_path
+        )
+    )
 
 
 def test_getlibinfo_api_negative(tmp_path, monkeypatch):
@@ -1792,7 +2041,10 @@ def test_getlibinfo_api_negative(tmp_path, monkeypatch):
     with pytest.raises(CommandError) as err:
         _get_lib_info(lib_path=test_path)
     assert str(err.value) == (
-        "Library {} metadata field LIBAPI is not zero or a positive integer.".format(test_path))
+        "Library {} metadata field LIBAPI is not zero or a positive integer.".format(
+            test_path
+        )
+    )
 
 
 def test_getlibinfo_patch_not_int(tmp_path, monkeypatch):
@@ -1802,7 +2054,10 @@ def test_getlibinfo_patch_not_int(tmp_path, monkeypatch):
     with pytest.raises(CommandError) as err:
         _get_lib_info(lib_path=test_path)
     assert str(err.value) == (
-        "Library {} metadata field LIBPATCH is not zero or a positive integer.".format(test_path))
+        "Library {} metadata field LIBPATCH is not zero or a positive integer.".format(
+            test_path
+        )
+    )
 
 
 def test_getlibinfo_patch_negative(tmp_path, monkeypatch):
@@ -1812,7 +2067,10 @@ def test_getlibinfo_patch_negative(tmp_path, monkeypatch):
     with pytest.raises(CommandError) as err:
         _get_lib_info(lib_path=test_path)
     assert str(err.value) == (
-        "Library {} metadata field LIBPATCH is not zero or a positive integer.".format(test_path))
+        "Library {} metadata field LIBPATCH is not zero or a positive integer.".format(
+            test_path
+        )
+    )
 
 
 def test_getlibinfo_api_patch_both_zero(tmp_path, monkeypatch):
@@ -1822,7 +2080,10 @@ def test_getlibinfo_api_patch_both_zero(tmp_path, monkeypatch):
     with pytest.raises(CommandError) as err:
         _get_lib_info(lib_path=test_path)
     assert str(err.value) == (
-        "Library {} metadata fields LIBAPI and LIBPATCH cannot both be zero.".format(test_path))
+        "Library {} metadata fields LIBAPI and LIBPATCH cannot both be zero.".format(
+            test_path
+        )
+    )
 
 
 def test_getlibinfo_metadata_api_different_path_api(tmp_path, monkeypatch):
@@ -1832,8 +2093,10 @@ def test_getlibinfo_metadata_api_different_path_api(tmp_path, monkeypatch):
     with pytest.raises(CommandError) as err:
         _get_lib_info(lib_path=test_path)
     assert str(err.value) == (
-        "Library {} metadata field LIBAPI is different from the version in the path."
-        .format(test_path))
+        "Library {} metadata field LIBAPI is different from the version in the path.".format(
+            test_path
+        )
+    )
 
 
 def test_getlibinfo_libid_non_string(tmp_path, monkeypatch):
@@ -1843,7 +2106,10 @@ def test_getlibinfo_libid_non_string(tmp_path, monkeypatch):
     with pytest.raises(CommandError) as err:
         _get_lib_info(lib_path=test_path)
     assert str(err.value) == (
-        "Library {} metadata field LIBID must be a non-empty ASCII string.".format(test_path))
+        "Library {} metadata field LIBID must be a non-empty ASCII string.".format(
+            test_path
+        )
+    )
 
 
 def test_getlibinfo_libid_non_ascii(tmp_path, monkeypatch):
@@ -1853,7 +2119,10 @@ def test_getlibinfo_libid_non_ascii(tmp_path, monkeypatch):
     with pytest.raises(CommandError) as err:
         _get_lib_info(lib_path=test_path)
     assert str(err.value) == (
-        "Library {} metadata field LIBID must be a non-empty ASCII string.".format(test_path))
+        "Library {} metadata field LIBID must be a non-empty ASCII string.".format(
+            test_path
+        )
+    )
 
 
 def test_getlibinfo_libid_empty(tmp_path, monkeypatch):
@@ -1863,93 +2132,141 @@ def test_getlibinfo_libid_empty(tmp_path, monkeypatch):
     with pytest.raises(CommandError) as err:
         _get_lib_info(lib_path=test_path)
     assert str(err.value) == (
-        "Library {} metadata field LIBID must be a non-empty ASCII string.".format(test_path))
+        "Library {} metadata field LIBID must be a non-empty ASCII string.".format(
+            test_path
+        )
+    )
 
 
 # -- tests for fetch libraries command
+
 
 def test_fetchlib_simple_downloaded(caplog, store_mock, tmp_path, monkeypatch, config):
     """Happy path fetching the lib for the first time (downloading it)."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
     monkeypatch.chdir(tmp_path)
 
-    lib_id = 'test-example-lib-id'
-    lib_content = 'some test content with uñicode ;)'
+    lib_id = "test-example-lib-id"
+    lib_content = "some test content with uñicode ;)"
     store_mock.get_libraries_tips.return_value = {
         (lib_id, 0): Library(
-            lib_id=lib_id, content=None, content_hash='abc', api=0, patch=7,
-            lib_name='testlib', charm_name='testcharm'),
+            lib_id=lib_id,
+            content=None,
+            content_hash="abc",
+            api=0,
+            patch=7,
+            lib_name="testlib",
+            charm_name="testcharm",
+        ),
     }
     store_mock.get_library.return_value = Library(
-        lib_id=lib_id, content=lib_content, content_hash='abc', api=0, patch=7,
-        lib_name='testlib', charm_name='testcharm')
+        lib_id=lib_id,
+        content=lib_content,
+        content_hash="abc",
+        api=0,
+        patch=7,
+        lib_name="testlib",
+        charm_name="testcharm",
+    )
 
-    FetchLibCommand('group', config).run(Namespace(library='charms.testcharm.v0.testlib'))
+    FetchLibCommand("group", config).run(
+        Namespace(library="charms.testcharm.v0.testlib")
+    )
 
     assert store_mock.mock_calls == [
         call.get_libraries_tips(
-            [{'charm_name': 'testcharm', 'lib_name': 'testlib', 'api': 0}]),
-        call.get_library('testcharm', lib_id, 0),
+            [{"charm_name": "testcharm", "lib_name": "testlib", "api": 0}]
+        ),
+        call.get_library("testcharm", lib_id, 0),
     ]
     expected = "Library charms.testcharm.v0.testlib version 0.7 downloaded."
     assert [expected] == [rec.message for rec in caplog.records]
-    saved_file = tmp_path / 'lib' / 'charms' / 'testcharm' / 'v0' / 'testlib.py'
+    saved_file = tmp_path / "lib" / "charms" / "testcharm" / "v0" / "testlib.py"
     assert saved_file.read_text() == lib_content
 
 
-def test_fetchlib_simple_dash_in_name(caplog, store_mock, tmp_path, monkeypatch, config):
+def test_fetchlib_simple_dash_in_name(
+    caplog, store_mock, tmp_path, monkeypatch, config
+):
     """Happy path fetching the lib for the first time (downloading it)."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
     monkeypatch.chdir(tmp_path)
 
-    lib_id = 'test-example-lib-id'
-    lib_content = 'some test content with uñicode ;)'
+    lib_id = "test-example-lib-id"
+    lib_content = "some test content with uñicode ;)"
     store_mock.get_libraries_tips.return_value = {
         (lib_id, 0): Library(
-            lib_id=lib_id, content=None, content_hash='abc', api=0, patch=7,
-            lib_name='testlib', charm_name='test-charm'),
+            lib_id=lib_id,
+            content=None,
+            content_hash="abc",
+            api=0,
+            patch=7,
+            lib_name="testlib",
+            charm_name="test-charm",
+        ),
     }
     store_mock.get_library.return_value = Library(
-        lib_id=lib_id, content=lib_content, content_hash='abc', api=0, patch=7,
-        lib_name='testlib', charm_name='test-charm')
+        lib_id=lib_id,
+        content=lib_content,
+        content_hash="abc",
+        api=0,
+        patch=7,
+        lib_name="testlib",
+        charm_name="test-charm",
+    )
 
-    FetchLibCommand('group', config).run(Namespace(library='charms.test_charm.v0.testlib'))
+    FetchLibCommand("group", config).run(
+        Namespace(library="charms.test_charm.v0.testlib")
+    )
 
     assert store_mock.mock_calls == [
         call.get_libraries_tips(
-            [{'charm_name': 'test-charm', 'lib_name': 'testlib', 'api': 0}]),
-        call.get_library('test-charm', lib_id, 0),
+            [{"charm_name": "test-charm", "lib_name": "testlib", "api": 0}]
+        ),
+        call.get_library("test-charm", lib_id, 0),
     ]
     expected = "Library charms.test_charm.v0.testlib version 0.7 downloaded."
     assert [expected] == [rec.message for rec in caplog.records]
-    saved_file = tmp_path / 'lib' / 'charms' / 'test_charm' / 'v0' / 'testlib.py'
+    saved_file = tmp_path / "lib" / "charms" / "test_charm" / "v0" / "testlib.py"
     assert saved_file.read_text() == lib_content
 
 
-def test_fetchlib_simple_dash_in_name_on_disk(caplog, store_mock, tmp_path, monkeypatch, config):
+def test_fetchlib_simple_dash_in_name_on_disk(
+    caplog, store_mock, tmp_path, monkeypatch, config
+):
     """Happy path fetching the lib for the first time (downloading it)."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
     monkeypatch.chdir(tmp_path)
 
-    lib_id = 'test-example-lib-id'
+    lib_id = "test-example-lib-id"
     lib_content = "test-content"
     store_mock.get_libraries_tips.return_value = {
         (lib_id, 0): Library(
-            lib_id=lib_id, content=None, content_hash='abc', api=0, patch=7,
-            lib_name='testlib', charm_name='test-charm'),
+            lib_id=lib_id,
+            content=None,
+            content_hash="abc",
+            api=0,
+            patch=7,
+            lib_name="testlib",
+            charm_name="test-charm",
+        ),
     }
     store_mock.get_library.return_value = Library(
-        lib_id=lib_id, content=lib_content, content_hash='abc', api=0, patch=7,
-        lib_name='testlib', charm_name='test-charm')
-    factory.create_lib_filepath(
-        'test-charm', 'testlib', api=0, patch=1, lib_id=lib_id)
+        lib_id=lib_id,
+        content=lib_content,
+        content_hash="abc",
+        api=0,
+        patch=7,
+        lib_name="testlib",
+        charm_name="test-charm",
+    )
+    factory.create_lib_filepath("test-charm", "testlib", api=0, patch=1, lib_id=lib_id)
 
-    FetchLibCommand('group', config).run(Namespace(library=None))
+    FetchLibCommand("group", config).run(Namespace(library=None))
 
     assert store_mock.mock_calls == [
-        call.get_libraries_tips(
-            [{'lib_id': 'test-example-lib-id', 'api': 0}]),
-        call.get_library('test-charm', lib_id, 0),
+        call.get_libraries_tips([{"lib_id": "test-example-lib-id", "api": 0}]),
+        call.get_library("test-charm", lib_id, 0),
     ]
     expected = "Library charms.test_charm.v0.testlib updated to version 0.7."
     assert [expected] == [rec.message for rec in caplog.records]
@@ -1960,29 +2277,44 @@ def test_fetchlib_simple_updated(caplog, store_mock, tmp_path, monkeypatch, conf
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
     monkeypatch.chdir(tmp_path)
 
-    lib_id = 'test-example-lib-id'
+    lib_id = "test-example-lib-id"
     content, content_hash = factory.create_lib_filepath(
-        'testcharm', 'testlib', api=0, patch=1, lib_id=lib_id)
+        "testcharm", "testlib", api=0, patch=1, lib_id=lib_id
+    )
 
-    new_lib_content = 'some test content with uñicode ;)'
+    new_lib_content = "some test content with uñicode ;)"
     store_mock.get_libraries_tips.return_value = {
         (lib_id, 0): Library(
-            lib_id=lib_id, content=None, content_hash='abc', api=0, patch=2,
-            lib_name='testlib', charm_name='testcharm'),
+            lib_id=lib_id,
+            content=None,
+            content_hash="abc",
+            api=0,
+            patch=2,
+            lib_name="testlib",
+            charm_name="testcharm",
+        ),
     }
     store_mock.get_library.return_value = Library(
-        lib_id=lib_id, content=new_lib_content, content_hash='abc', api=0, patch=2,
-        lib_name='testlib', charm_name='testcharm')
+        lib_id=lib_id,
+        content=new_lib_content,
+        content_hash="abc",
+        api=0,
+        patch=2,
+        lib_name="testlib",
+        charm_name="testcharm",
+    )
 
-    FetchLibCommand('group', config).run(Namespace(library='charms.testcharm.v0.testlib'))
+    FetchLibCommand("group", config).run(
+        Namespace(library="charms.testcharm.v0.testlib")
+    )
 
     assert store_mock.mock_calls == [
-        call.get_libraries_tips([{'lib_id': lib_id, 'api': 0}]),
-        call.get_library('testcharm', lib_id, 0),
+        call.get_libraries_tips([{"lib_id": lib_id, "api": 0}]),
+        call.get_library("testcharm", lib_id, 0),
     ]
     expected = "Library charms.testcharm.v0.testlib updated to version 0.2."
     assert [expected] == [rec.message for rec in caplog.records]
-    saved_file = tmp_path / 'lib' / 'charms' / 'testcharm' / 'v0' / 'testlib.py'
+    saved_file = tmp_path / "lib" / "charms" / "testcharm" / "v0" / "testlib.py"
     assert saved_file.read_text() == new_lib_content
 
 
@@ -1992,41 +2324,69 @@ def test_fetchlib_all(caplog, store_mock, tmp_path, monkeypatch, config):
     monkeypatch.chdir(tmp_path)
 
     c1, h1 = factory.create_lib_filepath(
-        'testcharm1', 'testlib1', api=0, patch=1, lib_id='lib_id_1')
+        "testcharm1", "testlib1", api=0, patch=1, lib_id="lib_id_1"
+    )
     c2, h2 = factory.create_lib_filepath(
-        'testcharm2', 'testlib2', api=3, patch=5, lib_id='lib_id_2')
+        "testcharm2", "testlib2", api=3, patch=5, lib_id="lib_id_2"
+    )
 
     store_mock.get_libraries_tips.return_value = {
-        ('lib_id_1', 0): Library(
-            lib_id='lib_id_1', content=None, content_hash='abc', api=0, patch=2,
-            lib_name='testlib1', charm_name='testcharm1'),
-        ('lib_id_2', 3): Library(
-            lib_id='lib_id_2', content=None, content_hash='def', api=3, patch=14,
-            lib_name='testlib2', charm_name='testcharm2'),
+        ("lib_id_1", 0): Library(
+            lib_id="lib_id_1",
+            content=None,
+            content_hash="abc",
+            api=0,
+            patch=2,
+            lib_name="testlib1",
+            charm_name="testcharm1",
+        ),
+        ("lib_id_2", 3): Library(
+            lib_id="lib_id_2",
+            content=None,
+            content_hash="def",
+            api=3,
+            patch=14,
+            lib_name="testlib2",
+            charm_name="testcharm2",
+        ),
     }
     _store_libs_info = [
         Library(
-            lib_id='lib_id_1', content='new lib content 1', content_hash='xxx', api=0, patch=2,
-            lib_name='testlib1', charm_name='testcharm1'),
+            lib_id="lib_id_1",
+            content="new lib content 1",
+            content_hash="xxx",
+            api=0,
+            patch=2,
+            lib_name="testlib1",
+            charm_name="testcharm1",
+        ),
         Library(
-            lib_id='lib_id_2', content='new lib content 2', content_hash='yyy', api=3, patch=14,
-            lib_name='testlib2', charm_name='testcharm2'),
+            lib_id="lib_id_2",
+            content="new lib content 2",
+            content_hash="yyy",
+            api=3,
+            patch=14,
+            lib_name="testlib2",
+            charm_name="testcharm2",
+        ),
     ]
     store_mock.get_library.side_effect = lambda *a: _store_libs_info.pop(0)
 
-    FetchLibCommand('group', config).run(Namespace(library=None))
+    FetchLibCommand("group", config).run(Namespace(library=None))
 
     assert store_mock.mock_calls == [
-        call.get_libraries_tips([
-            {'lib_id': 'lib_id_1', 'api': 0},
-            {'lib_id': 'lib_id_2', 'api': 3},
-        ]),
-        call.get_library('testcharm1', 'lib_id_1', 0),
-        call.get_library('testcharm2', 'lib_id_2', 3),
+        call.get_libraries_tips(
+            [
+                {"lib_id": "lib_id_1", "api": 0},
+                {"lib_id": "lib_id_2", "api": 3},
+            ]
+        ),
+        call.get_library("testcharm1", "lib_id_1", 0),
+        call.get_library("testcharm2", "lib_id_2", 3),
     ]
     names = [
-        'charms.testcharm1.v0.testlib1',
-        'charms.testcharm2.v3.testlib2',
+        "charms.testcharm1.v0.testlib1",
+        "charms.testcharm2.v3.testlib2",
     ]
     expected = [
         "Libraries found under lib/charms: " + str(names),
@@ -2036,10 +2396,10 @@ def test_fetchlib_all(caplog, store_mock, tmp_path, monkeypatch, config):
 
     records = [rec.message for rec in caplog.records]
     assert all(e in records for e in expected)
-    saved_file = tmp_path / 'lib' / 'charms' / 'testcharm1' / 'v0' / 'testlib1.py'
-    assert saved_file.read_text() == 'new lib content 1'
-    saved_file = tmp_path / 'lib' / 'charms' / 'testcharm2' / 'v3' / 'testlib2.py'
-    assert saved_file.read_text() == 'new lib content 2'
+    saved_file = tmp_path / "lib" / "charms" / "testcharm1" / "v0" / "testlib1.py"
+    assert saved_file.read_text() == "new lib content 1"
+    saved_file = tmp_path / "lib" / "charms" / "testcharm2" / "v3" / "testlib2.py"
+    assert saved_file.read_text() == "new lib content 2"
 
 
 def test_fetchlib_store_not_found(caplog, store_mock, config):
@@ -2047,11 +2407,14 @@ def test_fetchlib_store_not_found(caplog, store_mock, config):
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
     store_mock.get_libraries_tips.return_value = {}
-    FetchLibCommand('group', config).run(Namespace(library='charms.testcharm.v0.testlib'))
+    FetchLibCommand("group", config).run(
+        Namespace(library="charms.testcharm.v0.testlib")
+    )
 
     assert store_mock.mock_calls == [
         call.get_libraries_tips(
-            [{'charm_name': 'testcharm', 'lib_name': 'testlib', 'api': 0}]),
+            [{"charm_name": "testcharm", "lib_name": "testlib", "api": 0}]
+        ),
     ]
     expected = "Library charms.testcharm.v0.testlib not found in Charmhub."
     assert [expected] == [rec.message for rec in caplog.records]
@@ -2062,84 +2425,126 @@ def test_fetchlib_store_is_old(caplog, store_mock, tmp_path, monkeypatch, config
     caplog.set_level(logging.DEBUG, logger="charmcraft.commands")
     monkeypatch.chdir(tmp_path)
 
-    lib_id = 'test-example-lib-id'
-    factory.create_lib_filepath('testcharm', 'testlib', api=0, patch=7, lib_id=lib_id)
+    lib_id = "test-example-lib-id"
+    factory.create_lib_filepath("testcharm", "testlib", api=0, patch=7, lib_id=lib_id)
 
     store_mock.get_libraries_tips.return_value = {
         (lib_id, 0): Library(
-            lib_id=lib_id, content=None, content_hash='abc', api=0, patch=6,
-            lib_name='testlib', charm_name='testcharm'),
+            lib_id=lib_id,
+            content=None,
+            content_hash="abc",
+            api=0,
+            patch=6,
+            lib_name="testlib",
+            charm_name="testcharm",
+        ),
     }
-    FetchLibCommand('group', config).run(Namespace(library='charms.testcharm.v0.testlib'))
+    FetchLibCommand("group", config).run(
+        Namespace(library="charms.testcharm.v0.testlib")
+    )
 
     assert store_mock.mock_calls == [
-        call.get_libraries_tips([{'lib_id': lib_id, 'api': 0}]),
+        call.get_libraries_tips([{"lib_id": lib_id, "api": 0}]),
     ]
-    expected = "Library charms.testcharm.v0.testlib has local changes, can not be updated."
+    expected = (
+        "Library charms.testcharm.v0.testlib has local changes, can not be updated."
+    )
     assert expected in [rec.message for rec in caplog.records]
 
 
-def test_fetchlib_store_same_versions_same_hash(caplog, store_mock, tmp_path, monkeypatch, config):
+def test_fetchlib_store_same_versions_same_hash(
+    caplog, store_mock, tmp_path, monkeypatch, config
+):
     """The store situation is the same than locally."""
     caplog.set_level(logging.DEBUG, logger="charmcraft.commands")
     monkeypatch.chdir(tmp_path)
 
-    lib_id = 'test-example-lib-id'
-    _, c_hash = factory.create_lib_filepath('testcharm', 'testlib', api=0, patch=7, lib_id=lib_id)
+    lib_id = "test-example-lib-id"
+    _, c_hash = factory.create_lib_filepath(
+        "testcharm", "testlib", api=0, patch=7, lib_id=lib_id
+    )
 
     store_mock.get_libraries_tips.return_value = {
         (lib_id, 0): Library(
-            lib_id=lib_id, content=None, content_hash=c_hash, api=0, patch=7,
-            lib_name='testlib', charm_name='testcharm'),
+            lib_id=lib_id,
+            content=None,
+            content_hash=c_hash,
+            api=0,
+            patch=7,
+            lib_name="testlib",
+            charm_name="testcharm",
+        ),
     }
-    FetchLibCommand('group', config).run(Namespace(library='charms.testcharm.v0.testlib'))
+    FetchLibCommand("group", config).run(
+        Namespace(library="charms.testcharm.v0.testlib")
+    )
 
     assert store_mock.mock_calls == [
-        call.get_libraries_tips([{'lib_id': lib_id, 'api': 0}]),
+        call.get_libraries_tips([{"lib_id": lib_id, "api": 0}]),
     ]
-    expected = "Library charms.testcharm.v0.testlib was already up to date in version 0.7."
+    expected = (
+        "Library charms.testcharm.v0.testlib was already up to date in version 0.7."
+    )
     assert expected in [rec.message for rec in caplog.records]
 
 
 def test_fetchlib_store_same_versions_different_hash(
-        caplog, store_mock, tmp_path, monkeypatch, config):
+    caplog, store_mock, tmp_path, monkeypatch, config
+):
     """The store has the lib in the same version, but with different content."""
     caplog.set_level(logging.DEBUG, logger="charmcraft.commands")
     monkeypatch.chdir(tmp_path)
 
-    lib_id = 'test-example-lib-id'
-    factory.create_lib_filepath('testcharm', 'testlib', api=0, patch=7, lib_id=lib_id)
+    lib_id = "test-example-lib-id"
+    factory.create_lib_filepath("testcharm", "testlib", api=0, patch=7, lib_id=lib_id)
 
     store_mock.get_libraries_tips.return_value = {
         (lib_id, 0): Library(
-            lib_id=lib_id, content=None, content_hash='abc', api=0, patch=7,
-            lib_name='testlib', charm_name='testcharm'),
+            lib_id=lib_id,
+            content=None,
+            content_hash="abc",
+            api=0,
+            patch=7,
+            lib_name="testlib",
+            charm_name="testcharm",
+        ),
     }
-    FetchLibCommand('group', config).run(Namespace(library='charms.testcharm.v0.testlib'))
+    FetchLibCommand("group", config).run(
+        Namespace(library="charms.testcharm.v0.testlib")
+    )
 
     assert store_mock.mock_calls == [
-        call.get_libraries_tips([{'lib_id': lib_id, 'api': 0}]),
+        call.get_libraries_tips([{"lib_id": lib_id, "api": 0}]),
     ]
-    expected = "Library charms.testcharm.v0.testlib has local changes, can not be updated."
+    expected = (
+        "Library charms.testcharm.v0.testlib has local changes, can not be updated."
+    )
     assert expected in [rec.message for rec in caplog.records]
 
 
 # -- tests for list libraries command
+
 
 def test_listlib_simple(caplog, store_mock, config):
     """Happy path listing simple case."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
     store_mock.get_libraries_tips.return_value = {
-        ('some-lib-id', 3): Library(
-            lib_id='some-lib-id', content=None, content_hash='abc', api=3, patch=7,
-            lib_name='testlib', charm_name='testcharm'),
+        ("some-lib-id", 3): Library(
+            lib_id="some-lib-id",
+            content=None,
+            content_hash="abc",
+            api=3,
+            patch=7,
+            lib_name="testlib",
+            charm_name="testcharm",
+        ),
     }
-    args = Namespace(name='testcharm')
-    ListLibCommand('group', config).run(args)
+    args = Namespace(name="testcharm")
+    ListLibCommand("group", config).run(args)
 
     assert store_mock.mock_calls == [
-        call.get_libraries_tips([{'charm_name': 'testcharm'}]),
+        call.get_libraries_tips([{"charm_name": "testcharm"}]),
     ]
     expected = [
         "Library name    API    Patch",
@@ -2154,27 +2559,28 @@ def test_listlib_charm_from_metadata(caplog, store_mock, config):
 
     store_mock.get_libraries_tips.return_value = {}
     args = Namespace(name=None)
-    with patch('charmcraft.commands.store.get_name_from_metadata') as mock:
-        mock.return_value = 'testcharm'
-        ListLibCommand('group', config).run(args)
+    with patch("charmcraft.commands.store.get_name_from_metadata") as mock:
+        mock.return_value = "testcharm"
+        ListLibCommand("group", config).run(args)
 
     assert store_mock.mock_calls == [
-        call.get_libraries_tips([{'charm_name': 'testcharm'}]),
+        call.get_libraries_tips([{"charm_name": "testcharm"}]),
     ]
 
 
 def test_listlib_name_from_metadata_problem(store_mock, config):
     """The metadata wasn't there to get the name."""
     args = Namespace(name=None)
-    with patch('charmcraft.commands.store.get_name_from_metadata') as mock:
+    with patch("charmcraft.commands.store.get_name_from_metadata") as mock:
         mock.return_value = None
         with pytest.raises(CommandError) as cm:
-            ListLibCommand('group', config).run(args)
+            ListLibCommand("group", config).run(args)
 
         assert str(cm.value) == (
             "Can't access name in 'metadata.yaml' file. The 'list-lib' command must either be "
             "executed from a valid project directory, or specify a charm name using "
-            "the --charm-name option.")
+            "the --charm-name option."
+        )
 
 
 def test_listlib_empty(caplog, store_mock, config):
@@ -2182,8 +2588,8 @@ def test_listlib_empty(caplog, store_mock, config):
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
     store_mock.get_libraries_tips.return_value = {}
-    args = Namespace(name='testcharm')
-    ListLibCommand('group', config).run(args)
+    args = Namespace(name="testcharm")
+    ListLibCommand("group", config).run(args)
 
     expected = "No libraries found for charm testcharm."
     assert [expected] == [rec.message for rec in caplog.records]
@@ -2194,21 +2600,39 @@ def test_listlib_properly_sorted(caplog, store_mock, config):
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
     store_mock.get_libraries_tips.return_value = {
-        ('lib-id-2', 3): Library(
-            lib_id='lib-id-1', content=None, content_hash='abc', api=3, patch=7,
-            lib_name='testlib-2', charm_name='testcharm'),
-        ('lib-id-2', 2): Library(
-            lib_id='lib-id-1', content=None, content_hash='abc', api=2, patch=8,
-            lib_name='testlib-2', charm_name='testcharm'),
-        ('lib-id-1', 5): Library(
-            lib_id='lib-id-1', content=None, content_hash='abc', api=5, patch=124,
-            lib_name='testlib-1', charm_name='testcharm'),
+        ("lib-id-2", 3): Library(
+            lib_id="lib-id-1",
+            content=None,
+            content_hash="abc",
+            api=3,
+            patch=7,
+            lib_name="testlib-2",
+            charm_name="testcharm",
+        ),
+        ("lib-id-2", 2): Library(
+            lib_id="lib-id-1",
+            content=None,
+            content_hash="abc",
+            api=2,
+            patch=8,
+            lib_name="testlib-2",
+            charm_name="testcharm",
+        ),
+        ("lib-id-1", 5): Library(
+            lib_id="lib-id-1",
+            content=None,
+            content_hash="abc",
+            api=5,
+            patch=124,
+            lib_name="testlib-1",
+            charm_name="testcharm",
+        ),
     }
-    args = Namespace(name='testcharm')
-    ListLibCommand('group', config).run(args)
+    args = Namespace(name="testcharm")
+    ListLibCommand("group", config).run(args)
 
     assert store_mock.mock_calls == [
-        call.get_libraries_tips([{'charm_name': 'testcharm'}]),
+        call.get_libraries_tips([{"charm_name": "testcharm"}]),
     ]
     expected = [
         "Library name    API    Patch",
@@ -2221,20 +2645,21 @@ def test_listlib_properly_sorted(caplog, store_mock, config):
 
 # -- tests for list resources command
 
+
 def test_resources_simple(caplog, store_mock, config):
     """Happy path of one result from the Store."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
     store_response = [
-        Resource(name='testresource', optional=True, revision=1, resource_type='file'),
+        Resource(name="testresource", optional=True, revision=1, resource_type="file"),
     ]
     store_mock.list_resources.return_value = store_response
 
-    args = Namespace(charm_name='testcharm')
-    ListResourcesCommand('group', config).run(args)
+    args = Namespace(charm_name="testcharm")
+    ListResourcesCommand("group", config).run(args)
 
     assert store_mock.mock_calls == [
-        call.list_resources('testcharm'),
+        call.list_resources("testcharm"),
     ]
     expected = [
         "Charm Rev    Resource      Type    Optional",
@@ -2250,8 +2675,8 @@ def test_resources_empty(caplog, store_mock, config):
     store_response = []
     store_mock.list_resources.return_value = store_response
 
-    args = Namespace(charm_name='testcharm')
-    ListResourcesCommand('group', config).run(args)
+    args = Namespace(charm_name="testcharm")
+    ListResourcesCommand("group", config).run(args)
 
     expected = [
         "No resources associated to testcharm.",
@@ -2264,16 +2689,16 @@ def test_resources_ordered_and_grouped(caplog, store_mock, config):
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
     store_response = [
-        Resource(name='bbb-resource', optional=True, revision=2, resource_type='file'),
-        Resource(name='ccc-resource', optional=True, revision=1, resource_type='file'),
-        Resource(name='bbb-resource', optional=True, revision=3, resource_type='file'),
-        Resource(name='aaa-resource', optional=True, revision=2, resource_type='file'),
-        Resource(name='bbb-resource', optional=True, revision=5, resource_type='file'),
+        Resource(name="bbb-resource", optional=True, revision=2, resource_type="file"),
+        Resource(name="ccc-resource", optional=True, revision=1, resource_type="file"),
+        Resource(name="bbb-resource", optional=True, revision=3, resource_type="file"),
+        Resource(name="aaa-resource", optional=True, revision=2, resource_type="file"),
+        Resource(name="bbb-resource", optional=True, revision=5, resource_type="file"),
     ]
     store_mock.list_resources.return_value = store_response
 
-    args = Namespace(charm_name='testcharm')
-    ListResourcesCommand('group', config).run(args)
+    args = Namespace(charm_name="testcharm")
+    ListResourcesCommand("group", config).run(args)
 
     expected = [
         "Charm Rev    Resource      Type    Optional",
@@ -2288,37 +2713,43 @@ def test_resources_ordered_and_grouped(caplog, store_mock, config):
 
 # -- tests for upload resources command
 
+
 def test_uploadresource_options_filepath_type(config):
     """The --filepath option implies a set of validations."""
-    cmd = UploadResourceCommand('group', config)
+    cmd = UploadResourceCommand("group", config)
     parser = ArgumentParser()
     cmd.fill_parser(parser)
-    (action,) = [action for action in parser._actions if action.dest == 'filepath']
+    (action,) = [action for action in parser._actions if action.dest == "filepath"]
     assert isinstance(action.type, SingleOptionEnsurer)
     assert action.type.converter is useful_filepath
 
 
 def test_uploadresource_options_image_type(config):
     """The --image option implies a set of validations."""
-    cmd = UploadResourceCommand('group', config)
+    cmd = UploadResourceCommand("group", config)
     parser = ArgumentParser()
     cmd.fill_parser(parser)
-    (action,) = [action for action in parser._actions if action.dest == 'image']
+    (action,) = [action for action in parser._actions if action.dest == "image"]
     assert isinstance(action.type, SingleOptionEnsurer)
     assert action.type.converter is oci_image_spec
 
 
-@pytest.mark.parametrize("sysargs", [
-    ('c', 'r', '--filepath=fpath'),
-    ('c', 'r', '--image=x'),
-])
-def test_uploadresource_options_good_combinations(tmp_path, config, sysargs, monkeypatch):
+@pytest.mark.parametrize(
+    "sysargs",
+    [
+        ("c", "r", "--filepath=fpath"),
+        ("c", "r", "--image=x"),
+    ],
+)
+def test_uploadresource_options_good_combinations(
+    tmp_path, config, sysargs, monkeypatch
+):
     """Check the specific rules for filepath and image/[registry] good combinations."""
     # fake the file for filepath
-    (tmp_path / 'fpath').touch()
+    (tmp_path / "fpath").touch()
     monkeypatch.chdir(tmp_path)
 
-    cmd = UploadResourceCommand('group', config)
+    cmd = UploadResourceCommand("group", config)
     parser = ArgumentParser()
     cmd.fill_parser(parser)
     try:
@@ -2327,17 +2758,22 @@ def test_uploadresource_options_good_combinations(tmp_path, config, sysargs, mon
         pytest.fail("Argument parsing expected to succeed but failed")
 
 
-@pytest.mark.parametrize("sysargs", [
-    ('c', 'r'),  # filepath XOR image needs to be specified
-    ('c', 'r', '--filepath=fpath', '--image=y'),  # can't specify both
-])
-def test_uploadresource_options_bad_combinations(config, sysargs, tmp_path, monkeypatch):
+@pytest.mark.parametrize(
+    "sysargs",
+    [
+        ("c", "r"),  # filepath XOR image needs to be specified
+        ("c", "r", "--filepath=fpath", "--image=y"),  # can't specify both
+    ],
+)
+def test_uploadresource_options_bad_combinations(
+    config, sysargs, tmp_path, monkeypatch
+):
     """Check the specific rules for filepath and image/[registry] bad combinations."""
     # fake the file for filepath
-    (tmp_path / 'fpath').touch()
+    (tmp_path / "fpath").touch()
     monkeypatch.chdir(tmp_path)
 
-    cmd = UploadResourceCommand('group', config)
+    cmd = UploadResourceCommand("group", config)
     parser = ArgumentParser()
     cmd.fill_parser(parser)
     with pytest.raises(SystemExit):
@@ -2352,14 +2788,18 @@ def test_uploadresource_filepath_call_ok(caplog, store_mock, config, tmp_path):
     store_response = Uploaded(ok=True, status=200, revision=7, errors=[])
     store_mock.upload_resource.return_value = store_response
 
-    test_resource = tmp_path / 'mystuff.bin'
+    test_resource = tmp_path / "mystuff.bin"
     test_resource.write_text("sample stuff")
     args = Namespace(
-        charm_name='mycharm', resource_name='myresource', filepath=test_resource, image=None)
-    UploadResourceCommand('group', config).run(args)
+        charm_name="mycharm",
+        resource_name="myresource",
+        filepath=test_resource,
+        image=None,
+    )
+    UploadResourceCommand("group", config).run(args)
 
     assert store_mock.mock_calls == [
-        call.upload_resource('mycharm', 'myresource', 'file', test_resource)
+        call.upload_resource("mycharm", "myresource", "file", test_resource)
     ]
     expected = [
         "Uploading resource directly from file {}".format(test_resource),
@@ -2385,28 +2825,31 @@ def test_uploadresource_image_call_ok(caplog, store_mock, config, tmp_path):
         uploaded_resource_filepath = resource_filepath
         uploaded_resource_content = resource_filepath.read_text()
 
-        assert charm_name == 'mycharm'
-        assert resource_name == 'myresource'
-        assert resource_type == 'oci-image'
+        assert charm_name == "mycharm"
+        assert resource_name == "myresource"
+        assert resource_type == "oci-image"
         return store_response
+
     store_mock.upload_resource.side_effect = interceptor
 
-    spec = OCIImageSpec('test-orga', 'test-image', 'test-tag')
-    args = Namespace(charm_name='mycharm', resource_name='myresource', filepath=None, image=spec)
+    spec = OCIImageSpec("test-orga", "test-image", "test-tag")
+    args = Namespace(
+        charm_name="mycharm", resource_name="myresource", filepath=None, image=spec
+    )
 
-    with patch('charmcraft.commands.store.ImageHandler', autospec=True) as im_class_mock:
+    with patch(
+        "charmcraft.commands.store.ImageHandler", autospec=True
+    ) as im_class_mock:
         im_class_mock.return_value = im_mock = MagicMock()
-        im_mock.get_destination_url.return_value = 'test-final-url'
-        UploadResourceCommand('group', config).run(args)
+        im_mock.get_destination_url.return_value = "test-final-url"
+        UploadResourceCommand("group", config).run(args)
 
     # validate how ImageHandler was used
     assert im_class_mock.mock_calls == [
-        call('test-orga', 'test-image'),
-        call().get_destination_url('test-tag'),
+        call("test-orga", "test-image"),
+        call().get_destination_url("test-tag"),
     ]
-    assert im_mock.mock_calls == [
-        call.get_destination_url('test-tag')
-    ]
+    assert im_mock.mock_calls == [call.get_destination_url("test-tag")]
 
     # check that the uploaded file is fine and that was cleaned
     assert json.loads(uploaded_resource_content) == {"ImageName": "test-final-url"}
@@ -2425,16 +2868,18 @@ def test_uploadresource_call_error(caplog, store_mock, config, tmp_path):
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
     errors = [
-        Error(message="text 1", code='missing-stuff'),
-        Error(message="other long error text", code='broken'),
+        Error(message="text 1", code="missing-stuff"),
+        Error(message="other long error text", code="broken"),
     ]
     store_response = Uploaded(ok=False, status=400, revision=None, errors=errors)
     store_mock.upload_resource.return_value = store_response
 
-    test_resource = tmp_path / 'mystuff.bin'
+    test_resource = tmp_path / "mystuff.bin"
     test_resource.write_text("sample stuff")
-    args = Namespace(charm_name='mycharm', resource_name='myresource', filepath=test_resource)
-    UploadResourceCommand('group', config).run(args)
+    args = Namespace(
+        charm_name="mycharm", resource_name="myresource", filepath=test_resource
+    )
+    UploadResourceCommand("group", config).run(args)
 
     expected = [
         "Upload failed with status 400:",
@@ -2444,32 +2889,45 @@ def test_uploadresource_call_error(caplog, store_mock, config, tmp_path):
     assert expected == [rec.message for rec in caplog.records]
 
 
-@pytest.mark.parametrize('source,expected', [
-    ('testname', OCIImageSpec('library', 'testname', 'latest')),
-    ('testorga/testname', OCIImageSpec('testorga', 'testname', 'latest')),
-    ('testname:sometag', OCIImageSpec('library', 'testname', 'sometag')),
-    ('testorga/testname:sometag', OCIImageSpec('testorga', 'testname', 'sometag')),
-    ('testname@somedigest', OCIImageSpec('library', 'testname', 'somedigest')),
-    ('testorga/testname@somedigest', OCIImageSpec('testorga', 'testname', 'somedigest')),
-])
+@pytest.mark.parametrize(
+    "source,expected",
+    [
+        ("testname", OCIImageSpec("library", "testname", "latest")),
+        ("testorga/testname", OCIImageSpec("testorga", "testname", "latest")),
+        ("testname:sometag", OCIImageSpec("library", "testname", "sometag")),
+        ("testorga/testname:sometag", OCIImageSpec("testorga", "testname", "sometag")),
+        ("testname@somedigest", OCIImageSpec("library", "testname", "somedigest")),
+        (
+            "testorga/testname@somedigest",
+            OCIImageSpec("testorga", "testname", "somedigest"),
+        ),
+    ],
+)
 def test_uploadresource_ociimagespec_ok(source, expected):
     """Check oci image spec format, different good combinations."""
     result = oci_image_spec(source)
     assert result == expected
 
 
-@pytest.mark.parametrize('source,partial_error_message', [
-    ('testname:tag@digest', "Cannot specify both tag and digest"),
-    ('testname@digest:tag', "Cannot specify both tag and digest"),
-    ('@digest:tag', "Cannot specify both tag and digest"),
-    ('', "The image name is mandatory"),
-    (':tag', "The image name is mandatory"),
-    ('server/testorga/name', "The registry server cannot be specified as part of the image"),
-])
+@pytest.mark.parametrize(
+    "source,partial_error_message",
+    [
+        ("testname:tag@digest", "Cannot specify both tag and digest"),
+        ("testname@digest:tag", "Cannot specify both tag and digest"),
+        ("@digest:tag", "Cannot specify both tag and digest"),
+        ("", "The image name is mandatory"),
+        (":tag", "The image name is mandatory"),
+        (
+            "server/testorga/name",
+            "The registry server cannot be specified as part of the image",
+        ),
+    ],
+)
 def test_uploadresource_ociimagespec_error(source, partial_error_message):
     """Check oci image spec format, different bad combinations."""
     error_message = partial_error_message + (
-        " (the format is [organization/]name[:tag|@digest]).")
+        " (the format is [organization/]name[:tag|@digest])."
+    )
     with pytest.raises(CommandError) as cm:
         oci_image_spec(source)
     assert str(cm.value) == error_message
@@ -2477,21 +2935,24 @@ def test_uploadresource_ociimagespec_error(source, partial_error_message):
 
 # -- tests for list resource revisions command
 
+
 def test_resourcerevisions_simple(caplog, store_mock, config):
     """Happy path of one result from the Store."""
 
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
 
     store_response = [
-        ResourceRevision(revision=1, size=50, created_at=datetime.datetime(2020, 7, 3, 2, 30, 40)),
+        ResourceRevision(
+            revision=1, size=50, created_at=datetime.datetime(2020, 7, 3, 2, 30, 40)
+        ),
     ]
     store_mock.list_resource_revisions.return_value = store_response
 
-    args = Namespace(charm_name='testcharm', resource_name='testresource')
-    ListResourceRevisionsCommand('group', config).run(args)
+    args = Namespace(charm_name="testcharm", resource_name="testresource")
+    ListResourceRevisionsCommand("group", config).run(args)
 
     assert store_mock.mock_calls == [
-        call.list_resource_revisions('testcharm', 'testresource'),
+        call.list_resource_revisions("testcharm", "testresource"),
     ]
     expected = [
         "Revision    Created at    Size",
@@ -2507,8 +2968,8 @@ def test_resourcerevisions_empty(caplog, store_mock, config):
     store_response = []
     store_mock.list_resource_revisions.return_value = store_response
 
-    args = Namespace(charm_name='testcharm', resource_name='testresource')
-    ListResourceRevisionsCommand('group', config).run(args)
+    args = Namespace(charm_name="testcharm", resource_name="testresource")
+    ListResourceRevisionsCommand("group", config).run(args)
 
     expected = [
         "No revisions found.",
@@ -2531,8 +2992,8 @@ def test_resourcerevisions_ordered_by_revision(caplog, store_mock, config):
     ]
     store_mock.list_resource_revisions.return_value = store_response
 
-    args = Namespace(charm_name='testcharm', resource_name='testresource')
-    ListResourceRevisionsCommand('group', config).run(args)
+    args = Namespace(charm_name="testcharm", resource_name="testresource")
+    ListResourceRevisionsCommand("group", config).run(args)
 
     expected = [
         "Revision    Created at    Size",

--- a/tests/commands/test_version.py
+++ b/tests/commands/test_version.py
@@ -23,7 +23,7 @@ from charmcraft.commands.version import VersionCommand
 def test_version_result(caplog):
     """Check it produces the right version."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands.version")
-    cmd = VersionCommand('group', 'config')
+    cmd = VersionCommand("group", "config")
     cmd.run([])
     expected = __version__
     assert [expected] == [rec.message for rec in caplog.records]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,7 @@ def monkeypatch(monkeypatch):
 
     class Monkeypatcher:
         """Middle man for chdir."""
+
         def _chdir(self, value):
             """Change dir, but converting to str first.
 
@@ -42,8 +43,8 @@ def monkeypatch(monkeypatch):
             return monkeypatch.chdir(str(value))
 
         def __getattribute__(self, name):
-            if name == 'chdir':
-                return object.__getattribute__(self, '_chdir')
+            if name == "chdir":
+                return object.__getattribute__(self, "_chdir")
             else:
                 return getattr(monkeypatch, name)
 
@@ -59,20 +60,24 @@ def config(tmp_path):
 
         def set(self, **kwargs):
             # prime is special, so we don't need to write all this structure in all tests
-            prime = kwargs.pop('prime', None)
+            prime = kwargs.pop("prime", None)
             if prime is not None:
-                kwargs['parts'] = config_module.BasicPrime.from_dict({
-                    'bundle': {
-                        'prime': prime,
+                kwargs["parts"] = config_module.BasicPrime.from_dict(
+                    {
+                        "bundle": {
+                            "prime": prime,
+                        }
                     }
-                })
+                )
 
             # the rest is direct
             for k, v in kwargs.items():
                 object.__setattr__(self, k, v)
 
-    project = config_module.Project(dirpath=tmp_path, started_at=datetime.datetime.utcnow())
-    return TestConfig(type='bundle', project=project)
+    project = config_module.Project(
+        dirpath=tmp_path, started_at=datetime.datetime.utcnow()
+    )
+    return TestConfig(type="bundle", project=project)
 
 
 @pytest.fixture

--- a/tests/factory.py
+++ b/tests/factory.py
@@ -42,22 +42,26 @@ def create_command(name_, help_msg_=None, common_=False, overview_=None):
     return MyCommand
 
 
-def create_lib_filepath(charm_name, lib_name, api=0, patch=1, lib_id='test-lib-id'):
+def create_lib_filepath(charm_name, lib_name, api=0, patch=1, lib_id="test-lib-id"):
     """Helper to create the structures on disk for a given lib."""
     charm_name = create_importable_name(charm_name)
-    base_dir = pathlib.Path('lib')
-    lib_file = base_dir / 'charms' / charm_name / 'v{}'.format(api) / "{}.py".format(lib_name)
+    base_dir = pathlib.Path("lib")
+    lib_file = (
+        base_dir / "charms" / charm_name / "v{}".format(api) / "{}.py".format(lib_name)
+    )
     lib_file.parent.mkdir(parents=True, exist_ok=True)
 
     # save the content to that specific file under custom structure
-    template = textwrap.dedent("""
+    template = textwrap.dedent(
+        """
         # test content for a library
         LIBID = "{lib_id}"
         LIBAPI = {api}
         LIBPATCH = {patch}
 
         # more text and python code...
-    """)
+    """
+    )
     content = template.format(lib_id=lib_id, api=api, patch=patch)
     lib_file.write_text(content)
 

--- a/tests/test_cmdbase.py
+++ b/tests/test_cmdbase.py
@@ -24,21 +24,21 @@ from charmcraft.main import COMMAND_GROUPS
 
 def test_commanderror_retcode_default():
     """The CommandError return code default."""
-    err = CommandError('problem')
+    err = CommandError("problem")
     assert err.retcode == 1
 
 
 def test_commanderror_retcode_given():
     """The CommandError holds the return code."""
-    err = CommandError('problem', retcode=4)
+    err = CommandError("problem", retcode=4)
     assert err.retcode == 4
 
 
 all_commands = list.__add__(*[commands for _, _, commands in COMMAND_GROUPS])
 
 
-@pytest.mark.parametrize('command', all_commands)
-@pytest.mark.parametrize('attrib', ['name', 'help_msg', 'overview'])
+@pytest.mark.parametrize("command", all_commands)
+@pytest.mark.parametrize("attrib", ["name", "help_msg", "overview"])
 def test_basecommand_mandatory_attributes(command, attrib):
     """All commands must provide the mandatory attributes."""
     assert getattr(command, attrib) is not None
@@ -46,12 +46,13 @@ def test_basecommand_mandatory_attributes(command, attrib):
 
 def test_basecommand_holds_the_indicated_info():
     """BaseCommand subclasses ."""
-    class TestClass(BaseCommand):
-        help_msg = 'help message'
-        name = 'test'
 
-    group = 'test group'
-    config = 'test config'
+    class TestClass(BaseCommand):
+        help_msg = "help message"
+        name = "test"
+
+    group = "test group"
+    config = "test config"
     tc = TestClass(group, config)
     assert tc.group == group
     assert tc.config == config
@@ -59,9 +60,10 @@ def test_basecommand_holds_the_indicated_info():
 
 def test_basecommand_fill_parser_optional():
     """BaseCommand subclasses are allowed to not override fill_parser."""
+
     class TestClass(BaseCommand):
-        help_msg = 'help message'
-        name = 'test'
+        help_msg = "help message"
+        name = "test"
 
         def __init__(self, group, config):
             self.done = False
@@ -70,17 +72,18 @@ def test_basecommand_fill_parser_optional():
         def run(self, parsed_args):
             self.done = True
 
-    tc = TestClass('group', 'config')
+    tc = TestClass("group", "config")
     tc.run([])
     assert tc.done
 
 
 def test_basecommand_run_mandatory():
     """BaseCommand subclasses must override run."""
-    class TestClass(BaseCommand):
-        help_msg = 'help message'
-        name = 'test'
 
-    tc = TestClass('group', 'config')
+    class TestClass(BaseCommand):
+        help_msg = "help message"
+        name = "test"
+
+    tc = TestClass("group", "config")
     with pytest.raises(NotImplementedError):
         tc.run([])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -33,37 +33,44 @@ from charmcraft.config import (
 @pytest.fixture
 def create_config(tmp_path):
     """Helper to create the config."""
+
     def create_config(text):
         test_file = tmp_path / "charmcraft.yaml"
         test_file.write_text(text)
         return tmp_path
+
     return create_config
 
 
 # -- tests for the config loading
 
+
 def test_load_current_directory(create_config, monkeypatch):
     """Init the config using charmcraft.yaml in current directory."""
-    tmp_path = create_config("""
+    tmp_path = create_config(
+        """
         type: charm
-    """)
+    """
+    )
     monkeypatch.chdir(tmp_path)
-    with patch('datetime.datetime') as mock:
-        mock.utcnow.return_value = 'test_timestamp'
+    with patch("datetime.datetime") as mock:
+        mock.utcnow.return_value = "test_timestamp"
         config = load(None)
-    assert config.type == 'charm'
+    assert config.type == "charm"
     assert config.project.dirpath == tmp_path
     assert config.project.config_provided
-    assert config.project.started_at == 'test_timestamp'
+    assert config.project.started_at == "test_timestamp"
 
 
 def test_load_specific_directory_ok(create_config):
     """Init the config using charmcraft.yaml in a specific directory."""
-    tmp_path = create_config("""
+    tmp_path = create_config(
+        """
         type: charm
-    """)
+    """
+    )
     config = load(tmp_path)
-    assert config.type == 'charm'
+    assert config.type == "charm"
     assert config.project.dirpath == tmp_path
 
 
@@ -77,37 +84,43 @@ def test_load_optional_charmcraft_missing(tmp_path):
 
 def test_load_specific_directory_resolved(create_config, monkeypatch):
     """Ensure that the given directory is resolved to always show the whole path."""
-    tmp_path = create_config("""
+    tmp_path = create_config(
+        """
         type: charm
-    """)
+    """
+    )
     # change to some dir, and reference the config dir relatively
-    subdir = tmp_path / 'subdir'
+    subdir = tmp_path / "subdir"
     subdir.mkdir()
     monkeypatch.chdir(subdir)
-    config = load('../')
+    config = load("../")
 
-    assert config.type == 'charm'
+    assert config.type == "charm"
     assert config.project.dirpath == tmp_path
 
 
 def test_load_specific_directory_expanded(create_config, monkeypatch):
     """Ensure that the given directory is user-expanded."""
-    tmp_path = create_config("""
+    tmp_path = create_config(
+        """
         type: charm
-    """)
+    """
+    )
     # fake HOME so the '~' indication is verified to work
-    monkeypatch.setitem(os.environ, 'HOME', str(tmp_path))
-    config = load('~')
+    monkeypatch.setitem(os.environ, "HOME", str(tmp_path))
+    config = load("~")
 
-    assert config.type == 'charm'
+    assert config.type == "charm"
     assert config.project.dirpath == tmp_path
 
 
 # -- tests for schema restrictions
 
+
 @pytest.fixture
 def check_schema_error(tmp_path):
     """Helper to check the schema error."""
+
     def check_schema_error(expected_msg):
         """The real checker.
 
@@ -118,200 +131,243 @@ def check_schema_error(tmp_path):
         with pytest.raises(CommandError) as cm:
             load(tmp_path)
         assert str(cm.value) == expected_msg
+
     return check_schema_error
 
 
 def test_schema_top_level_no_extra_properties(create_config, check_schema_error):
     """Schema validation, can not add undefined properties at the top level."""
-    create_config("""
+    create_config(
+        """
         type: bundle
         whatever: new-stuff
-    """)
-    check_schema_error("Additional properties are not allowed ('whatever' was unexpected)")
+    """
+    )
+    check_schema_error(
+        "Additional properties are not allowed ('whatever' was unexpected)"
+    )
 
 
 def test_schema_type_missing(create_config, check_schema_error):
     """Schema validation, type is mandatory."""
-    create_config("""
+    create_config(
+        """
         charmhub:
             api_url: 33
-    """)
+    """
+    )
     check_schema_error("Bad charmcraft.yaml content; missing fields: type.")
 
 
 def test_schema_type_bad_type(create_config, check_schema_error):
     """Schema validation, type is a string."""
-    create_config("""
+    create_config(
+        """
         type: 33
-    """)
+    """
+    )
     check_schema_error(
-        "Bad charmcraft.yaml content; the 'type' field must be a string: got 'int'.")
+        "Bad charmcraft.yaml content; the 'type' field must be a string: got 'int'."
+    )
 
 
 def test_schema_type_limited_values(create_config, check_schema_error):
     """Schema validation, type must be a subset of values."""
-    create_config("""
+    create_config(
+        """
         type: whatever
-    """)
+    """
+    )
     check_schema_error(
-        "Bad charmcraft.yaml content; the 'type' field must be one of: 'charm', 'bundle'.")
+        "Bad charmcraft.yaml content; the 'type' field must be one of: 'charm', 'bundle'."
+    )
 
 
 def test_schema_charmhub_api_url_bad_type(create_config, check_schema_error):
     """Schema validation, charmhub.api_url must be a string."""
-    create_config("""
+    create_config(
+        """
         type: charm  # mandatory
         charmhub:
             api_url: 33
-    """)
+    """
+    )
     check_schema_error(
-        "Bad charmcraft.yaml content; the 'charmhub.api_url' field must be a string: got 'int'.")
+        "Bad charmcraft.yaml content; the 'charmhub.api_url' field must be a string: got 'int'."
+    )
 
 
 def test_schema_charmhub_api_url_bad_format(create_config, check_schema_error):
     """Schema validation, charmhub.api_url must be a full URL."""
-    create_config("""
+    create_config(
+        """
         type: charm  # mandatory
         charmhub:
             api_url: stuff.com
-    """)
+    """
+    )
     check_schema_error(
         "Bad charmcraft.yaml content; the 'charmhub.api_url' field must be a full URL (e.g. "
-        "'https://some.server.com'): got 'stuff.com'.")
+        "'https://some.server.com'): got 'stuff.com'."
+    )
 
 
 def test_schema_charmhub_storage_url_bad_type(create_config, check_schema_error):
     """Schema validation, charmhub.storage_url must be a string."""
-    create_config("""
+    create_config(
+        """
         type: charm  # mandatory
         charmhub:
             storage_url: 33
-    """)
+    """
+    )
     check_schema_error(
         "Bad charmcraft.yaml content; the 'charmhub.storage_url' field must be a string: "
-        "got 'int'.")
+        "got 'int'."
+    )
 
 
 def test_schema_charmhub_storage_url_bad_format(create_config, check_schema_error):
     """Schema validation, charmhub.storage_url must be a full URL."""
-    create_config("""
+    create_config(
+        """
         type: charm  # mandatory
         charmhub:
             storage_url: stuff.com
-    """)
+    """
+    )
     check_schema_error(
         "Bad charmcraft.yaml content; the 'charmhub.storage_url' field must be a full URL (e.g. "
-        "'https://some.server.com'): got 'stuff.com'.")
+        "'https://some.server.com'): got 'stuff.com'."
+    )
 
 
 def test_schema_charmhub_no_extra_properties(create_config, check_schema_error):
     """Schema validation, can not add undefined properties in charmhub key."""
-    create_config("""
+    create_config(
+        """
         type: bundle
         charmhub:
             storage_url: https://some.server.com
             crazy: false
-    """)
+    """
+    )
     check_schema_error("Additional properties are not allowed ('crazy' was unexpected)")
 
 
 def test_schema_basicprime_bad_init_structure(create_config, check_schema_error):
     """Schema validation, basic prime with bad parts."""
-    create_config("""
+    create_config(
+        """
         type: charm  # mandatory
         parts: ['foo', 'bar']
-    """)
+    """
+    )
     check_schema_error(
-        "Bad charmcraft.yaml content; the 'parts' field must be a dict: got 'list'.")
+        "Bad charmcraft.yaml content; the 'parts' field must be a dict: got 'list'."
+    )
 
 
 def test_schema_basicprime_bad_bundle_structure(create_config, check_schema_error):
     """Instantiate charmhub using a bad structure."""
     """Schema validation, basic prime with bad bundle."""
-    create_config("""
+    create_config(
+        """
         type: charm  # mandatory
         parts:
             bundle: ['foo', 'bar']
-    """)
+    """
+    )
     check_schema_error(
-        "Bad charmcraft.yaml content; the 'parts.bundle' field must be a dict: got 'list'.")
+        "Bad charmcraft.yaml content; the 'parts.bundle' field must be a dict: got 'list'."
+    )
 
 
 def test_schema_basicprime_bad_prime_structure(create_config, check_schema_error):
     """Schema validation, basic prime with bad prime."""
-    create_config("""
+    create_config(
+        """
         type: charm  # mandatory
         parts:
             bundle:
                 prime: foo
-    """)
+    """
+    )
     check_schema_error(
-        "Bad charmcraft.yaml content; the 'parts.bundle.prime' field must be a list: got 'str'.")
+        "Bad charmcraft.yaml content; the 'parts.bundle.prime' field must be a list: got 'str'."
+    )
 
 
 def test_schema_basicprime_bad_content_type(create_config, check_schema_error):
     """Schema validation, basic prime with a prime holding not strings."""
-    create_config("""
+    create_config(
+        """
         type: charm  # mandatory
         parts:
             bundle:
                 prime: [33, 'foo']
-    """)
+    """
+    )
     check_schema_error(
         "Bad charmcraft.yaml content; the item 0 in 'parts.bundle.prime' field must be "
-        "a string: got 'int'.")
+        "a string: got 'int'."
+    )
 
 
 def test_schema_basicprime_bad_content_format(create_config, check_schema_error):
     """Schema validation, basic prime with a prime holding not strings."""
-    create_config("""
+    create_config(
+        """
         type: charm  # mandatory
         parts:
             bundle:
                 prime: ['/bar/foo', 'foo']
-    """)
+    """
+    )
     check_schema_error(
         "Bad charmcraft.yaml content; the item 0 in 'parts.bundle.prime' field must be "
-        "a valid relative URL: got '/bar/foo'.")
+        "a valid relative URL: got '/bar/foo'."
+    )
 
 
 # -- tests for different validators
 
+
 def test_url_ok():
     """URL format is ok."""
-    assert check_url('https://some.server.com')
+    assert check_url("https://some.server.com")
 
 
 def test_url_no_scheme():
     """URL format is wrong, missing scheme."""
     with pytest.raises(ValueError) as cm:
-        check_url('some.server.com')
+        check_url("some.server.com")
     assert str(cm.value) == "must be a full URL (e.g. 'https://some.server.com')"
 
 
 def test_url_no_netloc():
     """URL format is wrong, missing network location."""
     with pytest.raises(ValueError) as cm:
-        check_url('https://')
+        check_url("https://")
     assert str(cm.value) == "must be a full URL (e.g. 'https://some.server.com')"
 
 
 def test_relativepaths_ok():
     """Indicated paths must be relative."""
-    assert check_relative_paths('foo/bar')
+    assert check_relative_paths("foo/bar")
 
 
 def test_relativepaths_absolute():
     """Indicated paths must be relative."""
     with pytest.raises(ValueError) as cm:
-        check_relative_paths('/foo/bar')
+        check_relative_paths("/foo/bar")
     assert str(cm.value) == "must be a valid relative URL"
 
 
 def test_relativepaths_empty():
     """Indicated paths must be relative."""
     with pytest.raises(ValueError) as cm:
-        check_relative_paths('')
+        check_relative_paths("")
     assert str(cm.value) == "must be a valid relative URL"
 
 
@@ -324,41 +380,49 @@ def test_relativepaths_nonstring():
 
 # -- tests for Charmhub config
 
+
 def test_charmhub_frozen():
     """Cannot change values from the charmhub config."""
     config = CharmhubConfig()
     with pytest.raises(attr.exceptions.FrozenInstanceError):
-        config.api_url = 'broken'
+        config.api_url = "broken"
 
 
 # -- tests for BasicPrime config
 
+
 def test_basicprime_frozen():
     """Cannot change values from the charmhub config."""
-    config = BasicPrime.from_dict({
-        'bundle': {
-            'prime': ['foo', 'bar'],
+    config = BasicPrime.from_dict(
+        {
+            "bundle": {
+                "prime": ["foo", "bar"],
+            }
         }
-    })
+    )
     with pytest.raises(TypeError):
-        config[0] = 'broken'
+        config[0] = "broken"
 
 
 def test_basicprime_ok():
     """A simple building ok."""
-    config = BasicPrime.from_dict({
-        'bundle': {
-            'prime': ['foo', 'bar'],
+    config = BasicPrime.from_dict(
+        {
+            "bundle": {
+                "prime": ["foo", "bar"],
+            }
         }
-    })
-    assert config == ('foo', 'bar')
+    )
+    assert config == ("foo", "bar")
 
 
 def test_basicprime_empty():
     """Building with an empty list."""
-    config = BasicPrime.from_dict({
-        'bundle': {
-            'prime': [],
+    config = BasicPrime.from_dict(
+        {
+            "bundle": {
+                "prime": [],
+            }
         }
-    })
+    )
     assert config == ()

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -36,16 +36,17 @@ from tests.factory import create_command
 all_commands = list.__add__(*[commands for _, _, commands in COMMAND_GROUPS])
 
 
-@pytest.mark.parametrize('command', all_commands)
+@pytest.mark.parametrize("command", all_commands)
 def test_aesthetic_help_msg(command):
     """All the real commands help msg start with uppercase and doesn't end with a dot."""
     msg = command.help_msg
-    assert msg[0].isupper() and msg[-1] != '.'
+    assert msg[0].isupper() and msg[-1] != "."
 
 
-@pytest.mark.parametrize('command', all_commands)
+@pytest.mark.parametrize("command", all_commands)
 def test_aesthetic_args_options_msg(command, config):
     """All the real commands args help messages start with uppercase and dont' end with a dot."""
+
     class FakeParser:
         """A fake to get the arguments added."""
 
@@ -55,55 +56,68 @@ def test_aesthetic_args_options_msg(command, config):
 
         def add_argument(self, *args, **kwargs):
             """Verify that all commands have a correctly formatted help."""
-            help_msg = kwargs.get('help')
+            help_msg = kwargs.get("help")
             assert help_msg, "The help message must be present in each option"
-            assert help_msg[0].isupper() and help_msg[-1] != '.'
+            assert help_msg[0].isupper() and help_msg[-1] != "."
 
-    command('group', config).fill_parser(FakeParser())
+    command("group", config).fill_parser(FakeParser())
 
 
 def test_get_usage_message():
     """Check the general "usage" text."""
-    text = get_usage_message('charmcraft build', 'bad parameter for the build')
-    expected = textwrap.dedent("""\
+    text = get_usage_message("charmcraft build", "bad parameter for the build")
+    expected = textwrap.dedent(
+        """\
         Usage: charmcraft [options] command [args]...
         Try 'charmcraft build -h' for help.
 
         Error: bad parameter for the build
-    """)
+    """
+    )
     assert text == expected
 
 
 # -- bulding of the big help text outputs
 
+
 def test_default_help_text():
     """All different parts for the default help."""
-    cmd1 = create_command('cmd1', 'Cmd help which is very long but whatever.', common_=True)
-    cmd2 = create_command('command-2', 'Cmd help.', common_=True)
-    cmd3 = create_command('cmd3', 'Extremely ' + 'super crazy long ' * 5 + ' help.', common_=True)
-    cmd4 = create_command('cmd4', 'Some help.')
-    cmd5 = create_command('cmd5', 'More help.')
-    cmd6 = create_command('cmd6-really-long', 'More help.', common_=True)
-    cmd7 = create_command('cmd7', 'More help.')
+    cmd1 = create_command(
+        "cmd1", "Cmd help which is very long but whatever.", common_=True
+    )
+    cmd2 = create_command("command-2", "Cmd help.", common_=True)
+    cmd3 = create_command(
+        "cmd3", "Extremely " + "super crazy long " * 5 + " help.", common_=True
+    )
+    cmd4 = create_command("cmd4", "Some help.")
+    cmd5 = create_command("cmd5", "More help.")
+    cmd6 = create_command("cmd6-really-long", "More help.", common_=True)
+    cmd7 = create_command("cmd7", "More help.")
 
     command_groups = [
-        ('group1', 'help text for g1', [cmd6, cmd2]),
-        ('group3', 'help text for g3', [cmd7]),
-        ('group2', 'help text for g2', [cmd3, cmd4, cmd5, cmd1]),
+        ("group1", "help text for g1", [cmd6, cmd2]),
+        ("group3", "help text for g3", [cmd7]),
+        ("group2", "help text for g2", [cmd3, cmd4, cmd5, cmd1]),
     ]
-    fake_summary = textwrap.indent(textwrap.dedent("""
+    fake_summary = textwrap.indent(
+        textwrap.dedent(
+            """
         This is the summary for
         the whole program.
-    """), "    ")
+    """
+        ),
+        "    ",
+    )
     global_options = [
-        ('-h, --help', 'Show this help message and exit.'),
-        ('-q, --quiet', 'Only show warnings and errors, not progress.'),
+        ("-h, --help", "Show this help message and exit."),
+        ("-q, --quiet", "Only show warnings and errors, not progress."),
     ]
 
-    with patch('charmcraft.helptexts.GENERAL_SUMMARY', fake_summary):
+    with patch("charmcraft.helptexts.GENERAL_SUMMARY", fake_summary):
         text = get_full_help(command_groups, global_options)
 
-    expected = textwrap.dedent("""\
+    expected = textwrap.dedent(
+        """\
         Usage:
             charmcraft [help] <command>
 
@@ -130,38 +144,49 @@ def test_default_help_text():
 
         For more information about a command, run 'charmcraft help <command>'.
         For a summary of all commands, run 'charmcraft help --all'.
-    """)
+    """
+    )
     assert text == expected
 
 
 def test_detailed_help_text():
     """All different parts for the detailed help, showing all commands."""
-    cmd1 = create_command('cmd1', 'Cmd help which is very long but whatever.', common_=True)
-    cmd2 = create_command('command-2', 'Cmd help.', common_=True)
-    cmd3 = create_command('cmd3', 'Extremely ' + 'super crazy long ' * 5 + ' help.', common_=True)
-    cmd4 = create_command('cmd4', 'Some help.')
-    cmd5 = create_command('cmd5', 'More help.')
-    cmd6 = create_command('cmd6-really-long', 'More help.', common_=True)
-    cmd7 = create_command('cmd7', 'More help.')
+    cmd1 = create_command(
+        "cmd1", "Cmd help which is very long but whatever.", common_=True
+    )
+    cmd2 = create_command("command-2", "Cmd help.", common_=True)
+    cmd3 = create_command(
+        "cmd3", "Extremely " + "super crazy long " * 5 + " help.", common_=True
+    )
+    cmd4 = create_command("cmd4", "Some help.")
+    cmd5 = create_command("cmd5", "More help.")
+    cmd6 = create_command("cmd6-really-long", "More help.", common_=True)
+    cmd7 = create_command("cmd7", "More help.")
 
     command_groups = [
-        ('group1', 'Group 1 description', [cmd6, cmd2]),
-        ('group3', 'Group 3 help text', [cmd7]),
-        ('group2', 'Group 2 stuff', [cmd3, cmd4, cmd5, cmd1]),
+        ("group1", "Group 1 description", [cmd6, cmd2]),
+        ("group3", "Group 3 help text", [cmd7]),
+        ("group2", "Group 2 stuff", [cmd3, cmd4, cmd5, cmd1]),
     ]
-    fake_summary = textwrap.indent(textwrap.dedent("""
+    fake_summary = textwrap.indent(
+        textwrap.dedent(
+            """
         This is the summary for
         the whole program.
-    """), "    ")
+    """
+        ),
+        "    ",
+    )
     global_options = [
-        ('-h, --help', 'Show this help message and exit.'),
-        ('-q, --quiet', 'Only show warnings and errors, not progress.'),
+        ("-h, --help", "Show this help message and exit."),
+        ("-q, --quiet", "Only show warnings and errors, not progress."),
     ]
 
-    with patch('charmcraft.helptexts.GENERAL_SUMMARY', fake_summary):
+    with patch("charmcraft.helptexts.GENERAL_SUMMARY", fake_summary):
         text = get_detailed_help(command_groups, global_options)
 
-    expected = textwrap.dedent("""\
+    expected = textwrap.dedent(
+        """\
         Usage:
             charmcraft [help] <command>
 
@@ -191,24 +216,27 @@ def test_detailed_help_text():
                         cmd1:  Cmd help which is very long but whatever.
 
         For more information about a specific command, run 'charmcraft help <command>'.
-    """)
+    """
+    )
     assert text == expected
 
 
 def test_command_help_text_no_parameters(config):
     """All different parts for a specific command help that doesn't have parameters."""
-    overview = textwrap.dedent("""
+    overview = textwrap.dedent(
+        """
         Quite some long text.
 
         Multiline!
-    """)
-    cmd1 = create_command('somecommand', 'Command one line help.', overview_=overview)
-    cmd2 = create_command('other-cmd-2', 'Some help.')
-    cmd3 = create_command('other-cmd-3', 'Some help.')
-    cmd4 = create_command('other-cmd-4', 'Some help.')
+    """
+    )
+    cmd1 = create_command("somecommand", "Command one line help.", overview_=overview)
+    cmd2 = create_command("other-cmd-2", "Some help.")
+    cmd3 = create_command("other-cmd-3", "Some help.")
+    cmd4 = create_command("other-cmd-4", "Some help.")
     command_groups = [
-        ('group1', 'help text for g1', [cmd1, cmd2, cmd4]),
-        ('group2', 'help text for g2', [cmd3]),
+        ("group1", "help text for g1", [cmd1, cmd2, cmd4]),
+        ("group2", "help text for g2", [cmd3]),
     ]
 
     options = [
@@ -218,9 +246,10 @@ def test_command_help_text_no_parameters(config):
         ("--revision", "The revision to release (defaults to latest)."),
     ]
 
-    text = get_command_help(command_groups, cmd1('group1', config), options)
+    text = get_command_help(command_groups, cmd1("group1", config), options)
 
-    expected = textwrap.dedent("""\
+    expected = textwrap.dedent(
+        """\
         Usage:
             charmcraft somecommand [options]
 
@@ -240,19 +269,22 @@ def test_command_help_text_no_parameters(config):
             other-cmd-4
 
         For a summary of all commands, run 'charmcraft help --all'.
-    """)
+    """
+    )
     assert text == expected
 
 
 def test_command_help_text_with_parameters(config):
     """All different parts for a specific command help that has parameters."""
-    overview = textwrap.dedent("""
+    overview = textwrap.dedent(
+        """
         Quite some long text.
-    """)
-    cmd1 = create_command('somecommand', 'Command one line help.', overview_=overview)
-    cmd2 = create_command('other-cmd-2', 'Some help.')
+    """
+    )
+    cmd1 = create_command("somecommand", "Command one line help.", overview_=overview)
+    cmd2 = create_command("other-cmd-2", "Some help.")
     command_groups = [
-        ('group1', 'help text for g1', [cmd1, cmd2]),
+        ("group1", "help text for g1", [cmd1, cmd2]),
     ]
 
     options = [
@@ -263,9 +295,10 @@ def test_command_help_text_with_parameters(config):
         ("--other-option", "Other option."),
     ]
 
-    text = get_command_help(command_groups, cmd1('group1', config), options)
+    text = get_command_help(command_groups, cmd1("group1", config), options)
 
-    expected = textwrap.dedent("""\
+    expected = textwrap.dedent(
+        """\
         Usage:
             charmcraft somecommand [options] <name> <extraparam>
 
@@ -281,20 +314,23 @@ def test_command_help_text_with_parameters(config):
             other-cmd-2
 
         For a summary of all commands, run 'charmcraft help --all'.
-    """)
+    """
+    )
     assert text == expected
 
 
 def test_command_help_text_loneranger(config):
     """All different parts for a specific command that's the only one in its group."""
-    overview = textwrap.dedent("""
+    overview = textwrap.dedent(
+        """
         Quite some long text.
-    """)
-    cmd1 = create_command('somecommand', 'Command one line help.', overview_=overview)
-    cmd2 = create_command('other-cmd-2', 'Some help.')
+    """
+    )
+    cmd1 = create_command("somecommand", "Command one line help.", overview_=overview)
+    cmd2 = create_command("other-cmd-2", "Some help.")
     command_groups = [
-        ('group1', 'help text for g1', [cmd1]),
-        ('group2', 'help text for g2', [cmd2]),
+        ("group1", "help text for g1", [cmd1]),
+        ("group2", "help text for g2", [cmd2]),
     ]
 
     options = [
@@ -302,9 +338,10 @@ def test_command_help_text_loneranger(config):
         ("-q, --quiet", "Only show warnings and errors, not progress."),
     ]
 
-    text = get_command_help(command_groups, cmd1('group1', config), options)
+    text = get_command_help(command_groups, cmd1("group1", config), options)
 
-    expected = textwrap.dedent("""\
+    expected = textwrap.dedent(
+        """\
         Usage:
             charmcraft somecommand [options]
 
@@ -316,24 +353,29 @@ def test_command_help_text_loneranger(config):
             -q, --quiet:  Only show warnings and errors, not progress.
 
         For a summary of all commands, run 'charmcraft help --all'.
-    """)
+    """
+    )
     assert text == expected
 
 
 # -- real execution outputs
 
-@pytest.mark.parametrize('sysargv', [
-    [],
-    ['-h'],
-    ['--help'],
-    ['help'],
-    ['--help', 'help'],
-    ['help', '-h'],
-])
+
+@pytest.mark.parametrize(
+    "sysargv",
+    [
+        [],
+        ["-h"],
+        ["--help"],
+        ["help"],
+        ["--help", "help"],
+        ["help", "-h"],
+    ],
+)
 def test_tool_exec_full_help(sysargv):
     """Execute charmcraft without any option at all or explicitly asking for help."""
-    with patch('charmcraft.helptexts.get_full_help') as mock:
-        mock.return_value = 'test help'
+    with patch("charmcraft.helptexts.get_full_help") as mock:
+        mock.return_value = "test help"
         with pytest.raises(CommandError) as cm:
             dispatcher = Dispatcher(sysargv, COMMAND_GROUPS)
             dispatcher.run()
@@ -343,34 +385,43 @@ def test_tool_exec_full_help(sysargv):
     args = mock.call_args[0]
     assert args[0] == COMMAND_GROUPS
     assert sorted(x[0] for x in args[1]) == [
-        '-h, --help', '-p, --project-dir', '-q, --quiet', '-v, --verbose']
+        "-h, --help",
+        "-p, --project-dir",
+        "-q, --quiet",
+        "-v, --verbose",
+    ]
 
     # check the result of the full help builder is what is shown
     assert error.argsparsing
     assert str(error) == "test help"
 
 
-@pytest.mark.parametrize('sysargv', [
-    ['wrongcommand'],
-    ['-h', 'wrongcommand'],
-    ['wrongcommand', '-h'],
-    ['--help', 'wrongcommand'],
-    ['wrongcommand', '--help'],
-    ['-h', 'wrongcommand', '--help'],
-])
+@pytest.mark.parametrize(
+    "sysargv",
+    [
+        ["wrongcommand"],
+        ["-h", "wrongcommand"],
+        ["wrongcommand", "-h"],
+        ["--help", "wrongcommand"],
+        ["wrongcommand", "--help"],
+        ["-h", "wrongcommand", "--help"],
+    ],
+)
 def test_tool_exec_command_incorrect(sysargv):
     """Execute a command that doesn't exist."""
-    command_groups = COMMAND_GROUPS + [('group', 'help text', [])]
+    command_groups = COMMAND_GROUPS + [("group", "help text", [])]
     with pytest.raises(CommandError) as cm:
         dispatcher = Dispatcher(sysargv, command_groups)
         dispatcher.run()
 
-    expected = textwrap.dedent("""\
+    expected = textwrap.dedent(
+        """\
         Usage: charmcraft [options] command [args]...
         Try 'charmcraft -h' for help.
 
         Error: no such command 'wrongcommand'
-        """)
+        """
+    )
 
     error = cm.value
     assert error.argsparsing
@@ -378,16 +429,16 @@ def test_tool_exec_command_incorrect(sysargv):
     assert error.retcode == 1
 
 
-@pytest.mark.parametrize('help_option', ['-h', '--help'])
+@pytest.mark.parametrize("help_option", ["-h", "--help"])
 def test_tool_exec_command_dash_help_simple(help_option):
     """Execute a command (that needs no params) asking for help."""
-    cmd = create_command('somecommand', 'This command does that.')
-    command_groups = COMMAND_GROUPS + [('group', 'help text', [cmd])]
+    cmd = create_command("somecommand", "This command does that.")
+    command_groups = COMMAND_GROUPS + [("group", "help text", [cmd])]
 
-    dispatcher = Dispatcher(['somecommand', help_option], command_groups)
+    dispatcher = Dispatcher(["somecommand", help_option], command_groups)
 
-    with patch('charmcraft.helptexts.get_command_help') as mock:
-        mock.return_value = 'test help'
+    with patch("charmcraft.helptexts.get_command_help") as mock:
+        mock.return_value = "test help"
         with pytest.raises(CommandError) as cm:
             dispatcher.run()
     error = cm.value
@@ -397,7 +448,11 @@ def test_tool_exec_command_dash_help_simple(help_option):
     assert args[0] == COMMAND_GROUPS
     assert args[1].__class__ == cmd
     assert sorted(x[0] for x in args[2]) == [
-        '-h, --help', '-p, --project-dir', '-q, --quiet', '-v, --verbose']
+        "-h, --help",
+        "-p, --project-dir",
+        "-q, --quiet",
+        "-v, --verbose",
+    ]
 
     # check the result of the full help builder is what is shown
     assert error.argsparsing
@@ -405,16 +460,16 @@ def test_tool_exec_command_dash_help_simple(help_option):
     assert error.retcode == 0
 
 
-@pytest.mark.parametrize('help_option', ['-h', '--help'])
+@pytest.mark.parametrize("help_option", ["-h", "--help"])
 def test_tool_exec_command_dash_help_reverse(help_option):
     """Execute a command (that needs no params) asking for help."""
-    cmd = create_command('somecommand', 'This command does that.')
-    command_groups = COMMAND_GROUPS + [('group', 'help text', [cmd])]
+    cmd = create_command("somecommand", "This command does that.")
+    command_groups = COMMAND_GROUPS + [("group", "help text", [cmd])]
 
-    dispatcher = Dispatcher([help_option, 'somecommand'], command_groups)
+    dispatcher = Dispatcher([help_option, "somecommand"], command_groups)
 
-    with patch('charmcraft.helptexts.get_command_help') as mock:
-        mock.return_value = 'test help'
+    with patch("charmcraft.helptexts.get_command_help") as mock:
+        mock.return_value = "test help"
         with pytest.raises(CommandError) as cm:
             dispatcher.run()
     error = cm.value
@@ -424,7 +479,11 @@ def test_tool_exec_command_dash_help_reverse(help_option):
     assert args[0] == COMMAND_GROUPS
     assert args[1].__class__ == cmd
     assert sorted(x[0] for x in args[2]) == [
-        '-h, --help', '-p, --project-dir', '-q, --quiet', '-v, --verbose']
+        "-h, --help",
+        "-p, --project-dir",
+        "-q, --quiet",
+        "-v, --verbose",
+    ]
 
     # check the result of the full help builder is what is shown
     assert error.argsparsing
@@ -432,20 +491,21 @@ def test_tool_exec_command_dash_help_reverse(help_option):
     assert error.retcode == 0
 
 
-@pytest.mark.parametrize('help_option', ['-h', '--help'])
+@pytest.mark.parametrize("help_option", ["-h", "--help"])
 def test_tool_exec_command_dash_help_missing_params(help_option):
     """Execute a command (which needs params) asking for help."""
+
     def fill_parser(self, parser):
-        parser.add_argument('mandatory')
+        parser.add_argument("mandatory")
 
-    cmd = create_command('somecommand', 'This command does that.')
+    cmd = create_command("somecommand", "This command does that.")
     cmd.fill_parser = fill_parser
-    command_groups = COMMAND_GROUPS + [('group', 'help text', [cmd])]
+    command_groups = COMMAND_GROUPS + [("group", "help text", [cmd])]
 
-    dispatcher = Dispatcher(['somecommand', help_option], command_groups)
+    dispatcher = Dispatcher(["somecommand", help_option], command_groups)
 
-    with patch('charmcraft.helptexts.get_command_help') as mock:
-        mock.return_value = 'test help'
+    with patch("charmcraft.helptexts.get_command_help") as mock:
+        mock.return_value = "test help"
         with pytest.raises(CommandError) as cm:
             dispatcher.run()
     error = cm.value
@@ -455,7 +515,12 @@ def test_tool_exec_command_dash_help_missing_params(help_option):
     assert args[0] == COMMAND_GROUPS
     assert args[1].__class__ == cmd
     assert sorted(x[0] for x in args[2]) == [
-        '-h, --help', '-p, --project-dir', '-q, --quiet', '-v, --verbose', 'mandatory']
+        "-h, --help",
+        "-p, --project-dir",
+        "-q, --quiet",
+        "-v, --verbose",
+        "mandatory",
+    ]
 
     # check the result of the full help builder is what is shown
     assert error.argsparsing
@@ -465,17 +530,19 @@ def test_tool_exec_command_dash_help_missing_params(help_option):
 
 def test_tool_exec_command_wrong_option():
     """Execute a correct command but with a wrong option."""
-    cmd = create_command('somecommand', 'This command does that.')
-    command_groups = [('group', 'help text', [cmd])]
+    cmd = create_command("somecommand", "This command does that.")
+    command_groups = [("group", "help text", [cmd])]
     with pytest.raises(CommandError) as cm:
-        Dispatcher(['somecommand', '--whatever'], command_groups)
+        Dispatcher(["somecommand", "--whatever"], command_groups)
 
-    expected = textwrap.dedent("""\
+    expected = textwrap.dedent(
+        """\
         Usage: charmcraft [options] command [args]...
         Try 'charmcraft somecommand -h' for help.
 
         Error: unrecognized arguments: --whatever
-        """)
+        """
+    )
 
     error = cm.value
     assert error.argsparsing
@@ -485,22 +552,25 @@ def test_tool_exec_command_wrong_option():
 
 def test_tool_exec_command_bad_option_type():
     """Execute a correct command but giving the valid option a bad value."""
-    def fill_parser(self, parser):
-        parser.add_argument('--number', type=int)
 
-    cmd = create_command('somecommand', 'This command does that.')
+    def fill_parser(self, parser):
+        parser.add_argument("--number", type=int)
+
+    cmd = create_command("somecommand", "This command does that.")
     cmd.fill_parser = fill_parser
 
-    command_groups = [('group', 'help text', [cmd])]
+    command_groups = [("group", "help text", [cmd])]
     with pytest.raises(CommandError) as cm:
-        Dispatcher(['somecommand', '--number=foo'], command_groups)
+        Dispatcher(["somecommand", "--number=foo"], command_groups)
 
-    expected = textwrap.dedent("""\
+    expected = textwrap.dedent(
+        """\
         Usage: charmcraft [options] command [args]...
         Try 'charmcraft somecommand -h' for help.
 
         Error: argument --number: invalid int value: 'foo'
-        """)
+        """
+    )
 
     error = cm.value
     assert error.argsparsing
@@ -510,10 +580,10 @@ def test_tool_exec_command_bad_option_type():
 
 def test_tool_exec_help_command_on_command_ok():
     """Execute charmcraft asking for help on a command ok."""
-    dispatcher = Dispatcher(['help', 'version'], COMMAND_GROUPS)
+    dispatcher = Dispatcher(["help", "version"], COMMAND_GROUPS)
 
-    with patch('charmcraft.helptexts.get_command_help') as mock:
-        mock.return_value = 'test help'
+    with patch("charmcraft.helptexts.get_command_help") as mock:
+        mock.return_value = "test help"
         with pytest.raises(CommandError) as cm:
             dispatcher.run()
     error = cm.value
@@ -523,7 +593,11 @@ def test_tool_exec_help_command_on_command_ok():
     assert args[0] == COMMAND_GROUPS
     assert args[1].__class__ == VersionCommand
     assert sorted(x[0] for x in args[2]) == [
-        '-h, --help', '-p, --project-dir', '-q, --quiet', '-v, --verbose']
+        "-h, --help",
+        "-p, --project-dir",
+        "-q, --quiet",
+        "-v, --verbose",
+    ]
 
     # check the result of the full help builder is what is shown
     assert error.argsparsing
@@ -533,21 +607,22 @@ def test_tool_exec_help_command_on_command_ok():
 
 def test_tool_exec_help_command_on_command_complex():
     """Execute charmcraft asking for help on a command with parameters and options."""
+
     def fill_parser(self, parser):
-        parser.add_argument('param1', help="help on param1")
-        parser.add_argument('param2', help="help on param2")
-        parser.add_argument('param3', metavar='transformed3', help="help on param2")
-        parser.add_argument('--option1', help="help on option1")
-        parser.add_argument('-o2', '--option2', help="help on option2")
+        parser.add_argument("param1", help="help on param1")
+        parser.add_argument("param2", help="help on param2")
+        parser.add_argument("param3", metavar="transformed3", help="help on param2")
+        parser.add_argument("--option1", help="help on option1")
+        parser.add_argument("-o2", "--option2", help="help on option2")
 
-    cmd = create_command('somecommand', 'This command does that.')
+    cmd = create_command("somecommand", "This command does that.")
     cmd.fill_parser = fill_parser
-    command_groups = COMMAND_GROUPS + [('group', 'help text', [cmd])]
+    command_groups = COMMAND_GROUPS + [("group", "help text", [cmd])]
 
-    dispatcher = Dispatcher(['help', 'somecommand'], command_groups)
+    dispatcher = Dispatcher(["help", "somecommand"], command_groups)
 
-    with patch('charmcraft.helptexts.get_command_help') as mock:
-        mock.return_value = 'test help'
+    with patch("charmcraft.helptexts.get_command_help") as mock:
+        mock.return_value = "test help"
         with pytest.raises(CommandError) as cm:
             dispatcher.run()
     error = cm.value
@@ -557,15 +632,15 @@ def test_tool_exec_help_command_on_command_complex():
     assert args[0] == COMMAND_GROUPS
     assert args[1].__class__ == cmd
     expected_options = [
-        '--option1',
-        '-h, --help',
-        '-o2, --option2',
-        '-p, --project-dir',
-        '-q, --quiet',
-        '-v, --verbose',
-        'param1',
-        'param2',
-        'transformed3',
+        "--option1",
+        "-h, --help",
+        "-o2, --option2",
+        "-p, --project-dir",
+        "-q, --quiet",
+        "-v, --verbose",
+        "param1",
+        "param2",
+        "transformed3",
     ]
     assert sorted(x[0] for x in args[2]) == expected_options
 
@@ -577,16 +652,16 @@ def test_tool_exec_help_command_on_command_complex():
 
 def test_tool_exec_help_command_on_command_wrong():
     """Execute charmcraft asking for help on a command which does not exist."""
-    dispatcher = Dispatcher(['help', 'wrongcommand'], COMMAND_GROUPS)
+    dispatcher = Dispatcher(["help", "wrongcommand"], COMMAND_GROUPS)
 
-    with patch('charmcraft.helptexts.get_usage_message') as mock:
-        mock.return_value = 'test help'
+    with patch("charmcraft.helptexts.get_usage_message") as mock:
+        mock.return_value = "test help"
         with pytest.raises(CommandError) as cm:
             dispatcher.run()
     error = cm.value
 
     # check the given information to the builder
-    assert mock.call_args[0] == ('charmcraft', "no such command 'wrongcommand'")
+    assert mock.call_args[0] == ("charmcraft", "no such command 'wrongcommand'")
 
     # check the result of the full help builder is what is shown
     assert error.argsparsing
@@ -596,10 +671,10 @@ def test_tool_exec_help_command_on_command_wrong():
 
 def test_tool_exec_help_command_all():
     """Execute charmcraft asking for detailed help."""
-    dispatcher = Dispatcher(['help', '--all'], COMMAND_GROUPS)
+    dispatcher = Dispatcher(["help", "--all"], COMMAND_GROUPS)
 
-    with patch('charmcraft.helptexts.get_detailed_help') as mock:
-        mock.return_value = 'test help'
+    with patch("charmcraft.helptexts.get_detailed_help") as mock:
+        mock.return_value = "test help"
         with pytest.raises(CommandError) as cm:
             dispatcher.run()
     error = cm.value
@@ -608,7 +683,11 @@ def test_tool_exec_help_command_all():
     args = mock.call_args[0]
     assert args[0] == COMMAND_GROUPS
     assert sorted(x[0] for x in args[1]) == [
-        '-h, --help', '-p, --project-dir', '-q, --quiet', '-v, --verbose']
+        "-h, --help",
+        "-p, --project-dir",
+        "-q, --quiet",
+        "-v, --verbose",
+    ]
 
     # check the result of the full help builder is what is shown
     assert error.argsparsing

--- a/tests/test_infra.py
+++ b/tests/test_infra.py
@@ -21,6 +21,8 @@ import re
 import subprocess
 from unittest.mock import patch
 
+import black
+import click.testing
 import pydocstyle
 import pytest
 from flake8.api.legacy import get_style_guide
@@ -132,3 +134,14 @@ def test_bashcompletion_all_commands():
         real_command_names.update(cmd.name for cmd in cmds)
 
     assert completed_commands == real_command_names
+
+
+def test_black():
+    runner = click.testing.CliRunner()
+    result = runner.invoke(
+        black.main,
+        ["--check"] + get_python_filepaths(),
+    )
+
+    if result.exit_code != 0:
+        pytest.fail(f"Please reformat files with black.\n{result.output}")

--- a/tests/test_infra.py
+++ b/tests/test_infra.py
@@ -33,9 +33,9 @@ from charmcraft import __version__, main
 def get_python_filepaths(*, roots=None, python_paths=None):
     """Helper to retrieve paths of Python files."""
     if python_paths is None:
-        python_paths = ['setup.py']
+        python_paths = ["setup.py"]
     if roots is None:
-        roots = ['charmcraft', 'tests']
+        roots = ["charmcraft", "tests"]
     for root in roots:
         for dirpath, dirnames, filenames in os.walk(root):
             for filename in filenames:
@@ -53,7 +53,7 @@ def pep8_test(python_filepaths):
     """Helper to check PEP8 (used from this module and from test_init.py to check templates)."""
     style_guide = get_style_guide()
     fake_stdout = io.StringIO()
-    with patch('sys.stdout', fake_stdout):
+    with patch("sys.stdout", fake_stdout):
         report = style_guide.check_files(python_filepaths)
 
     # if flake8 didnt' report anything, we're done
@@ -61,7 +61,7 @@ def pep8_test(python_filepaths):
         return
 
     # grab on which files we have issues
-    flake8_issues = fake_stdout.getvalue().split('\n')
+    flake8_issues = fake_stdout.getvalue().split("\n")
 
     if flake8_issues:
         msg = "Please fix the following flake8 issues!\n" + "\n".join(flake8_issues)
@@ -70,22 +70,26 @@ def pep8_test(python_filepaths):
 
 def test_pep257():
     """Verify all files have nice docstrings."""
-    pep257_test(get_python_filepaths(roots=['charmcraft']))
+    pep257_test(get_python_filepaths(roots=["charmcraft"]))
 
 
 def pep257_test(python_filepaths):
     """Helper to check PEP257 (used from this module and from test_init.py to check templates)."""
     to_ignore = {
-        'D105',  # Missing docstring in magic method
-        'D107',  # Missing docstring in __init__
+        "D105",  # Missing docstring in magic method
+        "D107",  # Missing docstring in __init__
     }
     to_include = pydocstyle.violations.conventions.pep257 - to_ignore
     errors = list(pydocstyle.check(python_filepaths, select=to_include))
 
     if errors:
-        report = ["Please fix files as suggested by pydocstyle ({:d} issues):".format(len(errors))]
+        report = [
+            "Please fix files as suggested by pydocstyle ({:d} issues):".format(
+                len(errors)
+            )
+        ]
         report.extend(str(e) for e in errors)
-        msg = '\n'.join(report)
+        msg = "\n".join(report)
         pytest.fail(msg, pytrace=False)
 
 
@@ -104,15 +108,17 @@ def test_ensure_copyright():
             else:
                 issues.append(filepath)
     if issues:
-        msg = "Please add copyright headers to the following files:\n" + "\n".join(issues)
+        msg = "Please add copyright headers to the following files:\n" + "\n".join(
+            issues
+        )
         pytest.fail(msg, pytrace=False)
 
 
 def test_setup_version():
     """Verify that setup.py is picking up the version correctly."""
-    cmd = [os.path.abspath('setup.py'), '--version']
+    cmd = [os.path.abspath("setup.py"), "--version"]
     proc = subprocess.run(cmd, stdout=subprocess.PIPE)
-    output = proc.stdout.decode('utf8')
+    output = proc.stdout.decode("utf8")
     assert output.strip() == __version__
 
 
@@ -121,7 +127,7 @@ def test_bashcompletion_all_commands():
     # get the line where all commands are specified in the completion file; this is custom
     # to our file, but simple and good enough
     completed_commands = None
-    with open('completion.bash', 'rt', encoding='utf8') as fh:
+    with open("completion.bash", "rt", encoding="utf8") as fh:
         completion_text = fh.read()
     m = re.search(r"cmds=\((.*?)\)", completion_text, re.DOTALL)
     if m:

--- a/tests/test_jujuignore.py
+++ b/tests/test_jujuignore.py
@@ -26,303 +26,330 @@ from charmcraft import jujuignore
 def test_default_important_files():
     """Don't ignore important files by default."""
     ignore = jujuignore.JujuIgnore(jujuignore.default_juju_ignore)
-    assert not ignore.match('version', is_dir=False)
+    assert not ignore.match("version", is_dir=False)
 
 
 def test_jujuignore_only_dir():
-    ignore = jujuignore.JujuIgnore(['target/'])
-    assert ignore.match('target', is_dir=True)
-    assert ignore.match('foo/target', is_dir=True)
-    assert not ignore.match('foo/1target', is_dir=True)
-    assert not ignore.match('foo/target', is_dir=False)
+    ignore = jujuignore.JujuIgnore(["target/"])
+    assert ignore.match("target", is_dir=True)
+    assert ignore.match("foo/target", is_dir=True)
+    assert not ignore.match("foo/1target", is_dir=True)
+    assert not ignore.match("foo/target", is_dir=False)
 
 
 def test_jujuignore_any_target():
-    ignore = jujuignore.JujuIgnore(['target'])
-    assert ignore.match('target', is_dir=True)
-    assert ignore.match('/foo/target', is_dir=True)
-    assert not ignore.match('/foo/1target', is_dir=True)
-    assert ignore.match('/foo/target', is_dir=False)
+    ignore = jujuignore.JujuIgnore(["target"])
+    assert ignore.match("target", is_dir=True)
+    assert ignore.match("/foo/target", is_dir=True)
+    assert not ignore.match("/foo/1target", is_dir=True)
+    assert ignore.match("/foo/target", is_dir=False)
 
 
 def test_jujuignore_only_root_target_dir():
-    ignore = jujuignore.JujuIgnore(['/target/'])
-    assert ignore.match('/target', is_dir=True)
-    assert not ignore.match('/foo/target', is_dir=True)
-    assert not ignore.match('/foo/1target', is_dir=True)
-    assert not ignore.match('/foo/target', is_dir=False)
-    assert not ignore.match('/target', is_dir=False)
+    ignore = jujuignore.JujuIgnore(["/target/"])
+    assert ignore.match("/target", is_dir=True)
+    assert not ignore.match("/foo/target", is_dir=True)
+    assert not ignore.match("/foo/1target", is_dir=True)
+    assert not ignore.match("/foo/target", is_dir=False)
+    assert not ignore.match("/target", is_dir=False)
 
 
 def test_jujuignore_only_root_target_file_or_dir():
-    ignore = jujuignore.JujuIgnore(['/target'])
-    assert ignore.match('/target', is_dir=True)
-    assert not ignore.match('/foo/target', is_dir=True)
-    assert not ignore.match('/foo/1target', is_dir=True)
-    assert not ignore.match('/foo/target', is_dir=False)
-    assert ignore.match('/target', is_dir=False)
+    ignore = jujuignore.JujuIgnore(["/target"])
+    assert ignore.match("/target", is_dir=True)
+    assert not ignore.match("/foo/target", is_dir=True)
+    assert not ignore.match("/foo/1target", is_dir=True)
+    assert not ignore.match("/foo/target", is_dir=False)
+    assert ignore.match("/target", is_dir=False)
 
 
 def test_jujuignore_all_py_files():
-    ignore = jujuignore.JujuIgnore(['*.py'])
-    assert not ignore.match('/target', is_dir=True)
-    assert ignore.match('/target.py', is_dir=True)
-    assert ignore.match('/target.py', is_dir=False)
-    assert ignore.match('/foo/target.py', is_dir=True)
-    assert ignore.match('/foo/target.py', is_dir=False)
-    assert not ignore.match('/target.pyT', is_dir=True)
-    assert not ignore.match('/target.pyT', is_dir=False)
+    ignore = jujuignore.JujuIgnore(["*.py"])
+    assert not ignore.match("/target", is_dir=True)
+    assert ignore.match("/target.py", is_dir=True)
+    assert ignore.match("/target.py", is_dir=False)
+    assert ignore.match("/foo/target.py", is_dir=True)
+    assert ignore.match("/foo/target.py", is_dir=False)
+    assert not ignore.match("/target.pyT", is_dir=True)
+    assert not ignore.match("/target.pyT", is_dir=False)
 
 
 def test_jujuignore_all_py_files_in_foo():
-    ignore = jujuignore.JujuIgnore(['/foo/*.py'])
-    assert not ignore.match('/target.py', is_dir=True)
-    assert not ignore.match('/target.py', is_dir=False)
-    assert ignore.match('/foo/target.py', is_dir=True)
-    assert ignore.match('/foo/target.py', is_dir=False)
-    assert not ignore.match('/foo/sub/target.py', is_dir=False)
+    ignore = jujuignore.JujuIgnore(["/foo/*.py"])
+    assert not ignore.match("/target.py", is_dir=True)
+    assert not ignore.match("/target.py", is_dir=False)
+    assert ignore.match("/foo/target.py", is_dir=True)
+    assert ignore.match("/foo/target.py", is_dir=False)
+    assert not ignore.match("/foo/sub/target.py", is_dir=False)
 
 
 def test_jujuignore_ignore_comment():
-    ignore = jujuignore.JujuIgnore([
-        '#comment',
-        'target',
-    ])
-    assert ignore.match('/target', is_dir=True)
-    assert not ignore.match('/comment', is_dir=False)
-    assert not ignore.match('/#comment', is_dir=False)
-    assert not ignore.match('#comment', is_dir=False)
-    assert not ignore.match('/foo/comment', is_dir=False)
-    assert not ignore.match('/foo/#comment', is_dir=False)
+    ignore = jujuignore.JujuIgnore(
+        [
+            "#comment",
+            "target",
+        ]
+    )
+    assert ignore.match("/target", is_dir=True)
+    assert not ignore.match("/comment", is_dir=False)
+    assert not ignore.match("/#comment", is_dir=False)
+    assert not ignore.match("#comment", is_dir=False)
+    assert not ignore.match("/foo/comment", is_dir=False)
+    assert not ignore.match("/foo/#comment", is_dir=False)
 
 
 def test_jujuignore_escaped_comment():
-    ignore = jujuignore.JujuIgnore([
-        '\\#comment',
-        'target',
-    ])
-    assert ignore.match('/target', is_dir=True)
-    assert ignore.match('/#comment', is_dir=False)
-    assert ignore.match('#comment', is_dir=False)
-    assert not ignore.match('/foo/comment', is_dir=False)
-    assert ignore.match('/foo/#comment', is_dir=False)
+    ignore = jujuignore.JujuIgnore(
+        [
+            "\\#comment",
+            "target",
+        ]
+    )
+    assert ignore.match("/target", is_dir=True)
+    assert ignore.match("/#comment", is_dir=False)
+    assert ignore.match("#comment", is_dir=False)
+    assert not ignore.match("/foo/comment", is_dir=False)
+    assert ignore.match("/foo/#comment", is_dir=False)
 
 
 def test_jujuignore_subdirectory_match():
-    ignore = jujuignore.JujuIgnore(['apps/logs/'])
-    assert not ignore.match('/logs', is_dir=True)
-    assert not ignore.match('/apps', is_dir=True)
-    assert ignore.match('/apps/logs', is_dir=True)
-    assert not ignore.match('/apps/logs', is_dir=False)
-    assert not ignore.match('/apps/foo/logs', is_dir=True)
+    ignore = jujuignore.JujuIgnore(["apps/logs/"])
+    assert not ignore.match("/logs", is_dir=True)
+    assert not ignore.match("/apps", is_dir=True)
+    assert ignore.match("/apps/logs", is_dir=True)
+    assert not ignore.match("/apps/logs", is_dir=False)
+    assert not ignore.match("/apps/foo/logs", is_dir=True)
 
 
 def test_jujuignore_sub_subdirectory_match():
-    ignore = jujuignore.JujuIgnore(['apps/*/logs/'])
-    assert not ignore.match('/logs', is_dir=True)
-    assert not ignore.match('/apps', is_dir=True)
-    assert not ignore.match('/apps/logs', is_dir=True)
-    assert not ignore.match('/apps/logs', is_dir=False)
-    assert ignore.match('/apps/foo/logs', is_dir=True)
-    assert ignore.match('/apps/bar/logs', is_dir=True)
-    assert not ignore.match('/apps/baz/logs', is_dir=False)
-    assert not ignore.match('/apps/foo/bar/logs', is_dir=True)
+    ignore = jujuignore.JujuIgnore(["apps/*/logs/"])
+    assert not ignore.match("/logs", is_dir=True)
+    assert not ignore.match("/apps", is_dir=True)
+    assert not ignore.match("/apps/logs", is_dir=True)
+    assert not ignore.match("/apps/logs", is_dir=False)
+    assert ignore.match("/apps/foo/logs", is_dir=True)
+    assert ignore.match("/apps/bar/logs", is_dir=True)
+    assert not ignore.match("/apps/baz/logs", is_dir=False)
+    assert not ignore.match("/apps/foo/bar/logs", is_dir=True)
 
 
 def test_jujuignore_any_subdirectory_match():
-    ignore = jujuignore.JujuIgnore(['apps/**/logs/'])
-    assert not ignore.match('/logs', is_dir=True)
-    assert not ignore.match('/apps', is_dir=True)
-    assert ignore.match('/apps/logs', is_dir=True)
-    assert not ignore.match('/apps/logs', is_dir=False)
-    assert ignore.match('/apps/foo/logs', is_dir=True)
-    assert ignore.match('/apps/bar/logs', is_dir=True)
-    assert ignore.match('/apps/bar/bing/logs', is_dir=True)
-    assert not ignore.match('/apps/baz/logs', is_dir=False)
+    ignore = jujuignore.JujuIgnore(["apps/**/logs/"])
+    assert not ignore.match("/logs", is_dir=True)
+    assert not ignore.match("/apps", is_dir=True)
+    assert ignore.match("/apps/logs", is_dir=True)
+    assert not ignore.match("/apps/logs", is_dir=False)
+    assert ignore.match("/apps/foo/logs", is_dir=True)
+    assert ignore.match("/apps/bar/logs", is_dir=True)
+    assert ignore.match("/apps/bar/bing/logs", is_dir=True)
+    assert not ignore.match("/apps/baz/logs", is_dir=False)
 
 
 def test_jujuignore_everything_under_foo():
-    ignore = jujuignore.JujuIgnore(['foo/**'])
-    assert not ignore.match('/foo', is_dir=True)
-    assert ignore.match('/foo/a', is_dir=True)
-    assert ignore.match('/foo/a', is_dir=False)
-    assert ignore.match('/foo/a/b', is_dir=False)
+    ignore = jujuignore.JujuIgnore(["foo/**"])
+    assert not ignore.match("/foo", is_dir=True)
+    assert ignore.match("/foo/a", is_dir=True)
+    assert ignore.match("/foo/a", is_dir=False)
+    assert ignore.match("/foo/a/b", is_dir=False)
 
 
 def test_jujuignore_everything_under_foo_but_readme():
-    ignore = jujuignore.JujuIgnore([
-        'foo/**',
-        '!foo/README.md',
-    ])
-    assert not ignore.match('/foo', is_dir=True)
-    assert ignore.match('/foo/a', is_dir=True)
-    assert ignore.match('/foo/a', is_dir=False)
-    assert ignore.match('/foo/a/b', is_dir=False)
-    assert not ignore.match('/foo/README.md', is_dir=False)
+    ignore = jujuignore.JujuIgnore(
+        [
+            "foo/**",
+            "!foo/README.md",
+        ]
+    )
+    assert not ignore.match("/foo", is_dir=True)
+    assert ignore.match("/foo/a", is_dir=True)
+    assert ignore.match("/foo/a", is_dir=False)
+    assert ignore.match("/foo/a/b", is_dir=False)
+    assert not ignore.match("/foo/README.md", is_dir=False)
 
 
 def test_jujuignore_negation():
-    ignore = jujuignore.JujuIgnore([
-        '*.py',
-        '!foo.py',
-        '!!!bar.py',
-    ])
-    assert not ignore.match('bar.py', is_dir=False)
-    assert not ignore.match('foo.py', is_dir=False)
-    assert ignore.match('baz.py', is_dir=False)
-    assert not ignore.match('foo/bar.py', is_dir=False)
-    assert not ignore.match('foo/foo.py', is_dir=False)
-    assert ignore.match('foo/baz.py', is_dir=False)
+    ignore = jujuignore.JujuIgnore(
+        [
+            "*.py",
+            "!foo.py",
+            "!!!bar.py",
+        ]
+    )
+    assert not ignore.match("bar.py", is_dir=False)
+    assert not ignore.match("foo.py", is_dir=False)
+    assert ignore.match("baz.py", is_dir=False)
+    assert not ignore.match("foo/bar.py", is_dir=False)
+    assert not ignore.match("foo/foo.py", is_dir=False)
+    assert ignore.match("foo/baz.py", is_dir=False)
 
 
 def test_jujuignore_multiple_doublestar():
-    ignore = jujuignore.JujuIgnore(['foo/**/bar/**/baz'])
-    assert ignore.match('/foo/1/2/bar/baz', is_dir=True)
-    assert ignore.match('/foo/1/2/bar/1/2/baz', is_dir=True)
-    assert ignore.match('/foo/bar/1/2/baz', is_dir=True)
-    assert ignore.match('/foo/1/bar/baz', is_dir=True)
-    assert ignore.match('/foo/bar/baz', is_dir=True)
+    ignore = jujuignore.JujuIgnore(["foo/**/bar/**/baz"])
+    assert ignore.match("/foo/1/2/bar/baz", is_dir=True)
+    assert ignore.match("/foo/1/2/bar/1/2/baz", is_dir=True)
+    assert ignore.match("/foo/bar/1/2/baz", is_dir=True)
+    assert ignore.match("/foo/1/bar/baz", is_dir=True)
+    assert ignore.match("/foo/bar/baz", is_dir=True)
 
 
 def test_jujuignore_trim_unescaped_trailing_space():
-    ignore = jujuignore.JujuIgnore([
-        r'foo  ',
-        r'bar\ \ ',
-    ])
-    assert ignore.match('/foo', is_dir=True)
-    assert not ignore.match('/bar', is_dir=True)
-    assert ignore.match('/bar  ', is_dir=True)
+    ignore = jujuignore.JujuIgnore(
+        [
+            r"foo  ",
+            r"bar\ \ ",
+        ]
+    )
+    assert ignore.match("/foo", is_dir=True)
+    assert not ignore.match("/bar", is_dir=True)
+    assert ignore.match("/bar  ", is_dir=True)
 
 
 def test_jujuignore_escaped_bang():
-    ignore = jujuignore.JujuIgnore([
-        r'foo',
-        r'!/foo',
-        r'\!foo',
-    ])
-    assert not ignore.match('/foo', is_dir=True)
-    assert ignore.match('/bar/foo', is_dir=True)
-    assert ignore.match('!foo', is_dir=True)
+    ignore = jujuignore.JujuIgnore(
+        [
+            r"foo",
+            r"!/foo",
+            r"\!foo",
+        ]
+    )
+    assert not ignore.match("/foo", is_dir=True)
+    assert ignore.match("/bar/foo", is_dir=True)
+    assert ignore.match("!foo", is_dir=True)
 
 
 def test_jujuignore_leading_whitespace():
-    ignore = jujuignore.JujuIgnore([
-        r'foo',
-        r' bar',
-        r' #comment',
-    ])
-    assert ignore.match('/foo', is_dir=True)
-    assert ignore.match('/bar', is_dir=True)
-    assert ignore.match('/bar/foo', is_dir=True)
-    assert not ignore.match('#comment', is_dir=True)
-    assert not ignore.match('comment', is_dir=True)
+    ignore = jujuignore.JujuIgnore(
+        [
+            r"foo",
+            r" bar",
+            r" #comment",
+        ]
+    )
+    assert ignore.match("/foo", is_dir=True)
+    assert ignore.match("/bar", is_dir=True)
+    assert ignore.match("/bar/foo", is_dir=True)
+    assert not ignore.match("#comment", is_dir=True)
+    assert not ignore.match("comment", is_dir=True)
 
 
 def test_jujuignore_bracket():
-    ignore = jujuignore.JujuIgnore([
-        r'*.py[cod]',
-    ])
-    assert not ignore.match('foo.py', is_dir=False)
-    assert ignore.match('foo.pyc', is_dir=False)
-    assert ignore.match('foo.pyo', is_dir=False)
-    assert ignore.match('foo.pyd', is_dir=False)
+    ignore = jujuignore.JujuIgnore(
+        [
+            r"*.py[cod]",
+        ]
+    )
+    assert not ignore.match("foo.py", is_dir=False)
+    assert ignore.match("foo.pyc", is_dir=False)
+    assert ignore.match("foo.pyo", is_dir=False)
+    assert ignore.match("foo.pyd", is_dir=False)
 
 
 def test_jujuignore_simple_match():
-    ignore = jujuignore.JujuIgnore([
-        r'foo',
-    ])
-    assert ignore.match('/foo', is_dir=True)
-    assert ignore.match('/bar/foo', is_dir=True)
-    assert not ignore.match('/bar/bfoo', is_dir=True)
-    assert not ignore.match('/bfoo', is_dir=True)
+    ignore = jujuignore.JujuIgnore(
+        [
+            r"foo",
+        ]
+    )
+    assert ignore.match("/foo", is_dir=True)
+    assert ignore.match("/bar/foo", is_dir=True)
+    assert not ignore.match("/bar/bfoo", is_dir=True)
+    assert not ignore.match("/bfoo", is_dir=True)
 
 
 def test_jujuignore_star_match():
-    ignore = jujuignore.JujuIgnore([
-        r'foo*.py',
-    ])
-    assert ignore.match('/foo.py', is_dir=False)
-    assert ignore.match('/foo2.py', is_dir=False)
-    assert ignore.match('/foobar.py', is_dir=False)
-    assert ignore.match('/bar/foo.py', is_dir=False)
-    assert not ignore.match('/foo/2.py', is_dir=False)
+    ignore = jujuignore.JujuIgnore(
+        [
+            r"foo*.py",
+        ]
+    )
+    assert ignore.match("/foo.py", is_dir=False)
+    assert ignore.match("/foo2.py", is_dir=False)
+    assert ignore.match("/foobar.py", is_dir=False)
+    assert ignore.match("/bar/foo.py", is_dir=False)
+    assert not ignore.match("/foo/2.py", is_dir=False)
 
 
 def test_jujuignore_paths_with_newlines():
-    ignore = jujuignore.JujuIgnore([
-        r'bar/**/*.py'
-    ])
-    assert ignore.match('/bar/foo.py', is_dir=False)
-    assert ignore.match('/bar/f\noo.py', is_dir=False)
-    assert ignore.match('/bar/baz/f\noo.py', is_dir=False)
-    assert ignore.match('/bar/b\nz/f\noo.py', is_dir=False)
+    ignore = jujuignore.JujuIgnore([r"bar/**/*.py"])
+    assert ignore.match("/bar/foo.py", is_dir=False)
+    assert ignore.match("/bar/f\noo.py", is_dir=False)
+    assert ignore.match("/bar/baz/f\noo.py", is_dir=False)
+    assert ignore.match("/bar/b\nz/f\noo.py", is_dir=False)
 
 
 def test_rstrip_unescaped():
-    assert jujuignore._rstrip_unescaped(r'') == ''
-    assert jujuignore._rstrip_unescaped(r' ') == ''
-    assert jujuignore._rstrip_unescaped(r'a') == 'a'
-    assert jujuignore._rstrip_unescaped(r'a ') == 'a'
-    assert jujuignore._rstrip_unescaped(r'a  ') == 'a'
-    assert jujuignore._rstrip_unescaped(r'a\  ') == r'a\ '
-    assert jujuignore._rstrip_unescaped(r'a foo\  ') == r'a foo\ '
+    assert jujuignore._rstrip_unescaped(r"") == ""
+    assert jujuignore._rstrip_unescaped(r" ") == ""
+    assert jujuignore._rstrip_unescaped(r"a") == "a"
+    assert jujuignore._rstrip_unescaped(r"a ") == "a"
+    assert jujuignore._rstrip_unescaped(r"a  ") == "a"
+    assert jujuignore._rstrip_unescaped(r"a\  ") == r"a\ "
+    assert jujuignore._rstrip_unescaped(r"a foo\  ") == r"a foo\ "
 
 
 def test_unescape_rule():
-    assert jujuignore._unescape_rule(r'') == ''
-    assert jujuignore._unescape_rule(r' ') == ''
-    assert jujuignore._unescape_rule(r'\#') == '#'
-    assert jujuignore._unescape_rule(r'\!') == '!'
-    assert jujuignore._unescape_rule(r'\ ') == ' '
-    assert jujuignore._unescape_rule(r' foo\ ') == 'foo '
+    assert jujuignore._unescape_rule(r"") == ""
+    assert jujuignore._unescape_rule(r" ") == ""
+    assert jujuignore._unescape_rule(r"\#") == "#"
+    assert jujuignore._unescape_rule(r"\!") == "!"
+    assert jujuignore._unescape_rule(r"\ ") == " "
+    assert jujuignore._unescape_rule(r" foo\ ") == "foo "
 
 
 def test_from_file():
-    content = io.StringIO(textwrap.dedent('''\
+    content = io.StringIO(
+        textwrap.dedent(
+            """\
     foo
     /bar
-    '''))
+    """
+        )
+    )
     ignore = jujuignore.JujuIgnore(content)
-    assert ignore.match('foo', is_dir=False)
-    assert ignore.match('/foo', is_dir=False)
-    assert ignore.match('/bar', is_dir=False)
-    assert not ignore.match('/foo/bar', is_dir=False)
+    assert ignore.match("foo", is_dir=False)
+    assert ignore.match("/foo", is_dir=False)
+    assert ignore.match("/bar", is_dir=False)
+    assert not ignore.match("/foo/bar", is_dir=False)
 
 
 def assertMatchedAndNonMatched(globs, matched, unmatched, skip_git=False):
     """For a given set of globs, check that it does and doesn't match as expected"""
     ignore = jujuignore.JujuIgnore(globs)
     for m in matched:
-        assert ignore.match(m, is_dir=False), '{} should have matched'.format(m)
+        assert ignore.match(m, is_dir=False), "{} should have matched".format(m)
     for m in unmatched:
-        assert not ignore.match(m, is_dir=False), '{} should not have matched'.format(m)
+        assert not ignore.match(m, is_dir=False), "{} should not have matched".format(m)
     if skip_git:
         return
     with tempfile.TemporaryDirectory() as tmpdir:
-        subprocess.run(['git', 'init', tmpdir], check=True)
-        with open(str(pathlib.Path(tmpdir) / '.gitignore'), 'wt') as gitignore:
-            gitignore.writelines([g + '\n' for g in globs])
-        input = ''.join(
-            [m.lstrip('/') + '\n' for m in matched + unmatched])
+        subprocess.run(["git", "init", tmpdir], check=True)
+        with open(str(pathlib.Path(tmpdir) / ".gitignore"), "wt") as gitignore:
+            gitignore.writelines([g + "\n" for g in globs])
+        input = "".join([m.lstrip("/") + "\n" for m in matched + unmatched])
         check = True
         if len(matched) == 0:
             # We don't check git return value because it returns nonzero if no paths match
             check = False
         p = subprocess.run(
-            ['git', 'check-ignore', '--stdin'],
-            check=check, input=input, stdout=subprocess.PIPE, cwd=tmpdir, universal_newlines=True)
+            ["git", "check-ignore", "--stdin"],
+            check=check,
+            input=input,
+            stdout=subprocess.PIPE,
+            cwd=tmpdir,
+            universal_newlines=True,
+        )
     matched_out = p.stdout.splitlines()
-    assert sorted(matched) == sorted(matched_out),\
-        'expected exactly {} to match not {}'.format(matched, matched_out)
+    assert sorted(matched) == sorted(
+        matched_out
+    ), "expected exactly {} to match not {}".format(matched, matched_out)
 
 
 def test_star_vs_star_start():
     assertMatchedAndNonMatched(
-        ['/*.py', '**/foo'],
+        ["/*.py", "**/foo"],
         # Only top level .py files, but foo at any level
-        ['a.py', 'b.py', 'foo', 'bar/foo'],
-        ['bar/b.py'],
+        ["a.py", "b.py", "foo", "bar/foo"],
+        ["bar/b.py"],
         # 'foo/a.py',  git matches foo/a.py because of foo, ours doesn't but I don't think it
         # matters because the whole directory would have already been skipped
     )
@@ -330,85 +357,85 @@ def test_star_vs_star_start():
 
 def test_questionmark():
     assertMatchedAndNonMatched(
-        ['foo?.py'],
-        ['fooa.py', 'foob.py'],
-        ['foo.py', 'footwo.py', 'foo/.py'],
+        ["foo?.py"],
+        ["fooa.py", "foob.py"],
+        ["foo.py", "footwo.py", "foo/.py"],
     )
 
 
 def test_brackets():
     assertMatchedAndNonMatched(
-        ['*.py[cod]'],
-        ['a.pyc', 'b.pyo', 'd.pyd', 'foo/.pyc', 'bar/__pycache__.pyc'],
-        ['a.py', 'b.pyq', 'c.so', 'foo/__pycache__/bar.py'],
+        ["*.py[cod]"],
+        ["a.pyc", "b.pyo", "d.pyd", "foo/.pyc", "bar/__pycache__.pyc"],
+        ["a.py", "b.pyq", "c.so", "foo/__pycache__/bar.py"],
     )
 
 
 def test_bracket_ranges():
     assertMatchedAndNonMatched(
-        ['foo[1-9].py'],
-        ['foo1.py', 'foo2.py', 'foo9.py'],
-        ['foo0.py', 'foo10.py', 'fooa.py'],
+        ["foo[1-9].py"],
+        ["foo1.py", "foo2.py", "foo9.py"],
+        ["foo0.py", "foo10.py", "fooa.py"],
     )
 
 
 def test_bracket_inverted():
     assertMatchedAndNonMatched(
-        ['foo[!1-9].py', 'bar[!a].py'],
-        ['fooa.py', 'foob.py', 'fooc.py', 'barb.py', 'barc.py'],
-        ['foo1.py', 'foo2.py', 'foo10.py', 'bara.py'],
+        ["foo[!1-9].py", "bar[!a].py"],
+        ["fooa.py", "foob.py", "fooc.py", "barb.py", "barc.py"],
+        ["foo1.py", "foo2.py", "foo10.py", "bara.py"],
     )
 
 
 def test_slashes_in_brackets():
     assertMatchedAndNonMatched(
-        [r'foo[\\].py'],
-        [r'foo\.py'],
-        [r'fooa.py'],
+        [r"foo[\\].py"],
+        [r"foo\.py"],
+        [r"fooa.py"],
         # We don't test against git here, because it replies with "foo\\.py"
         # which is an escaped form that we'd have to interpret
-        skip_git=True)
+        skip_git=True,
+    )
 
 
 def test_special_chars_in_brackets():
     assertMatchedAndNonMatched(
-        [r'foo[a|b].py'],
-        [r'fooa.py', 'foob.py', 'foo|.py'],
-        [r'foo.py', r'fooc.py'],
+        [r"foo[a|b].py"],
+        [r"fooa.py", "foob.py", "foo|.py"],
+        [r"foo.py", r"fooc.py"],
     )
     assertMatchedAndNonMatched(
-        [r'foo[ab|cd].py'],
-        [r'fooa.py', 'foob.py', 'fooc.py', 'food.py', 'foo|.py'],
-        [r'foo.py', 'fooe.py', 'fooab.py', 'fooac.py'],
+        [r"foo[ab|cd].py"],
+        [r"fooa.py", "foob.py", "fooc.py", "food.py", "foo|.py"],
+        [r"foo.py", "fooe.py", "fooab.py", "fooac.py"],
     )
     assertMatchedAndNonMatched(
-        [r'foo[a&].py'],
-        [r'fooa.py', r'foo&.py'],
-        [r'foo.py', r'fooa&.py', 'foob.py'],
-
+        [r"foo[a&].py"],
+        [r"fooa.py", r"foo&.py"],
+        [r"foo.py", r"fooa&.py", "foob.py"],
     )
     assertMatchedAndNonMatched(
-        [r'foo[a~].py'],
-        [r'fooa.py', r'foo~.py'],
-        [r'foo.py', r'fooa~.py', 'foob.py'],
+        [r"foo[a~].py"],
+        [r"fooa.py", r"foo~.py"],
+        [r"foo.py", r"fooa~.py", "foob.py"],
     )
     assertMatchedAndNonMatched(
-        [r'foo[[a].py'],
-        [r'fooa.py', r'foo[.py'],
-        [r'foo.py', r'fooa[.py', 'foob.py'],
+        [r"foo[[a].py"],
+        [r"fooa.py", r"foo[.py"],
+        [r"foo.py", r"fooa[.py", "foob.py"],
     )
     # Git allows ! or ^ to mean negate the glob
     assertMatchedAndNonMatched(
-        [r'foo[^a].py'],
-        ['foob.py', 'fooc.py', 'foo^.py'],
-        [r'foo.py', r'fooa.py', r'fooa^.py'],
+        [r"foo[^a].py"],
+        ["foob.py", "fooc.py", "foo^.py"],
+        [r"foo.py", r"fooa.py", r"fooa^.py"],
     )
 
 
 def test_extend_patterns():
-    ignore = jujuignore.JujuIgnore(['foo'])
-    assert ignore.match('foo', is_dir=False)
-    assert not ignore.match('bar', is_dir=False)
-    ignore.extend_patterns(['bar'])
-    assert ignore.match('foo', is_dir=False)
-    assert ignore.match('bar', is_dir=False)
+    ignore = jujuignore.JujuIgnore(["foo"])
+    assert ignore.match("foo", is_dir=False)
+    assert not ignore.match("bar", is_dir=False)
+    ignore.extend_patterns(["bar"])
+    assert ignore.match("foo", is_dir=False)
+    assert ignore.match("bar", is_dir=False)

--- a/tests/test_logsetup.py
+++ b/tests/test_logsetup.py
@@ -191,8 +191,9 @@ def test_ended_crash_while_normal(caplog, create_message_handler):
     except Exception as err:
         mh.ended_crash(err)  # needs to have an exception "active"
 
-    expected_msg = "charmcraft internal error! ValueError: crazy crash (full execution logs in {})".format(
-        mh._log_filepath
+    expected_msg = (
+        "charmcraft internal error! "
+        "ValueError: crazy crash (full execution logs in {})".format(mh._log_filepath)
     )
 
     # file is present, and it has the error and the traceback
@@ -219,8 +220,9 @@ def test_ended_crash_while_verbose(caplog, create_message_handler):
     except Exception as err:
         mh.ended_crash(err)  # needs to have an exception "active"
 
-    expected_msg = "charmcraft internal error! ValueError: crazy crash (full execution logs in {})".format(
-        mh._log_filepath
+    expected_msg = (
+        "charmcraft internal error! "
+        "ValueError: crazy crash (full execution logs in {})".format(mh._log_filepath)
     )
 
     # file is present, and it has the error and the traceback

--- a/tests/test_logsetup.py
+++ b/tests/test_logsetup.py
@@ -30,19 +30,19 @@ def create_message_handler(tmp_path):
 
     Always in a temp directory, maybe with patched modes.
     """
-    temp_log_file = tmp_path / 'test.log'
+    temp_log_file = tmp_path / "test.log"
     patchers = []
 
     def factory(modes=None):
-        p = patch('tempfile.mkstemp', lambda prefix: ('fd', str(temp_log_file)))
+        p = patch("tempfile.mkstemp", lambda prefix: ("fd", str(temp_log_file)))
         p.start()
         patchers.append(p)
 
         if modes is not None:
-            if 'verbose' not in modes:
+            if "verbose" not in modes:
                 # verbose should always be there, as it's used internally
-                modes['verbose'] = (10, "%(message)s")
-            p = patch.object(_MessageHandler, '_modes', modes)
+                modes["verbose"] = (10, "%(message)s")
+            p = patch.object(_MessageHandler, "_modes", modes)
             p.start()
             patchers.append(p)
 
@@ -57,11 +57,12 @@ def create_message_handler(tmp_path):
 
 # --- Tests for the MessageHandler
 
+
 def test_mode_setting_init(create_message_handler):
     """The internal mode is set on init and logger properly changed."""
     test_level = 123
     test_format = "test:: %(message)s"
-    mh = create_message_handler({'foo': (test_level, test_format)})
+    mh = create_message_handler({"foo": (test_level, test_format)})
     mh.init(mh.FOO)
 
     assert mh.mode == mh.FOO
@@ -73,7 +74,7 @@ def test_mode_setting_changed(create_message_handler):
     """The internal mode can be set later and logger properly changed."""
     test_level = 123
     test_format = "test:: %(message)s"
-    mh = create_message_handler({'foo': (0, ''), 'bar': (test_level, test_format)})
+    mh = create_message_handler({"foo": (0, ""), "bar": (test_level, test_format)})
     mh.init(mh.FOO)
     mh.set_mode(mh.BAR)
 
@@ -93,14 +94,14 @@ def test_logfile_all_stored(create_message_handler):
     logger.warning("test warning")
     logger.error("test error")
 
-    with open(mh._log_filepath, 'rt') as fh:
+    with open(mh._log_filepath, "rt") as fh:
         logcontent = fh.readlines()
 
     # start checking from pos 1, as in 0 we always have the bootstrap message
-    assert 'test debug' in logcontent[1]
-    assert 'test info' in logcontent[2]
-    assert 'test warning' in logcontent[3]
-    assert 'test error' in logcontent[4]
+    assert "test debug" in logcontent[1]
+    assert "test info" in logcontent[2]
+    assert "test warning" in logcontent[3]
+    assert "test error" in logcontent[4]
 
 
 def test_ended_success(caplog, create_message_handler):
@@ -156,12 +157,14 @@ def test_ended_commanderror_regular(caplog, create_message_handler):
     mh.init(mh.NORMAL)
     mh.ended_cmderror(CommandError("test controlled error"))
 
-    expected_msg = "test controlled error (full execution logs in {})".format(mh._log_filepath)
+    expected_msg = "test controlled error (full execution logs in {})".format(
+        mh._log_filepath
+    )
 
     # file is present, and it has the error
-    with open(mh._log_filepath, 'rt', encoding='ascii') as fh:
+    with open(mh._log_filepath, "rt", encoding="ascii") as fh:
         log_content = fh.read()
-    assert 'ERROR' in log_content
+    assert "ERROR" in log_content
     assert expected_msg in log_content
 
     # also it shown the error to the user
@@ -188,16 +191,16 @@ def test_ended_crash_while_normal(caplog, create_message_handler):
     except Exception as err:
         mh.ended_crash(err)  # needs to have an exception "active"
 
-    expected_msg = (
-        "charmcraft internal error! ValueError: crazy crash (full execution logs in {})".format(
-            mh._log_filepath))
+    expected_msg = "charmcraft internal error! ValueError: crazy crash (full execution logs in {})".format(
+        mh._log_filepath
+    )
 
     # file is present, and it has the error and the traceback
-    with open(mh._log_filepath, 'rt', encoding='ascii') as fh:
+    with open(mh._log_filepath, "rt", encoding="ascii") as fh:
         log_content = fh.read()
-    assert 'ERROR' in log_content
+    assert "ERROR" in log_content
     assert expected_msg in log_content
-    assert 'Traceback' in log_content
+    assert "Traceback" in log_content
 
     # also it shown ONLY the error to the user
     (record,) = caplog.records
@@ -216,16 +219,16 @@ def test_ended_crash_while_verbose(caplog, create_message_handler):
     except Exception as err:
         mh.ended_crash(err)  # needs to have an exception "active"
 
-    expected_msg = (
-        "charmcraft internal error! ValueError: crazy crash (full execution logs in {})".format(
-            mh._log_filepath))
+    expected_msg = "charmcraft internal error! ValueError: crazy crash (full execution logs in {})".format(
+        mh._log_filepath
+    )
 
     # file is present, and it has the error and the traceback
-    with open(mh._log_filepath, 'rt', encoding='ascii') as fh:
+    with open(mh._log_filepath, "rt", encoding="ascii") as fh:
         log_content = fh.read()
-    assert 'ERROR' in log_content
+    assert "ERROR" in log_content
     assert expected_msg in log_content
-    assert 'Traceback' in log_content
+    assert "Traceback" in log_content
 
     # also it shown the error to the user AND also the traceback
     (_, record) = caplog.records

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -35,6 +35,7 @@ import pytest
 
 def test_dispatcher_command_execution_ok():
     """Command execution depends of the indicated name in command line, return code ok."""
+
     class MyCommandControl(BaseCommand):
         help_msg = "some help"
 
@@ -42,15 +43,15 @@ def test_dispatcher_command_execution_ok():
             self._executed.append(parsed_args)
 
     class MyCommand1(MyCommandControl):
-        name = 'name1'
+        name = "name1"
         _executed = []
 
     class MyCommand2(MyCommandControl):
-        name = 'name2'
+        name = "name2"
         _executed = []
 
-    groups = [('test-group', 'title', [MyCommand1, MyCommand2])]
-    dispatcher = Dispatcher(['name2'], groups)
+    groups = [("test-group", "title", [MyCommand1, MyCommand2])]
+    dispatcher = Dispatcher(["name2"], groups)
     dispatcher.run()
     assert MyCommand1._executed == []
     assert isinstance(MyCommand2._executed[0], argparse.Namespace)
@@ -58,24 +59,26 @@ def test_dispatcher_command_execution_ok():
 
 def test_dispatcher_command_execution_crash():
     """Command crashing doesn't pass through, we inform nicely."""
+
     class MyCommand(BaseCommand):
         help_msg = "some help"
-        name = 'cmdname'
+        name = "cmdname"
 
         def run(self, parsed_args):
             raise ValueError()
 
-    groups = [('test-group', 'title', [MyCommand])]
-    dispatcher = Dispatcher(['cmdname'], groups)
+    groups = [("test-group", "title", [MyCommand])]
+    dispatcher = Dispatcher(["cmdname"], groups)
     with pytest.raises(ValueError):
         dispatcher.run()
 
 
 def test_dispatcher_config_needed_ok(tmp_path):
     """Command needs a config, which is provided ok."""
+
     class MyCommand(BaseCommand):
         help_msg = "some help"
-        name = 'cmdname'
+        name = "cmdname"
         needs_config = True
 
         def run(self, parsed_args):
@@ -83,150 +86,173 @@ def test_dispatcher_config_needed_ok(tmp_path):
 
     # put the config in place
     test_file = tmp_path / "charmcraft.yaml"
-    test_file.write_text("""
+    test_file.write_text(
+        """
         type: charm
-    """)
+    """
+    )
 
-    groups = [('test-group', 'title', [MyCommand])]
-    dispatcher = Dispatcher(['cmdname', '--project-dir', tmp_path], groups)
+    groups = [("test-group", "title", [MyCommand])]
+    dispatcher = Dispatcher(["cmdname", "--project-dir", tmp_path], groups)
     dispatcher.run()
 
 
 def test_dispatcher_config_needed_problem():
     """Command needs a config, which is not there."""
+
     class MyCommand(BaseCommand):
         help_msg = "some help"
-        name = 'cmdname'
+        name = "cmdname"
         needs_config = True
 
         def run(self, parsed_args):
             pass
 
-    groups = [('test-group', 'title', [MyCommand])]
-    dispatcher = Dispatcher(['cmdname'], groups)
+    groups = [("test-group", "title", [MyCommand])]
+    dispatcher = Dispatcher(["cmdname"], groups)
     with pytest.raises(CommandError) as err:
         dispatcher.run()
     assert str(err.value) == (
         "The specified command needs a valid 'charmcraft.yaml' configuration file (in the "
         "current directory or where specified with --project-dir option); see the reference: "
-        "https://discourse.charmhub.io/t/charmcraft-configuration/4138")
+        "https://discourse.charmhub.io/t/charmcraft-configuration/4138"
+    )
 
 
 def test_dispatcher_config_not_needed():
     """Command does not needs a config."""
+
     class MyCommand(BaseCommand):
         help_msg = "some help"
-        name = 'cmdname'
+        name = "cmdname"
 
         def run(self, parsed_args):
             pass
 
-    groups = [('test-group', 'title', [MyCommand])]
-    dispatcher = Dispatcher(['cmdname'], groups)
+    groups = [("test-group", "title", [MyCommand])]
+    dispatcher = Dispatcher(["cmdname"], groups)
     dispatcher.run()
 
 
 def test_dispatcher_generic_setup_default():
     """Generic parameter handling for default values."""
-    cmd = create_command('somecommand')
-    groups = [('test-group', 'title', [cmd])]
+    cmd = create_command("somecommand")
+    groups = [("test-group", "title", [cmd])]
     logsetup.message_handler.mode = None
-    with patch('charmcraft.config.load') as config_mock:
-        Dispatcher(['somecommand'], groups)
+    with patch("charmcraft.config.load") as config_mock:
+        Dispatcher(["somecommand"], groups)
     assert logsetup.message_handler.mode is None
     config_mock.assert_called_once_with(None)
 
 
-@pytest.mark.parametrize("options", [
-    ['somecommand', '--verbose'],
-    ['somecommand', '-v'],
-    ['-v', 'somecommand'],
-    ['--verbose', 'somecommand'],
-    ['--verbose', 'somecommand', '-v'],
-])
+@pytest.mark.parametrize(
+    "options",
+    [
+        ["somecommand", "--verbose"],
+        ["somecommand", "-v"],
+        ["-v", "somecommand"],
+        ["--verbose", "somecommand"],
+        ["--verbose", "somecommand", "-v"],
+    ],
+)
 def test_dispatcher_generic_setup_verbose(options):
     """Generic parameter handling for verbose log setup, directly or after the command."""
-    cmd = create_command('somecommand')
-    groups = [('test-group', 'title', [cmd])]
+    cmd = create_command("somecommand")
+    groups = [("test-group", "title", [cmd])]
     logsetup.message_handler.mode = None
     Dispatcher(options, groups)
     assert logsetup.message_handler.mode == logsetup.message_handler.VERBOSE
 
 
-@pytest.mark.parametrize("options", [
-    ['somecommand', '--quiet'],
-    ['somecommand', '-q'],
-    ['-q', 'somecommand'],
-    ['--quiet', 'somecommand'],
-    ['--quiet', 'somecommand', '-q'],
-])
+@pytest.mark.parametrize(
+    "options",
+    [
+        ["somecommand", "--quiet"],
+        ["somecommand", "-q"],
+        ["-q", "somecommand"],
+        ["--quiet", "somecommand"],
+        ["--quiet", "somecommand", "-q"],
+    ],
+)
 def test_dispatcher_generic_setup_quiet(options):
     """Generic parameter handling for quiet log setup, directly or after the command."""
-    cmd = create_command('somecommand')
-    groups = [('test-group', 'title', [cmd])]
+    cmd = create_command("somecommand")
+    groups = [("test-group", "title", [cmd])]
     logsetup.message_handler.mode = None
     Dispatcher(options, groups)
     assert logsetup.message_handler.mode == logsetup.message_handler.QUIET
 
 
-@pytest.mark.parametrize("options", [
-    ['--quiet', '--verbose', 'somecommand'],
-    ['-v', '-q', 'somecommand'],
-    ['somecommand', '--quiet', '--verbose'],
-    ['somecommand', '-v', '-q'],
-    ['--verbose', 'somecommand', '--quiet'],
-    ['-q', 'somecommand', '-v'],
-])
+@pytest.mark.parametrize(
+    "options",
+    [
+        ["--quiet", "--verbose", "somecommand"],
+        ["-v", "-q", "somecommand"],
+        ["somecommand", "--quiet", "--verbose"],
+        ["somecommand", "-v", "-q"],
+        ["--verbose", "somecommand", "--quiet"],
+        ["-q", "somecommand", "-v"],
+    ],
+)
 def test_dispatcher_generic_setup_mutually_exclusive(options):
     """Disallow mutually exclusive generic options."""
-    cmd = create_command('somecommand')
-    groups = [('test-group', 'title', [cmd])]
+    cmd = create_command("somecommand")
+    groups = [("test-group", "title", [cmd])]
     # test the system exit, which is done automatically by argparse
     with pytest.raises(CommandError) as err:
         Dispatcher(options, groups)
     assert str(err.value) == "The 'verbose' and 'quiet' options are mutually exclusive."
 
 
-@pytest.mark.parametrize("options", [
-    ['somecommand', '--project-dir', 'foobar'],
-    ['somecommand', '--project-dir=foobar'],
-    ['somecommand', '-p', 'foobar'],
-    ['-p', 'foobar', 'somecommand'],
-    ['--project-dir', 'foobar', 'somecommand'],
-    ['--project-dir=foobar', 'somecommand'],
-])
+@pytest.mark.parametrize(
+    "options",
+    [
+        ["somecommand", "--project-dir", "foobar"],
+        ["somecommand", "--project-dir=foobar"],
+        ["somecommand", "-p", "foobar"],
+        ["-p", "foobar", "somecommand"],
+        ["--project-dir", "foobar", "somecommand"],
+        ["--project-dir=foobar", "somecommand"],
+    ],
+)
 def test_dispatcher_generic_setup_projectdir_with_param(options):
     """Generic parameter handling for 'project dir' with the param, directly or after the cmd."""
-    cmd = create_command('somecommand')
-    groups = [('test-group', 'title', [cmd])]
-    with patch('charmcraft.config.load') as config_mock:
+    cmd = create_command("somecommand")
+    groups = [("test-group", "title", [cmd])]
+    with patch("charmcraft.config.load") as config_mock:
         Dispatcher(options, groups)
-    config_mock.assert_called_once_with('foobar')
+    config_mock.assert_called_once_with("foobar")
 
 
-@pytest.mark.parametrize("options", [
-    ['somecommand', '--project-dir'],
-    ['somecommand', '--project-dir='],
-    ['somecommand', '-p'],
-    ['--project-dir=', 'somecommand'],
-])
+@pytest.mark.parametrize(
+    "options",
+    [
+        ["somecommand", "--project-dir"],
+        ["somecommand", "--project-dir="],
+        ["somecommand", "-p"],
+        ["--project-dir=", "somecommand"],
+    ],
+)
 def test_dispatcher_generic_setup_projectdir_without_param_simple(options):
     """Generic parameter handling for 'project dir' without the requested parameter."""
-    cmd = create_command('somecommand')
-    groups = [('test-group', 'title', [cmd])]
+    cmd = create_command("somecommand")
+    groups = [("test-group", "title", [cmd])]
     with pytest.raises(CommandError) as err:
         Dispatcher(options, groups)
     assert str(err.value) == "The 'project-dir' option expects one argument."
 
 
-@pytest.mark.parametrize("options", [
-    ['-p', 'somecommand'],
-    ['--project-dir', 'somecommand'],
-])
+@pytest.mark.parametrize(
+    "options",
+    [
+        ["-p", "somecommand"],
+        ["--project-dir", "somecommand"],
+    ],
+)
 def test_dispatcher_generic_setup_projectdir_without_param_confusing(options):
     """Generic parameter handling for 'project dir' taking confusingly the command as the arg."""
-    cmd = create_command('somecommand')
-    groups = [('test-group', 'title', [cmd])]
+    cmd = create_command("somecommand")
+    groups = [("test-group", "title", [cmd])]
     with pytest.raises(CommandError) as err:
         Dispatcher(options, groups)
 
@@ -236,14 +262,20 @@ def test_dispatcher_generic_setup_projectdir_without_param_confusing(options):
 
 def test_dispatcher_build_commands_ok():
     """Correct command loading."""
-    cmd0, cmd1, cmd2 = [create_command('cmd-name-{}'.format(n), 'cmd help') for n in range(3)]
+    cmd0, cmd1, cmd2 = [
+        create_command("cmd-name-{}".format(n), "cmd help") for n in range(3)
+    ]
     groups = [
-        ('test-group-A', 'whatever title', [cmd0]),
-        ('test-group-B', 'other title', [cmd1, cmd2]),
+        ("test-group-A", "whatever title", [cmd0]),
+        ("test-group-B", "other title", [cmd1, cmd2]),
     ]
     dispatcher = Dispatcher([cmd0.name], groups)
     assert len(dispatcher.commands) == 3
-    for cmd, group in [(cmd0, 'test-group-A'), (cmd1, 'test-group-B'), (cmd2, 'test-group-B')]:
+    for cmd, group in [
+        (cmd0, "test-group-A"),
+        (cmd1, "test-group-B"),
+        (cmd2, "test-group-B"),
+    ]:
         expected_class, expected_group = dispatcher.commands[cmd.name]
         assert expected_class == cmd
         assert expected_group == group
@@ -251,21 +283,22 @@ def test_dispatcher_build_commands_ok():
 
 def test_dispatcher_build_commands_repeated():
     """Error while loading commands with repeated name."""
+
     class Foo(BaseCommand):
         help_msg = "some help"
-        name = 'repeated'
+        name = "repeated"
 
     class Bar(BaseCommand):
         help_msg = "some help"
-        name = 'cool'
+        name = "cool"
 
     class Baz(BaseCommand):
         help_msg = "some help"
-        name = 'repeated'
+        name = "repeated"
 
     groups = [
-        ('test-group-1', 'whatever title', [Foo, Bar]),
-        ('test-group-2', 'other title', [Baz]),
+        ("test-group-1", "whatever title", [Foo, Bar]),
+        ("test-group-2", "other title", [Baz]),
     ]
     expected_msg = "Multiple commands with same name: (Foo|Baz) and (Baz|Foo)"
     with pytest.raises(RuntimeError, match=expected_msg):
@@ -275,7 +308,8 @@ def test_dispatcher_build_commands_repeated():
 def test_dispatcher_commands_are_not_loaded_if_not_needed():
     class MyCommand1(BaseCommand):
         """Expected to be executed."""
-        name = 'command1'
+
+        name = "command1"
         help_msg = "some help"
         _executed = []
 
@@ -284,7 +318,8 @@ def test_dispatcher_commands_are_not_loaded_if_not_needed():
 
     class MyCommand2(BaseCommand):
         """Expected to not be instantiated, or parse args, or run."""
-        name = 'command2'
+
+        name = "command2"
         help_msg = "some help"
 
         def __init__(self, *args):
@@ -296,8 +331,8 @@ def test_dispatcher_commands_are_not_loaded_if_not_needed():
         def run(self, parsed_args):
             raise AssertionError
 
-    groups = [('test-group', 'title', [MyCommand1, MyCommand2])]
-    dispatcher = Dispatcher(['command1'], groups)
+    groups = [("test-group", "title", [MyCommand1, MyCommand2])]
+    dispatcher = Dispatcher(["command1"], groups)
     dispatcher.run()
     assert isinstance(MyCommand1._executed[0], argparse.Namespace)
 
@@ -311,10 +346,10 @@ def test_dispatcher_commands_are_not_loaded_if_not_needed():
 
 def test_main_ok():
     """Work ended ok: message handler notified properly, return code in 0."""
-    with patch('charmcraft.main.message_handler') as mh_mock:
-        with patch('charmcraft.main.Dispatcher.run') as d_mock:
+    with patch("charmcraft.main.message_handler") as mh_mock:
+        with patch("charmcraft.main.Dispatcher.run") as d_mock:
             d_mock.return_value = None
-            retcode = main(['charmcraft', 'version'])
+            retcode = main(["charmcraft", "version"])
 
     assert retcode == 0
     mh_mock.ended_ok.assert_called_once_with()
@@ -322,8 +357,8 @@ def test_main_ok():
 
 def test_main_no_args():
     """The setup.py entry_point function needs to work with no arguments."""
-    with patch('sys.argv', ['charmcraft']):
-        with patch('charmcraft.main.message_handler') as mh_mock:
+    with patch("sys.argv", ["charmcraft"]):
+        with patch("charmcraft.main.message_handler") as mh_mock:
             retcode = main()
 
     assert retcode == 1
@@ -332,11 +367,11 @@ def test_main_no_args():
 
 def test_main_controlled_error():
     """Work raised CommandError: message handler notified properly, use indicated return code."""
-    simulated_exception = CommandError('boom', retcode=33)
-    with patch('charmcraft.main.message_handler') as mh_mock:
-        with patch('charmcraft.main.Dispatcher.run') as d_mock:
+    simulated_exception = CommandError("boom", retcode=33)
+    with patch("charmcraft.main.message_handler") as mh_mock:
+        with patch("charmcraft.main.Dispatcher.run") as d_mock:
             d_mock.side_effect = simulated_exception
-            retcode = main(['charmcraft', 'version'])
+            retcode = main(["charmcraft", "version"])
 
     assert retcode == 33
     mh_mock.ended_cmderror.assert_called_once_with(simulated_exception)
@@ -344,11 +379,11 @@ def test_main_controlled_error():
 
 def test_main_crash():
     """Work crashed: message handler notified properly, return code in 1."""
-    simulated_exception = ValueError('boom')
-    with patch('charmcraft.main.message_handler') as mh_mock:
-        with patch('charmcraft.main.Dispatcher.run') as d_mock:
+    simulated_exception = ValueError("boom")
+    with patch("charmcraft.main.message_handler") as mh_mock:
+        with patch("charmcraft.main.Dispatcher.run") as d_mock:
             d_mock.side_effect = simulated_exception
-            retcode = main(['charmcraft', 'version'])
+            retcode = main(["charmcraft", "version"])
 
     assert retcode == 1
     mh_mock.ended_crash.assert_called_once_with(simulated_exception)
@@ -356,10 +391,10 @@ def test_main_crash():
 
 def test_main_interrupted():
     """Work interrupted: message handler notified properly, return code in 1."""
-    with patch('charmcraft.main.message_handler') as mh_mock:
-        with patch('charmcraft.main.Dispatcher.run') as d_mock:
+    with patch("charmcraft.main.message_handler") as mh_mock:
+        with patch("charmcraft.main.Dispatcher.run") as d_mock:
             d_mock.side_effect = KeyboardInterrupt
-            retcode = main(['charmcraft', 'version'])
+            retcode = main(["charmcraft", "version"])
 
     assert retcode == 1
     assert mh_mock.ended_interrupt.call_count == 1
@@ -370,22 +405,26 @@ def test_main_interrupted():
 
 def test_initmsg_default():
     """Without any option, the init msg only goes to disk."""
-    cmd = create_command('somecommand')
+    cmd = create_command("somecommand")
     fake_stream = io.StringIO()
-    with patch('charmcraft.main.COMMAND_GROUPS', [('test-group', 'whatever title', [cmd])]):
-        with patch.object(logsetup.message_handler, 'ended_ok') as ended_ok_mock:
-            with patch.object(logsetup.message_handler._stderr_handler, 'stream', fake_stream):
-                main(['charmcraft', 'somecommand'])
+    with patch(
+        "charmcraft.main.COMMAND_GROUPS", [("test-group", "whatever title", [cmd])]
+    ):
+        with patch.object(logsetup.message_handler, "ended_ok") as ended_ok_mock:
+            with patch.object(
+                logsetup.message_handler._stderr_handler, "stream", fake_stream
+            ):
+                main(["charmcraft", "somecommand"])
 
     # get the logfile first line before removing it
     ended_ok_mock.assert_called_once_with()
     logged_to_file = pathlib.Path(logsetup.message_handler._log_filepath).read_text()
-    file_first_line = logged_to_file.split('\n')[0]
+    file_first_line = logged_to_file.split("\n")[0]
     logsetup.message_handler.ended_ok()
 
     # get the terminal first line
     captured = fake_stream.getvalue()
-    terminal_first_line = captured.split('\n')[0]
+    terminal_first_line = captured.split("\n")[0]
 
     expected = "Starting charmcraft version " + __version__
     assert expected in file_first_line
@@ -394,22 +433,26 @@ def test_initmsg_default():
 
 def test_initmsg_quiet():
     """In quiet mode, the init msg only goes to disk."""
-    cmd = create_command('somecommand')
+    cmd = create_command("somecommand")
     fake_stream = io.StringIO()
-    with patch('charmcraft.main.COMMAND_GROUPS', [('test-group', 'whatever title', [cmd])]):
-        with patch.object(logsetup.message_handler, 'ended_ok') as ended_ok_mock:
-            with patch.object(logsetup.message_handler._stderr_handler, 'stream', fake_stream):
-                main(['charmcraft', '--quiet', 'somecommand'])
+    with patch(
+        "charmcraft.main.COMMAND_GROUPS", [("test-group", "whatever title", [cmd])]
+    ):
+        with patch.object(logsetup.message_handler, "ended_ok") as ended_ok_mock:
+            with patch.object(
+                logsetup.message_handler._stderr_handler, "stream", fake_stream
+            ):
+                main(["charmcraft", "--quiet", "somecommand"])
 
     # get the logfile first line before removing it
     ended_ok_mock.assert_called_once_with()
     logged_to_file = pathlib.Path(logsetup.message_handler._log_filepath).read_text()
-    file_first_line = logged_to_file.split('\n')[0]
+    file_first_line = logged_to_file.split("\n")[0]
     logsetup.message_handler.ended_ok()
 
     # get the terminal first line
     captured = fake_stream.getvalue()
-    terminal_first_line = captured.split('\n')[0]
+    terminal_first_line = captured.split("\n")[0]
 
     expected = "Starting charmcraft version " + __version__
     assert expected in file_first_line
@@ -418,22 +461,26 @@ def test_initmsg_quiet():
 
 def test_initmsg_verbose():
     """In verbose mode, the init msg goes both to disk and terminal."""
-    cmd = create_command('somecommand')
+    cmd = create_command("somecommand")
     fake_stream = io.StringIO()
-    with patch('charmcraft.main.COMMAND_GROUPS', [('test-group', 'whatever title', [cmd])]):
-        with patch.object(logsetup.message_handler, 'ended_ok') as ended_ok_mock:
-            with patch.object(logsetup.message_handler._stderr_handler, 'stream', fake_stream):
-                main(['charmcraft', '--verbose', 'somecommand'])
+    with patch(
+        "charmcraft.main.COMMAND_GROUPS", [("test-group", "whatever title", [cmd])]
+    ):
+        with patch.object(logsetup.message_handler, "ended_ok") as ended_ok_mock:
+            with patch.object(
+                logsetup.message_handler._stderr_handler, "stream", fake_stream
+            ):
+                main(["charmcraft", "--verbose", "somecommand"])
 
     # get the logfile first line before removing it
     ended_ok_mock.assert_called_once_with()
     logged_to_file = pathlib.Path(logsetup.message_handler._log_filepath).read_text()
-    file_first_line = logged_to_file.split('\n')[0]
+    file_first_line = logged_to_file.split("\n")[0]
     logsetup.message_handler.ended_ok()
 
     # get the terminal first line
     captured = fake_stream.getvalue()
-    terminal_first_line = captured.split('\n')[0]
+    terminal_first_line = captured.split("\n")[0]
 
     expected = "Starting charmcraft version " + __version__
     assert expected in file_first_line
@@ -444,13 +491,17 @@ def test_commands():
     cmds = [cmd.name for _, _, cmds in COMMAND_GROUPS for cmd in cmds]
 
     env = os.environ.copy()
-    env_paths = [p for p in sys.path if 'env/lib/python' in p]
+    env_paths = [p for p in sys.path if "env/lib/python" in p]
     if env_paths:
-        if 'PYTHONPATH' in env:
-            env['PYTHONPATH'] += ':' + ':'.join(env_paths)
+        if "PYTHONPATH" in env:
+            env["PYTHONPATH"] += ":" + ":".join(env_paths)
         else:
-            env['PYTHONPATH'] = ':'.join(env_paths)
+            env["PYTHONPATH"] = ":".join(env_paths)
 
     for cmd in cmds:
-        subprocess.run([sys.executable, '-m', 'charmcraft', cmd, '-h'],
-                       check=True, env=env, stdout=subprocess.DEVNULL)
+        subprocess.run(
+            [sys.executable, "-m", "charmcraft", cmd, "-h"],
+            check=True,
+            env=env,
+            stdout=subprocess.DEVNULL,
+        )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -52,11 +52,13 @@ def test_make_executable_read_bits(tmp_path):
 
 def test_load_yaml_success(tmp_path):
     test_file = tmp_path / "testfile.yaml"
-    test_file.write_text("""
+    test_file.write_text(
+        """
         foo: 33
-    """)
+    """
+    )
     content = load_yaml(test_file)
-    assert content == {'foo': 33}
+    assert content == {"foo": 33}
 
 
 def test_load_yaml_no_file(tmp_path, caplog):
@@ -86,9 +88,11 @@ def test_load_yaml_corrupted_format(tmp_path, caplog):
     caplog.set_level(logging.ERROR, logger="charmcraft.commands")
 
     test_file = tmp_path / "testfile.yaml"
-    test_file.write_text("""
+    test_file.write_text(
+        """
         foo: [1, 2
-    """)
+    """
+    )
     content = load_yaml(test_file)
     assert content is None
 
@@ -101,9 +105,11 @@ def test_load_yaml_file_problem(tmp_path, caplog):
     caplog.set_level(logging.ERROR, logger="charmcraft.commands")
 
     test_file = tmp_path / "testfile.yaml"
-    test_file.write_text("""
+    test_file.write_text(
+        """
         foo: bar
-    """)
+    """
+    )
     test_file.chmod(0o000)
     content = load_yaml(test_file)
     assert content is None
@@ -115,53 +121,60 @@ def test_load_yaml_file_problem(tmp_path, caplog):
 
 # -- tests for the SingleOptionEnsurer helper class
 
+
 def test_singleoptionensurer_convert_ok():
     """Work fine with one call, convert as expected."""
     soe = SingleOptionEnsurer(int)
-    assert soe('33') == 33
+    assert soe("33") == 33
 
 
 def test_singleoptionensurer_too_many():
     """Raise an error after one ok call."""
     soe = SingleOptionEnsurer(int)
-    assert soe('33') == 33
+    assert soe("33") == 33
     with pytest.raises(ValueError) as cm:
-        soe('33')
+        soe("33")
     assert str(cm.value) == "the option can be specified only once"
 
 
 # -- tests for the ResourceOption helper class
 
+
 def test_resourceoption_convert_ok():
     """Convert as expected."""
     r = ResourceOption()("foo:13")
-    assert r.name == 'foo'
+    assert r.name == "foo"
     assert r.revision == 13
 
 
-@pytest.mark.parametrize('value', [
-    'foo15',  # no separation
-    'foo:',  # no revision
-    'foo:x3',  # no int
-    'foo:0',  # revision 0 is not allowed
-    'foo:-1',  # negative revisions are not allowed
-    ':15',  # no name
-    '  :15',  # no name, really!
-    'foo:bar:15',  # invalid name, anyway
-])
+@pytest.mark.parametrize(
+    "value",
+    [
+        "foo15",  # no separation
+        "foo:",  # no revision
+        "foo:x3",  # no int
+        "foo:0",  # revision 0 is not allowed
+        "foo:-1",  # negative revisions are not allowed
+        ":15",  # no name
+        "  :15",  # no name, really!
+        "foo:bar:15",  # invalid name, anyway
+    ],
+)
 def test_resourceoption_convert_error(value):
     """Error while converting."""
     with pytest.raises(ValueError) as cm:
         ResourceOption()(value)
     assert str(cm.value) == (
-        "the resource format must be <name>:<revision> (revision being a positive integer)")
+        "the resource format must be <name>:<revision> (revision being a positive integer)"
+    )
 
 
 # -- tests for the useful_filepath helper
 
+
 def test_usefulfilepath_pathlib(tmp_path):
     """Convert the string to Path."""
-    test_file = tmp_path / 'testfile.bin'
+    test_file = tmp_path / "testfile.bin"
     test_file.touch()
     path = useful_filepath(str(test_file))
     assert path == test_file
@@ -170,26 +183,26 @@ def test_usefulfilepath_pathlib(tmp_path):
 
 def test_usefulfilepath_home_expanded(tmp_path, monkeypatch):
     """Home-expand the indicated path."""
-    fake_home = tmp_path / 'homedir'
+    fake_home = tmp_path / "homedir"
     fake_home.mkdir()
-    test_file = fake_home / 'testfile.bin'
+    test_file = fake_home / "testfile.bin"
     test_file.touch()
 
-    monkeypatch.setitem(os.environ, 'HOME', str(fake_home))
-    path = useful_filepath('~/testfile.bin')
+    monkeypatch.setitem(os.environ, "HOME", str(fake_home))
+    path = useful_filepath("~/testfile.bin")
     assert path == test_file
 
 
 def test_usefulfilepath_missing():
     """The indicated path is not there."""
     with pytest.raises(CommandError) as cm:
-        useful_filepath('not_really_there.txt')
+        useful_filepath("not_really_there.txt")
     assert str(cm.value) == "Cannot access 'not_really_there.txt'."
 
 
 def test_usefulfilepath_inaccessible(tmp_path):
     """The indicated path is not readable."""
-    test_file = tmp_path / 'testfile.bin'
+    test_file = tmp_path / "testfile.bin"
     test_file.touch(mode=0o000)
     with pytest.raises(CommandError) as cm:
         useful_filepath(str(test_file))
@@ -205,12 +218,14 @@ def test_usefulfilepath_not_a_file(tmp_path):
 
 # -- tests for the OS platform getter
 
+
 def test_get_os_platform_linux(tmp_path):
     """Utilize an /etc/os-release file to determine platform."""
     # explicitly add commented and empty lines, for parser robustness
-    filepath = (tmp_path / "os-release")
-    filepath.write_text(dedent(
-        """
+    filepath = tmp_path / "os-release"
+    filepath.write_text(
+        dedent(
+            """
         # the following is an empty line
 
         NAME="Ubuntu"
@@ -231,9 +246,10 @@ def test_get_os_platform_linux(tmp_path):
         VERSION_CODENAME=focal
         UBUNTU_CODENAME=focal
         """
-    ))
-    with patch('platform.machine', return_value='x86_64'):
-        with patch('platform.system', return_value='Linux'):
+        )
+    )
+    with patch("platform.machine", return_value="x86_64"):
+        with patch("platform.system", return_value="Linux"):
             os_platform = get_os_platform(filepath)
     assert os_platform.system == "ubuntu"
     assert os_platform.release == "20.04"
@@ -243,9 +259,10 @@ def test_get_os_platform_linux(tmp_path):
 def test_get_os_platform_strict_snaps(tmp_path):
     """Utilize an /etc/os-release file to determine platform, core-20 values."""
     # explicitly add commented and empty lines, for parser robustness
-    filepath = (tmp_path / "os-release")
-    filepath.write_text(dedent(
-        """
+    filepath = tmp_path / "os-release"
+    filepath.write_text(
+        dedent(
+            """
         NAME="Ubuntu Core"
         VERSION="20"
         ID=ubuntu-core
@@ -254,49 +271,57 @@ def test_get_os_platform_strict_snaps(tmp_path):
         HOME_URL="https://snapcraft.io/"
         BUG_REPORT_URL="https://bugs.launchpad.net/snappy/"
         """
-    ))
-    with patch('platform.machine', return_value='x86_64'):
-        with patch('platform.system', return_value='Linux'):
+        )
+    )
+    with patch("platform.machine", return_value="x86_64"):
+        with patch("platform.system", return_value="Linux"):
             os_platform = get_os_platform(filepath)
     assert os_platform.system == "ubuntu-core"
     assert os_platform.release == "20"
     assert os_platform.machine == "x86_64"
 
 
-@pytest.mark.parametrize('name', [
-    ('"foo bar"', 'foo bar'),  # what's normally found
-    ('foo bar', 'foo bar'),  # no quotes
-    ('"foo " bar"', 'foo " bar'),  # quotes in the middle
-    ('foo bar"', 'foo bar"'),  # unbalanced quotes (no really enclosing)
-    ('"foo bar', '"foo bar'),  # unbalanced quotes (no really enclosing)
-    ("'foo bar'", 'foo bar'),  # enclosing with single quote
-    ("'foo ' bar'", "foo ' bar"),  # single quote in the middle
-    ("foo bar'", "foo bar'"),  # unbalanced single quotes (no really enclosing)
-    ("'foo bar", "'foo bar"),  # unbalanced single quotes (no really enclosing)
-    ("'foo bar\"", "'foo bar\""),  # unbalanced mixed quotes
-    ("\"foo bar'", "\"foo bar'"),  # unbalanced mixed quotes
-])
+@pytest.mark.parametrize(
+    "name",
+    [
+        ('"foo bar"', "foo bar"),  # what's normally found
+        ("foo bar", "foo bar"),  # no quotes
+        ('"foo " bar"', 'foo " bar'),  # quotes in the middle
+        ('foo bar"', 'foo bar"'),  # unbalanced quotes (no really enclosing)
+        ('"foo bar', '"foo bar'),  # unbalanced quotes (no really enclosing)
+        ("'foo bar'", "foo bar"),  # enclosing with single quote
+        ("'foo ' bar'", "foo ' bar"),  # single quote in the middle
+        ("foo bar'", "foo bar'"),  # unbalanced single quotes (no really enclosing)
+        ("'foo bar", "'foo bar"),  # unbalanced single quotes (no really enclosing)
+        ("'foo bar\"", "'foo bar\""),  # unbalanced mixed quotes
+        ("\"foo bar'", "\"foo bar'"),  # unbalanced mixed quotes
+    ],
+)
 def test_get_os_platform_alternative_formats(name, tmp_path):
     """Support different ways of building the string."""
     source, result = name
-    filepath = (tmp_path / "os-release")
-    filepath.write_text(dedent(
-        """
+    filepath = tmp_path / "os-release"
+    filepath.write_text(
+        dedent(
+            """
         ID={}
         VERSION_ID="20.04"
-        """.format(source)
-    ))
+        """.format(
+                source
+            )
+        )
+    )
     # need to patch this to "Linux" so actually uses /etc/os-release...
-    with patch('platform.system', return_value='Linux'):
+    with patch("platform.system", return_value="Linux"):
         os_platform = get_os_platform(filepath)
     assert os_platform.system == result
 
 
 def test_get_os_platform_windows():
     """Get platform from a patched Windows machine."""
-    with patch('platform.system', return_value='Windows'):
-        with patch('platform.release', return_value='10'):
-            with patch('platform.machine', return_value='AMD64'):
+    with patch("platform.system", return_value="Windows"):
+        with patch("platform.release", return_value="10"):
+            with patch("platform.machine", return_value="AMD64"):
                 os_platform = get_os_platform()
     assert os_platform.system == "Windows"
     assert os_platform.release == "10"
@@ -305,23 +330,24 @@ def test_get_os_platform_windows():
 
 # -- tests for the manifest creation
 
+
 def test_manifest_simple_ok(tmp_path):
     """Simple construct."""
     tstamp = datetime.datetime(2020, 2, 1, 15, 40, 33)
-    os_platform = OSPlatform(system='SuperUbuntu', release='40.10', machine='SomeRISC')
-    with patch('charmcraft.utils.get_os_platform', return_value=os_platform):
+    os_platform = OSPlatform(system="SuperUbuntu", release="40.10", machine="SomeRISC")
+    with patch("charmcraft.utils.get_os_platform", return_value=os_platform):
         result_filepath = create_manifest(tmp_path, tstamp)
 
-    assert result_filepath == tmp_path / 'manifest.yaml'
+    assert result_filepath == tmp_path / "manifest.yaml"
     saved = yaml.safe_load(result_filepath.read_text())
     expected = {
-        'charmcraft-started-at': '2020-02-01T15:40:33Z',
-        'charmcraft-version': __version__,
-        'bases': [
+        "charmcraft-started-at": "2020-02-01T15:40:33Z",
+        "charmcraft-version": __version__,
+        "bases": [
             {
-                'name': 'superubuntu',
-                'channel': '40.10',
-                'architectures': ['SomeRISC'],
+                "name": "superubuntu",
+                "channel": "40.10",
+                "architectures": ["SomeRISC"],
             }
         ],
     }
@@ -330,31 +356,32 @@ def test_manifest_simple_ok(tmp_path):
 
 def test_manifest_architecture_translated(tmp_path, monkeypatch):
     """All known architectures must be translated."""
-    monkeypatch.setitem(ARCH_TRANSLATIONS, 'weird_arch', 'nice_arch')
-    os_platform = OSPlatform(system='Ubuntu', release='40.10', machine='weird_arch')
-    with patch('charmcraft.utils.get_os_platform', return_value=os_platform):
+    monkeypatch.setitem(ARCH_TRANSLATIONS, "weird_arch", "nice_arch")
+    os_platform = OSPlatform(system="Ubuntu", release="40.10", machine="weird_arch")
+    with patch("charmcraft.utils.get_os_platform", return_value=os_platform):
         result_filepath = create_manifest(tmp_path, datetime.datetime.now())
 
     saved = yaml.safe_load(result_filepath.read_text())
-    assert saved['bases'][0]['architectures'] == ['nice_arch']
+    assert saved["bases"][0]["architectures"] == ["nice_arch"]
 
 
 def test_manifest_fields_from_strict_snap(tmp_path, monkeypatch):
     """Fields found in a strict snap must be translated."""
-    os_platform = OSPlatform(system='ubuntu-core', release='20', machine='amd64')
-    with patch('charmcraft.utils.get_os_platform', return_value=os_platform):
+    os_platform = OSPlatform(system="ubuntu-core", release="20", machine="amd64")
+    with patch("charmcraft.utils.get_os_platform", return_value=os_platform):
         result_filepath = create_manifest(tmp_path, datetime.datetime.now())
 
     saved = yaml.safe_load(result_filepath.read_text())
-    base = saved['bases'][0]
-    assert base['name'] == 'ubuntu'
-    assert base['channel'] == '20.04'
+    base = saved["bases"][0]
+    assert base["name"] == "ubuntu"
+    assert base["channel"] == "20.04"
 
 
 def test_manifest_dont_overwrite(tmp_path):
     """Don't overwrite the already-existing file."""
-    (tmp_path / 'manifest.yaml').touch()
+    (tmp_path / "manifest.yaml").touch()
     with pytest.raises(CommandError) as cm:
         create_manifest(tmp_path, datetime.datetime.now())
     assert str(cm.value) == (
-        "Cannot write the manifest as there is already a 'manifest.yaml' in disk.")
+        "Cannot write the manifest as there is already a 'manifest.yaml' in disk."
+    )


### PR DESCRIPTION
- Add test case to check formatting.

- Add a couple of ignores to flake8 that conflict with black, including
  E203 and W503. For further reading, the rationale is provided @
  https://black.readthedocs.io/en/stable/the_black_code_style.html

They also recommend to disable E501 (line-too-long), but for this PR
I simply bumped the minimum required line length after using black. We
need to revisit our approach if we want to be stricter than that.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>