### PR TITLE
New config, and deprecation infrastructure

### DIFF
--- a/charmcraft/deprecations.py
+++ b/charmcraft/deprecations.py
@@ -29,16 +29,26 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+# the message to show for each deprecation ID (this needs to be in sync with the
+# documentation)
 _DEPRECATION_MESSAGES = {
     "dn01": "Configuration keywords are now separated using dashes.",
 }
 
+# the URL to point to the deprecation entry in the documentation
 _DEPRECATION_URL_FMT = "https://discourse.charmhub.io/t/4652#heading--{deprecation_id}"
+
+# already-notified deprecations will be stored here to not log them twice
+_ALREADY_NOTIFIED = set()
 
 
 def notify_deprecation(deprecation_id):
     """Present proper messages to the user for the indicated deprecation id."""
+    if deprecation_id in _ALREADY_NOTIFIED:
+        return
+
     message = _DEPRECATION_MESSAGES[deprecation_id]
     logger.warning("DEPRECATED: %s", message)
     url = _DEPRECATION_URL_FMT.format(deprecation_id=deprecation_id)
     logger.warning("See %s for more information.", url)
+    _ALREADY_NOTIFIED.add(deprecation_id)

--- a/charmcraft/deprecations.py
+++ b/charmcraft/deprecations.py
@@ -1,0 +1,44 @@
+# Copyright 2021 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For further info, check https://github.com/canonical/charmcraft
+
+"""Handle surfacing deprecation notices.
+
+When a new deprecation has occurred, write a Deprecation Notice for it here
+(assigning it the next DN<nn> ID):
+
+    https://discourse.charmhub.io/t/4652
+
+Then add that ID along with the deprecation title in the list below.
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+_DEPRECATION_MESSAGES = {
+    "dn01": "Configuration keywords are now separated using dashes.",
+}
+
+_DEPRECATION_URL_FMT = "https://discourse.charmhub.io/t/4652#heading--{deprecation_id}"
+
+
+def notify_deprecation(deprecation_id):
+    """Present proper messages to the user for the indicated deprecation id."""
+    message = _DEPRECATION_MESSAGES[deprecation_id]
+    logger.warning("DEPRECATED: %s", message)
+    url = _DEPRECATION_URL_FMT.format(deprecation_id=deprecation_id)
+    logger.warning("See %s for more information.", url)

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -1,0 +1,53 @@
+# Copyright 2021 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For further info, check https://github.com/canonical/charmcraft
+
+import logging
+import re
+
+import pytest
+
+from charmcraft import deprecations
+from charmcraft.deprecations import notify_deprecation, _DEPRECATION_MESSAGES
+
+
+def test_notice_ok(monkeypatch, caplog):
+    """Present proper messages to the user."""
+    caplog.set_level(logging.WARNING, logger="charmcraft")
+
+    monkeypatch.setitem(_DEPRECATION_MESSAGES, "dn666", "Test message for the user.")
+    monkeypatch.setattr(
+        deprecations, "_DEPRECATION_URL_FMT", "http://docs.com/#{deprecation_id}"
+    )
+
+    notify_deprecation("dn666")
+    expected = [
+        "DEPRECATED: Test message for the user.",
+        "See http://docs.com/#dn666 for more information.",
+    ]
+    assert expected == [rec.message for rec in caplog.records]
+
+
+@pytest.mark.parametrize("deprecation_id", _DEPRECATION_MESSAGES.keys())
+def test_check_real_deprecation_ids(deprecation_id):
+    """Verify all the real IDs used have the correct form."""
+    assert re.match(r"dn\d\d", deprecation_id)
+
+
+@pytest.mark.parametrize("message", _DEPRECATION_MESSAGES.values())
+def test_check_real_deprecation_messages(message):
+    """Verify all the real messages conform some rules."""
+    assert message[0].isupper()
+    assert message[-1] == "."


### PR DESCRIPTION
Added `registry-url` to the configuration, in preparation for the resources refactor.

Also changed the other `charmhub` keys to use dash, instead of underscore. But to do that change, I included some deprecation infrastructure.

I thought about preparing a branch with the deprecation infra alone, but I took the opportunity of being able to include it here (not too many lines) as it shows also how that infra is used.