### PR TITLE
config: migrate to use pydantic BaseModel

### DIFF
--- a/charmcraft/commands/pack.py
+++ b/charmcraft/commands/pack.py
@@ -49,10 +49,12 @@ def get_paths_to_include(config):
         allpaths.add(fpath)
 
     # the extra files (relative paths)
-    for spec in config.parts:
-        fpaths = sorted(fpath for fpath in dirpath.glob(spec) if fpath.is_file())
-        logger.debug("Including per prime config %r: %s.", spec, fpaths)
-        allpaths.update(fpaths)
+    bundle = config.parts.get("bundle")
+    if bundle is not None:
+        for spec in bundle.prime:
+            fpaths = sorted(fpath for fpath in dirpath.glob(spec) if fpath.is_file())
+            logger.debug("Including per prime config %r: %s.", spec, fpaths)
+            allpaths.update(fpaths)
 
     return sorted(allpaths)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,20 +55,15 @@ def monkeypatch(monkeypatch):
 def config(tmp_path):
     """Provide a config class with an extra set method for the test to change it."""
 
-    class TestConfig(config_module.Config):
+    class TestConfig(config_module.Config, frozen=False):
         """The Config, but with a method to set test values."""
 
-        def set(self, **kwargs):
+        def set(self, prime=None, **kwargs):
             # prime is special, so we don't need to write all this structure in all tests
-            prime = kwargs.pop("prime", None)
             if prime is not None:
-                kwargs["parts"] = config_module.BasicPrime.from_dict(
-                    {
-                        "bundle": {
-                            "prime": prime,
-                        }
-                    }
-                )
+                self.parts.__root__["bundle"] = config_module.Part(prime=prime)
+            else:
+                self.parts = config_module.Parts()
 
             # the rest is direct
             for k, v in kwargs.items():


### PR DESCRIPTION
- Drop json schema in favor of BaseModel's validations

- Add unmarshal() interface to Config to handle unmarshaling the
  yaml object.

- Since `type` is not allowed to be None, set to "no-charmcraft-yaml"
when there is no YAML.

- Add a minimal Parts() and Part() implementation to allow for
  parts.bundle.prime definition.  This should ultimately be replaced
  with a reference to the implementation in craft-parts.

- Minor logging message changes:

  - must be a full URL -> must be a fully qualified URL

  - must be a valid relative URL -> must be a valid relative path

- Errors are now output as a list, with fields represented with
  python-like notation.  Lists items are indexed with [n] and
  dictionary items are reduced to the key. For example:

```
Bad charmcraft.yaml content:
- field: <broken-field>
  reason: <some reason>
- field: <parts.bundle>
  reason: <some reason>
- field: <broken.field_list[3]>
  reason: <some reason>
- ...
```

...where:

- "bundle" is the object key under parts

- "field_list[3]" is indicating the third element in field_list

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>