### PR TITLE
Refactor how OCIRegistry and ImageHandler are used (CRAFT-53)

### DIFF
--- a/charmcraft/commands/store/__init__.py
+++ b/charmcraft/commands/store/__init__.py
@@ -41,7 +41,7 @@ from charmcraft.utils import (
 )
 
 from .store import Store
-from .registry import ImageHandler
+from .registry import ImageHandler, OCIRegistry
 
 logger = logging.getLogger("charmcraft.commands.store")
 
@@ -1399,7 +1399,11 @@ class UploadResourceCommand(BaseCommand):
             logger.debug(
                 "Uploading resource from image %s at Dockerhub", parsed_args.image
             )
-            ih = ImageHandler(parsed_args.image.organization, parsed_args.image.name)
+            full_image_name = "/".join(
+                (parsed_args.image.organization, parsed_args.image.name)
+            )
+            registry = OCIRegistry("https://registry.hub.docker.com", full_image_name)
+            ih = ImageHandler(registry)
             final_resource_url = ih.get_destination_url(parsed_args.image.reference)
             logger.debug("Resource URL: %s", final_resource_url)
             resource_type = "oci-image"

--- a/tests/commands/test_store_commands.py
+++ b/tests/commands/test_store_commands.py
@@ -43,6 +43,7 @@ from charmcraft.commands.store import (
     LoginCommand,
     LogoutCommand,
     OCIImageSpec,
+    OCIRegistry,
     PublishLibCommand,
     RegisterBundleNameCommand,
     RegisterCharmNameCommand,
@@ -2843,8 +2844,9 @@ def test_uploadresource_image_call_ok(caplog, store_mock, config, tmp_path):
         UploadResourceCommand("group", config).run(args)
 
     # validate how ImageHandler was used
+    registry = OCIRegistry("https://registry.hub.docker.com", "test-orga/test-image")
     assert im_class_mock.mock_calls == [
-        call("test-orga", "test-image"),
+        call(registry),
         call().get_destination_url("test-tag"),
     ]
     assert im_mock.mock_calls == [call.get_destination_url("test-tag")]

--- a/tests/commands/test_store_registry.py
+++ b/tests/commands/test_store_registry.py
@@ -163,6 +163,25 @@ def test_auth_with_credentials(caplog, responses):
     assert [expected] == [rec.message for rec in caplog.records]
 
 
+def test_auth_with_just_username(caplog, responses):
+    """Authenticate passing credentials."""
+    responses.add(
+        responses.GET,
+        "https://auth.fakereg.com?service=test-service&scope=test-scope",
+        json={"token": "test-token"},
+    )
+
+    ocireg = OCIRegistry("https://fakereg.com", "test-image", username="test-user")
+    auth_info = dict(
+        realm="https://auth.fakereg.com", service="test-service", scope="test-scope"
+    )
+    token = ocireg._authenticate(auth_info)
+    assert token == "test-token"
+    sent_auth_header = responses.calls[0].request.headers.get("Authorization")
+    expected_encoded = base64.b64encode(b"test-user:")
+    assert sent_auth_header == "Basic " + expected_encoded.decode("ascii")
+
+
 def test_hit_simple_initial_auth_ok(caplog, responses):
     """Simple GET with auth working at once."""
     caplog.set_level(logging.DEBUG, logger="charmcraft")


### PR DESCRIPTION
This is to align the classes' signatures for the big refactor ahead.

Specifically, in OCIRegistry:

- receive just the image name (whatever it could be) and not the two "orga" and "name" parameters which were too specific for image names with only two "tokens"

- also receive username and password, and store the ready-to-use encoded credentials

- changed slightly a couple of url-massaging functions to reflect the fact that the server has now the schema in it (not faking it anymore, more robust)


And in ImageHandler:

- receive now just the registry and use it

- it will hold only one registry now, so now need for the "dst_" prefix


Also in the upload-command command, changed from passing the components to just pass the registry itself.

Note I minimized the changes in the tests; some of those may be simplified further, but they will disappear in the refactor, so no need for the noise now.
