### PR TITLE
commands/build: charm file name format support for bases (CRAFT-66)

### DIFF
--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -81,7 +81,7 @@ def format_charm_file_name(
     :param bases_config: Bases configuration for charm.  None will use legacy
         format that will be removed shortly.
 
-    :returns: File name string, including .zip extension.
+    :returns: File name string, including .charm extension.
     """
     # TODO: Patterson 2021-06-14 Temporary legacy support prior to bases configuration.
     if bases_config is None:

--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -23,7 +23,7 @@ import pathlib
 import shutil
 import subprocess
 import zipfile
-from typing import List, Optional
+from typing import Optional
 
 import yaml
 
@@ -55,16 +55,9 @@ MANDATORY_HOOK_NAMES = {"install", "start", "upgrade-charm"}
 HOOKS_DIR = "hooks"
 
 
-def _format_architectures(architectures: List[str]) -> str:
-    """Formulate charm string for architectures list section."""
-    return "-".join(architectures)
-
-
 def _format_run_on_base(base: Base) -> str:
     """Formulate charm string for base section."""
-    return "-".join(
-        [base.name, base.channel, _format_architectures(base.architectures)]
-    )
+    return "-".join([base.name, base.channel, *base.architectures])
 
 
 def _format_bases_config(bases_config: BasesConfiguration) -> str:

--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -66,7 +66,7 @@ def _format_bases_config(bases_config: BasesConfiguration) -> str:
 
 
 def format_charm_file_name(
-    *, charm_name: str, bases_config: Optional[BasesConfiguration] = None
+    charm_name: str, bases_config: Optional[BasesConfiguration] = None
 ) -> str:
     """Formulate charm file name.
 
@@ -320,7 +320,7 @@ class Builder:
             metadata = yaml.safe_load(fh)
 
         logger.debug("Creating the package itself")
-        zipname = format_charm_file_name(charm_name=metadata["name"])
+        zipname = format_charm_file_name(metadata["name"], None)
         zipfh = zipfile.ZipFile(zipname, "w", zipfile.ZIP_DEFLATED)
         for dirpath, dirnames, filenames in os.walk(self.buildpath, followlinks=True):
             dirpath = pathlib.Path(dirpath)

--- a/tests/commands/test_build.py
+++ b/tests/commands/test_build.py
@@ -1365,10 +1365,7 @@ def test_relativise_different_parents_deep():
 
 def test_format_charm_file_name_legacy():
     """Basic entry."""
-    assert (
-        format_charm_file_name(charm_name="charm-name", bases_config=None)
-        == "charm-name.charm"
-    )
+    assert format_charm_file_name("charm-name", None) == "charm-name.charm"
 
 
 def test_format_charm_file_name_basic():
@@ -1383,7 +1380,7 @@ def test_format_charm_file_name_basic():
     )
 
     assert (
-        format_charm_file_name(charm_name="charm-name", bases_config=bases_config)
+        format_charm_file_name("charm-name", bases_config)
         == "charm-name_xname-xchannel-xarch1.charm"
     )
 
@@ -1404,7 +1401,7 @@ def test_format_charm_file_name_multi_arch():
     )
 
     assert (
-        format_charm_file_name(charm_name="charm-name", bases_config=bases_config)
+        format_charm_file_name("charm-name", bases_config)
         == "charm-name_xname-xchannel-xarch1-xarch2-xarch3.charm"
     )
 
@@ -1426,6 +1423,6 @@ def test_format_charm_file_name_multi_run_on():
     )
 
     assert (
-        format_charm_file_name(charm_name="charm-name", bases_config=bases_config)
+        format_charm_file_name("charm-name", bases_config)
         == "charm-name_x1name-x1channel-x1arch_x2name-x2channel-x2arch1-x2arch2.charm"
     )

--- a/tests/commands/test_build.py
+++ b/tests/commands/test_build.py
@@ -29,6 +29,7 @@ from unittest.mock import patch, call
 import pytest
 import yaml
 
+from charmcraft.config import Base, BasesConfiguration
 from charmcraft.cmdbase import CommandError
 from charmcraft.commands.build import (
     BUILD_DIRNAME,
@@ -38,6 +39,7 @@ from charmcraft.commands.build import (
     DISPATCH_FILENAME,
     VENV_DIRNAME,
     Validator,
+    format_charm_file_name,
     polite_exec,
     relativise,
 )
@@ -1359,3 +1361,71 @@ def test_relativise_different_parents_deep():
     dst = pathlib.Path("/tmp/foo/baz1/baz2/baz3/dst.txt")
     rel = relativise(src, dst)
     assert rel == pathlib.Path("../../baz1/baz2/baz3/dst.txt")
+
+
+def test_format_charm_file_name_legacy():
+    """Basic entry."""
+    assert (
+        format_charm_file_name(charm_name="charm-name", bases_config=None)
+        == "charm-name.charm"
+    )
+
+
+def test_format_charm_file_name_basic():
+    """Basic entry."""
+    bases_config = BasesConfiguration(
+        **{
+            "build-on": [],
+            "run-on": [
+                Base(name="xname", channel="xchannel", architectures=["xarch1"])
+            ],
+        }
+    )
+
+    assert (
+        format_charm_file_name(charm_name="charm-name", bases_config=bases_config)
+        == "charm-name_xname-xchannel-xarch1.charm"
+    )
+
+
+def test_format_charm_file_name_multi_arch():
+    """Multiple architectures."""
+    bases_config = BasesConfiguration(
+        **{
+            "build-on": [],
+            "run-on": [
+                Base(
+                    name="xname",
+                    channel="xchannel",
+                    architectures=["xarch1", "xarch2", "xarch3"],
+                )
+            ],
+        }
+    )
+
+    assert (
+        format_charm_file_name(charm_name="charm-name", bases_config=bases_config)
+        == "charm-name_xname-xchannel-xarch1-xarch2-xarch3.charm"
+    )
+
+
+def test_format_charm_file_name_multi_run_on():
+    """Multiple run-on entries."""
+    bases_config = BasesConfiguration(
+        **{
+            "build-on": [],
+            "run-on": [
+                Base(name="x1name", channel="x1channel", architectures=["x1arch"]),
+                Base(
+                    name="x2name",
+                    channel="x2channel",
+                    architectures=["x2arch1", "x2arch2"],
+                ),
+            ],
+        }
+    )
+
+    assert (
+        format_charm_file_name(charm_name="charm-name", bases_config=bases_config)
+        == "charm-name_x1name-x1channel-x1arch_x2name-x2channel-x2arch1-x2arch2.charm"
+    )


### PR DESCRIPTION
Maintain current format as "legacy" until we have the (default) bases
configuration available in upcoming PRs. Note that only the legacy
path is utilized at runtime, with tests added for bases configuration
support.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>