### PR TITLE
build & pack: add and use default ubuntu 20.04 bases configuration (CRAFT-266)

### DIFF
--- a/charmcraft/commands/pack.py
+++ b/charmcraft/commands/pack.py
@@ -176,7 +176,9 @@ class PackCommand(BaseCommand):
 
         # pack everything
         project = self.config.project
-        manifest_filepath = create_manifest(project.dirpath, project.started_at)
+        manifest_filepath = create_manifest(
+            project.dirpath, project.started_at, build.DEFAULT_BASES_CONFIGURATION
+        )
         try:
             paths = get_paths_to_include(self.config)
             zipname = project.dirpath / (bundle_name + ".zip")

--- a/charmcraft/manifest.py
+++ b/charmcraft/manifest.py
@@ -19,11 +19,10 @@
 import datetime
 import logging
 import pathlib
-from typing import Optional
 
 import yaml
 
-from charmcraft import __version__, config, utils
+from charmcraft import __version__, config
 from charmcraft.cmdbase import CommandError
 
 logger = logging.getLogger(__name__)
@@ -32,7 +31,7 @@ logger = logging.getLogger(__name__)
 def create_manifest(
     basedir: pathlib.Path,
     started_at: datetime.datetime,
-    bases_config: Optional[config.BasesConfiguration] = None,
+    bases_config: config.BasesConfiguration,
 ):
     """Create manifest.yaml in basedir for given base configuration.
 
@@ -42,31 +41,14 @@ def create_manifest(
 
     :returns: Path to created manifest.yaml.
     """
-    if bases_config is None:
-        os_platform = utils.get_os_platform()
-
-        # XXX Facundo 2021-03-29: the architectures list will be provided by the caller when
-        # we integrate lifecycle lib in future branches
-        architectures = [utils.get_host_architecture()]
-
-        name = os_platform.system.lower()
-        channel = os_platform.release
-        bases = [
-            {
-                "name": name,
-                "channel": channel,
-                "architectures": architectures,
-            }
-        ]
-    else:
-        bases = [
-            {
-                "name": r.name,
-                "channel": r.channel,
-                "architectures": r.architectures,
-            }
-            for r in bases_config.run_on
-        ]
+    bases = [
+        {
+            "name": r.name,
+            "channel": r.channel,
+            "architectures": r.architectures,
+        }
+        for r in bases_config.run_on
+    ]
 
     content = {
         "charmcraft-version": __version__,


### PR DESCRIPTION

- Add a default base of Ubuntu 20.04 to match the behavior of the
strict snap which always reports as Ubuntu 20.04.  Upcoming work
will enable the use of `bases:` configuration in the charmcraft.yaml
to override this.

- Update pack command for bundles to use default bases configuration
as well.

- Remove legacy charm name format as it will no longer be used.

- Remove legacy manifest bases support as it will no longer be used.
Update associated unit tests.

Note that there is no deprecation warning for the use of default
   bases, this will be added in a follow up PR.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>