### PR TITLE
Tests improvements to minimize future merges from resources draft branch

### DIFF
--- a/tests/commands/test_store_registry.py
+++ b/tests/commands/test_store_registry.py
@@ -337,6 +337,7 @@ def test_ociregistry_is_manifest_uploaded():
     url = "https://fakereg.com/v2/test-image/manifests/test-reference"
     mock_verifier.assert_called_with(url)
 
+
 def test_ociregistry_is_blob_uploaded():
     """Check the simple call with correct path to the generic verifier."""
     ocireg = OCIRegistry("https://fakereg.com", "test-image")
@@ -345,6 +346,8 @@ def test_ociregistry_is_blob_uploaded():
         result = ocireg.is_blob_already_uploaded("test-reference")
     assert result == "whatever"
     url = "https://fakereg.com/v2/test-image/blobs/test-reference"
+    mock_verifier.assert_called_with(url)
+
 
 def test_ociregistry_is_item_uploaded_simple_yes(responses):
     """Simple case for the item already uploaded."""

--- a/tests/commands/test_store_registry.py
+++ b/tests/commands/test_store_registry.py
@@ -218,7 +218,7 @@ def test_hit_simple_re_auth_ok(responses):
     headers = {
         "Www-Authenticate": (
             'Bearer realm="https://auth.fakereg.com/token",'
-            'service="fakereg.com",scope="repository:library/stuff:pull"'
+            'service="https://fakereg.com",scope="repository:library/stuff:pull"'
         )
     }
     responses.add(
@@ -235,7 +235,7 @@ def test_hit_simple_re_auth_ok(responses):
         {
             "realm": "https://auth.fakereg.com/token",
             "scope": "repository:library/stuff:pull",
-            "service": "fakereg.com",
+            "service": "https://fakereg.com",
         }
     )
 
@@ -324,21 +324,24 @@ def test_get_fully_qualified_url():
     assert url == "fakereg.com/test-orga/test-image@sha256:thehash"
 
 
-def test_is_manifest_uploaded():
+# -- tests for some OCIRegistry helpers
+
+
+def test_ociregistry_is_manifest_uploaded():
     """Check the simple call with correct path to the generic verifier."""
-    ocireg = OCIRegistry("https://fakereg.com", "test-orga/test-image")
+    ocireg = OCIRegistry("https://fakereg.com", "test-image")
     with patch.object(ocireg, "_is_item_already_uploaded") as mock_verifier:
         mock_verifier.return_value = "whatever"
         result = ocireg.is_manifest_already_uploaded("test-reference")
     assert result == "whatever"
-    url = "https://fakereg.com/v2/test-orga/test-image/manifests/test-reference"
+    url = "https://fakereg.com/v2/test-image/manifests/test-reference"
     mock_verifier.assert_called_with(url)
 
 
-def test_is_item_uploaded_simple_yes(responses):
+def test_ociregistry_is_item_uploaded_simple_yes(responses):
     """Simple case for the item already uploaded."""
-    ocireg = OCIRegistry("http://fakereg.com/", "test-orga/test-image")
-    url = "http://fakereg.com/v2/test-orga/test-image/stuff/some-reference"
+    ocireg = OCIRegistry("http://fakereg.com/", "test-image")
+    url = "http://fakereg.com/v2/test-image/stuff/some-reference"
     responses.add(responses.HEAD, url)
 
     # try it
@@ -346,10 +349,10 @@ def test_is_item_uploaded_simple_yes(responses):
     assert result is True
 
 
-def test_is_item_uploaded_simple_no(responses):
+def test_ociregistry_is_item_uploaded_simple_no(responses):
     """Simple case for the item NOT already uploaded."""
-    ocireg = OCIRegistry("http://fakereg.com/", "test-orga/test-image")
-    url = "http://fakereg.com/v2/test-orga/test-image/stuff/some-reference"
+    ocireg = OCIRegistry("http://fakereg.com/", "test-image")
+    url = "http://fakereg.com/v2/test-image/stuff/some-reference"
     responses.add(responses.HEAD, url, status=404)
 
     # try it
@@ -358,11 +361,11 @@ def test_is_item_uploaded_simple_no(responses):
 
 
 @pytest.mark.parametrize("redir_status", [302, 307])
-def test_is_item_uploaded_redirect(responses, redir_status):
+def test_ociregistry_is_item_uploaded_redirect(responses, redir_status):
     """The verification is redirected to somewhere else."""
-    ocireg = OCIRegistry("http://fakereg.com/", "test-orga/test-image")
-    url1 = "http://fakereg.com/v2/test-orga/test-image/stuff/some-reference"
-    url2 = "http://fakereg.com/real-check/test-orga/test-image/stuff/some-reference"
+    ocireg = OCIRegistry("http://fakereg.com/", "test-image")
+    url1 = "http://fakereg.com/v2/test-image/stuff/some-reference"
+    url2 = "http://fakereg.com/real-check/test-image/stuff/some-reference"
     responses.add(responses.HEAD, url1, status=redir_status, headers={"Location": url2})
     responses.add(responses.HEAD, url2, status=200)
 
@@ -371,12 +374,12 @@ def test_is_item_uploaded_redirect(responses, redir_status):
     assert result is True
 
 
-def test_is_item_uploaded_strange_response(responses, caplog):
+def test_ociregistry_is_item_uploaded_strange_response(responses, caplog):
     """Unexpected response."""
     caplog.set_level(logging.DEBUG, logger="charmcraft")
 
-    ocireg = OCIRegistry("http://fakereg.com/", "test-orga/test-image")
-    url = "http://fakereg.com/v2/test-orga/test-image/stuff/some-reference"
+    ocireg = OCIRegistry("http://fakereg.com/", "test-image")
+    url = "http://fakereg.com/v2/test-image/stuff/some-reference"
     responses.add(responses.HEAD, url, status=400, headers={"foo": "bar"})
 
     # try it
@@ -384,7 +387,7 @@ def test_is_item_uploaded_strange_response(responses, caplog):
     assert result is False
     expected = (
         "Bad response when checking for uploaded "
-        "'http://fakereg.com/v2/test-orga/test-image/stuff/some-reference': 400 "
+        "'http://fakereg.com/v2/test-image/stuff/some-reference': 400 "
         "(headers={'Content-Type': 'text/plain', 'foo': 'bar'})"
     )
     assert expected in [rec.message for rec in caplog.records]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -97,7 +97,7 @@ def test_dispatcher_config_needed_ok(tmp_path):
     dispatcher.run()
 
 
-def test_dispatcher_config_needed_problem():
+def test_dispatcher_config_needed_problem(tmp_path):
     """Command needs a config, which is not there."""
 
     class MyCommand(BaseCommand):
@@ -109,7 +109,7 @@ def test_dispatcher_config_needed_problem():
             pass
 
     groups = [("test-group", "title", [MyCommand])]
-    dispatcher = Dispatcher(["cmdname"], groups)
+    dispatcher = Dispatcher(["cmdname", "--project-dir", tmp_path], groups)
     with pytest.raises(CommandError) as err:
         dispatcher.run()
     assert str(err.value) == (


### PR DESCRIPTION
Some small changes, everything just in tests, no affected functionality:

- simplified some OCIRegistry calls, the "test-orga" makes no more sense (left it as-is in other tests that will disappear in the future)

- improved some test names

- added schema to "service" key in auth tests, it's more real now

- improved a test in test_main.py to isolate it from the running environment
