### PR TITLE
manifest: add bases support to create_manifest() (CRAFT-63)

### DIFF
--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -28,7 +28,8 @@ import yaml
 
 from charmcraft.cmdbase import BaseCommand, CommandError
 from charmcraft.jujuignore import JujuIgnore, default_juju_ignore
-from charmcraft.utils import make_executable, create_manifest
+from charmcraft.manifest import create_manifest
+from charmcraft.utils import make_executable
 
 logger = logging.getLogger(__name__)
 

--- a/charmcraft/commands/pack.py
+++ b/charmcraft/commands/pack.py
@@ -22,9 +22,9 @@ from argparse import Namespace
 
 from charmcraft.cmdbase import BaseCommand, CommandError
 from charmcraft.commands import build
+from charmcraft.manifest import create_manifest
 from charmcraft.utils import (
     SingleOptionEnsurer,
-    create_manifest,
     load_yaml,
     useful_filepath,
 )

--- a/charmcraft/manifest.py
+++ b/charmcraft/manifest.py
@@ -64,7 +64,14 @@ def create_manifest(
             }
         ]
     else:
-        bases = [r.dict() for r in bases_config.run_on]
+        bases = [
+            {
+                "name": r.name,
+                "channel": r.channel,
+                "architectures": r.architectures,
+            }
+            for r in bases_config.run_on
+        ]
 
     content = {
         "charmcraft-version": __version__,

--- a/charmcraft/manifest.py
+++ b/charmcraft/manifest.py
@@ -1,0 +1,80 @@
+# Copyright 2020-2021 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For further info, check https://github.com/canonical/charmcraft
+
+"""Charmcraft manifest.yaml related functionality."""
+
+import datetime
+import logging
+import pathlib
+from typing import Optional
+
+import yaml
+
+from charmcraft import __version__, config, utils
+from charmcraft.cmdbase import CommandError
+
+logger = logging.getLogger(__name__)
+
+
+def create_manifest(
+    basedir: pathlib.Path,
+    started_at: datetime.datetime,
+    bases_config: Optional[config.BasesConfiguration] = None,
+):
+    """Create manifest.yaml in basedir for given base configuration.
+
+    :param basedir: Directory to create Charm in.
+    :param started_at: Build start time.
+    :param bases_config: Relevant bases configuration.
+
+    :returns: Path to created manifest.yaml.
+    """
+    if bases_config is None:
+        os_platform = utils.get_os_platform()
+
+        # XXX Facundo 2021-03-29: the architectures list will be provided by the caller when
+        # we integrate lifecycle lib in future branches
+        architectures = [utils.get_host_architecture()]
+
+        # XXX Facundo 2021-04-19: these are temporary translations until charmcraft
+        # changes to be a "classic" snap
+        name_translation = {"ubuntu-core": "ubuntu"}
+        channel_translation = {"20": "20.04"}
+        name = os_platform.system.lower()
+        name = name_translation.get(name, name)
+        channel = channel_translation.get(os_platform.release, os_platform.release)
+        bases = [
+            {
+                "name": name,
+                "channel": channel,
+                "architectures": architectures,
+            }
+        ]
+    else:
+        bases = [r.dict() for r in bases_config.run_on]
+
+    content = {
+        "charmcraft-version": __version__,
+        "charmcraft-started-at": started_at.isoformat() + "Z",
+        "bases": bases,
+    }
+    filepath = basedir / "manifest.yaml"
+    if filepath.exists():
+        raise CommandError(
+            "Cannot write the manifest as there is already a 'manifest.yaml' in disk."
+        )
+    filepath.write_text(yaml.dump(content))
+    return filepath

--- a/charmcraft/manifest.py
+++ b/charmcraft/manifest.py
@@ -49,13 +49,8 @@ def create_manifest(
         # we integrate lifecycle lib in future branches
         architectures = [utils.get_host_architecture()]
 
-        # XXX Facundo 2021-04-19: these are temporary translations until charmcraft
-        # changes to be a "classic" snap
-        name_translation = {"ubuntu-core": "ubuntu"}
-        channel_translation = {"20": "20.04"}
         name = os_platform.system.lower()
-        name = name_translation.get(name, name)
-        channel = channel_translation.get(os_platform.release, os_platform.release)
+        channel = os_platform.release
         bases = [
             {
                 "name": name,

--- a/charmcraft/utils.py
+++ b/charmcraft/utils.py
@@ -27,7 +27,6 @@ import attr
 import yaml
 from jinja2 import Environment, PackageLoader, StrictUndefined
 
-from charmcraft import __version__
 from charmcraft.cmdbase import CommandError
 
 logger = logging.getLogger("charmcraft.commands")
@@ -186,42 +185,3 @@ def get_host_architecture():
     """Get host architecture in deb format suitable for base definition."""
     os_platform = get_os_platform()
     return ARCH_TRANSLATIONS.get(os_platform.machine, os_platform.machine)
-
-
-def create_manifest(basedir, started_at):
-    """Save context information for the charm execution.
-
-    Mostly to be used by builders.
-    """
-    os_platform = get_os_platform()
-
-    # XXX Facundo 2021-03-29: the architectures list will be provided by the caller when
-    # we integrate lifecycle lib in future branches
-    architectures = [get_host_architecture()]
-
-    # XXX Facundo 2021-04-19: these are temporary translations until charmcraft
-    # changes to be a "classic" snap
-    name_translation = {"ubuntu-core": "ubuntu"}
-    channel_translation = {"20": "20.04"}
-    name = os_platform.system.lower()
-    name = name_translation.get(name, name)
-    channel = channel_translation.get(os_platform.release, os_platform.release)
-
-    content = {
-        "charmcraft-version": __version__,
-        "charmcraft-started-at": started_at.isoformat() + "Z",
-        "bases": [
-            {
-                "name": name,
-                "channel": channel,
-                "architectures": architectures,
-            }
-        ],
-    }
-    filepath = basedir / "manifest.yaml"
-    if filepath.exists():
-        raise CommandError(
-            "Cannot write the manifest as there is already a 'manifest.yaml' in disk."
-        )
-    filepath.write_text(yaml.dump(content))
-    return filepath

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,0 +1,136 @@
+# Copyright 2020-2021 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For further info, check https://github.com/canonical/charmcraft
+
+import datetime
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from charmcraft import __version__, config
+from charmcraft.manifest import create_manifest
+from charmcraft.cmdbase import CommandError
+from charmcraft.utils import (
+    ARCH_TRANSLATIONS,
+    OSPlatform,
+)
+
+
+def test_manifest_simple_ok(tmp_path):
+    """Simple construct."""
+    tstamp = datetime.datetime(2020, 2, 1, 15, 40, 33)
+    os_platform = OSPlatform(system="SuperUbuntu", release="40.10", machine="SomeRISC")
+    with patch("charmcraft.utils.get_os_platform", return_value=os_platform):
+        result_filepath = create_manifest(tmp_path, tstamp)
+
+    assert result_filepath == tmp_path / "manifest.yaml"
+    saved = yaml.safe_load(result_filepath.read_text())
+    expected = {
+        "charmcraft-started-at": "2020-02-01T15:40:33Z",
+        "charmcraft-version": __version__,
+        "bases": [
+            {
+                "name": "superubuntu",
+                "channel": "40.10",
+                "architectures": ["SomeRISC"],
+            }
+        ],
+    }
+    assert saved == expected
+
+
+def test_manifest_architecture_translated(tmp_path, monkeypatch):
+    """All known architectures must be translated."""
+    monkeypatch.setitem(ARCH_TRANSLATIONS, "weird_arch", "nice_arch")
+    os_platform = OSPlatform(system="Ubuntu", release="40.10", machine="weird_arch")
+    with patch("charmcraft.utils.get_os_platform", return_value=os_platform):
+        result_filepath = create_manifest(tmp_path, datetime.datetime.now())
+
+    saved = yaml.safe_load(result_filepath.read_text())
+    assert saved["bases"][0]["architectures"] == ["nice_arch"]
+
+
+def test_manifest_fields_from_strict_snap(tmp_path, monkeypatch):
+    """Fields found in a strict snap must be translated."""
+    os_platform = OSPlatform(system="ubuntu-core", release="20", machine="amd64")
+    with patch("charmcraft.utils.get_os_platform", return_value=os_platform):
+        result_filepath = create_manifest(tmp_path, datetime.datetime.now())
+
+    saved = yaml.safe_load(result_filepath.read_text())
+    base = saved["bases"][0]
+    assert base["name"] == "ubuntu"
+    assert base["channel"] == "20.04"
+
+
+def test_manifest_dont_overwrite(tmp_path):
+    """Don't overwrite the already-existing file."""
+    (tmp_path / "manifest.yaml").touch()
+    with pytest.raises(CommandError) as cm:
+        create_manifest(tmp_path, datetime.datetime.now())
+    assert str(cm.value) == (
+        "Cannot write the manifest as there is already a 'manifest.yaml' in disk."
+    )
+
+
+def test_manifest_using_bases_configuration(tmp_path):
+    """Simple construct."""
+    bases_config = config.BasesConfiguration(
+        **{
+            "build-on": [
+                config.Base(
+                    name="test-name",
+                    channel="test-channel",
+                ),
+            ],
+            "run-on": [
+                config.Base(
+                    name="test-name",
+                    channel="test-channel",
+                    architectures=["arch1"],
+                ),
+                config.Base(
+                    name="test-name2",
+                    channel="test-channel2",
+                    architectures=["arch1", "arch2"],
+                ),
+            ],
+        }
+    )
+
+    tstamp = datetime.datetime(2020, 2, 1, 15, 40, 33)
+    os_platform = OSPlatform(system="SuperUbuntu", release="40.10", machine="SomeRISC")
+    with patch("charmcraft.utils.get_os_platform", return_value=os_platform):
+        result_filepath = create_manifest(tmp_path, tstamp, bases_config=bases_config)
+
+    assert result_filepath == tmp_path / "manifest.yaml"
+    saved = yaml.safe_load(result_filepath.read_text())
+    expected = {
+        "charmcraft-started-at": "2020-02-01T15:40:33Z",
+        "charmcraft-version": __version__,
+        "bases": [
+            {
+                "name": "test-name",
+                "channel": "test-channel",
+                "architectures": ["arch1"],
+            },
+            {
+                "name": "test-name2",
+                "channel": "test-channel2",
+                "architectures": ["arch1", "arch2"],
+            },
+        ],
+    }
+    assert saved == expected

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -63,18 +63,6 @@ def test_manifest_architecture_translated(tmp_path, monkeypatch):
     assert saved["bases"][0]["architectures"] == ["nice_arch"]
 
 
-def test_manifest_fields_from_strict_snap(tmp_path, monkeypatch):
-    """Fields found in a strict snap must be translated."""
-    os_platform = OSPlatform(system="ubuntu-core", release="20", machine="amd64")
-    with patch("charmcraft.utils.get_os_platform", return_value=os_platform):
-        result_filepath = create_manifest(tmp_path, datetime.datetime.now())
-
-    saved = yaml.safe_load(result_filepath.read_text())
-    base = saved["bases"][0]
-    assert base["name"] == "ubuntu"
-    assert base["channel"] == "20.04"
-
-
 def test_manifest_dont_overwrite(tmp_path):
     """Don't overwrite the already-existing file."""
     (tmp_path / "manifest.yaml").touch()


### PR DESCRIPTION
- Move create_manifest() out of utils into its own module.  This will
prevent a potential import loop due to dependencies on util in config.

- Add optional bases_config parameter to use the run-on bases
configuration.

Note that runtime usage still only invokes the "legacy" non-bases
configuration.  Future work will enable the usage of bases and this
just adds test coverage for the future case.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>