### PR TITLE
build/pack: add support for bases in managed mode (CRAFT-131)

### DIFF
--- a/charmcraft/bases.py
+++ b/charmcraft/bases.py
@@ -1,0 +1,69 @@
+# Copyright 2021 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For further info, check https://github.com/canonical/charmcraft
+
+"""Logic dealing with bases."""
+
+import logging
+from typing import Tuple, Union
+
+from charmcraft.config import Base
+from charmcraft.utils import get_host_architecture, get_os_platform
+
+logger = logging.getLogger(__name__)
+
+
+def get_host_as_base() -> Base:
+    """Get host OS represented as Base.
+
+    The host OS name is translated to lower-case for consistency.
+
+    :returns: Base configuration matching host.
+    """
+    os_platform = get_os_platform()
+    host_arch = get_host_architecture()
+    name = os_platform.system.lower()
+    channel = os_platform.release
+
+    return Base(name=name, channel=channel, architectures=[host_arch])
+
+
+def check_if_base_matches_host(base: Base) -> Tuple[bool, Union[str, None]]:
+    """Check if given base matches the host.
+
+    :param base: Base to check.
+
+    :returns: Tuple of bool indicating whether it is a match, with optional
+              reason if not a match.
+    """
+    host_base = get_host_as_base()
+    host_arch = host_base.architectures[0]
+
+    if host_base.name != base.name:
+        return False, f"name {base.name!r} does not match host {host_base.name!r}"
+
+    if host_base.channel != base.channel:
+        return (
+            False,
+            f"channel {base.channel!r} does not match host {host_base.channel!r}",
+        )
+
+    if host_arch not in base.architectures:
+        return (
+            False,
+            f"host architecture {host_arch!r} not in base architectures {base.architectures!r}",
+        )
+
+    return True, None

--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -168,7 +168,7 @@ class Builder:
 
         In managed-mode (and eventually destructive-mode), build for each bases
         configuration which has a matching build-on to the host we are executing
-        on.  Warn for each bases configuration that is unbuildable.  Error if
+        on.  Warn for each base configuration that is incompatible.  Error if
         unable to produce any builds for any bases configuration.
 
         Otherwise, build the charm in the legacy mode until we have complete

--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -23,12 +23,14 @@ import pathlib
 import shutil
 import subprocess
 import zipfile
-from typing import Optional
+from typing import List, Optional
 
 import yaml
 
+from charmcraft.bases import check_if_base_matches_host
 from charmcraft.config import Base, BasesConfiguration
 from charmcraft.cmdbase import BaseCommand, CommandError
+from charmcraft.env import is_charmcraft_running_in_managed_mode
 from charmcraft.jujuignore import JujuIgnore, default_juju_ignore
 from charmcraft.manifest import create_manifest
 from charmcraft.utils import make_executable
@@ -138,23 +140,78 @@ class Builder:
         self.ignore_rules = self._load_juju_ignore()
         self.config = config
 
-    def run(self):
-        """Build the charm."""
+    def build_charm(self, bases_config: Optional[BasesConfiguration]) -> str:
+        """Build the charm.
+
+        :param bases_config: Bases configuration to use for build.
+
+        :returns: File name of charm.
+        """
         logger.debug("Building charm in '%s'", self.buildpath)
 
         if self.buildpath.exists():
             shutil.rmtree(str(self.buildpath))
         self.buildpath.mkdir()
 
-        create_manifest(self.buildpath, self.config.project.started_at)
+        create_manifest(self.buildpath, self.config.project.started_at, bases_config)
 
         linked_entrypoint = self.handle_generic_paths()
         self.handle_dispatcher(linked_entrypoint)
         self.handle_dependencies()
-        zipname = self.handle_package()
+        zipname = self.handle_package(bases_config)
 
         logger.info("Created '%s'.", zipname)
         return zipname
+
+    def run(self) -> List[str]:
+        """Run build process.
+
+        In managed-mode (and eventually destructive-mode), build for each bases
+        configuration which has a matching build-on to the host we are executing
+        on.  Warn for each bases configuration that is unbuildable.  Error if
+        unable to produce any builds for any bases configuration.
+
+        Otherwise, build the charm in the legacy mode until we have complete
+        provider support and can drop it.
+
+        :returns: List of charm files created.
+        """
+        charms: List[str] = []
+
+        if is_charmcraft_running_in_managed_mode():
+            if self.config.bases is None:
+                # XXX: 2021-06-16 Patterson temporary until we have the default base
+                raise CommandError("Bases are currently required in managed-mode.")
+
+            for i, bases_config in enumerate(self.config.bases):
+                for j, build_on in enumerate(bases_config.build_on):
+                    matches, reason = check_if_base_matches_host(build_on)
+                    if matches:
+                        logger.debug(
+                            f"Building for 'bases[{i}]' as host matches 'build-on[{j}]'."
+                        )
+                        charm_name = self.build_charm(bases_config)
+                        charms.append(charm_name)
+                        break
+                    else:
+                        logger.debug(
+                            f"Host does not match 'bases[{i}].build-on[{j}]' ({reason})"
+                        )
+                else:
+                    logger.warning(
+                        f"No suitable 'build-on' environment found in 'bases[{i}]' configuration."
+                    )
+
+            if not charms:
+                raise CommandError(
+                    "No suitable 'build-on' environment found in any 'bases' configuration."
+                )
+
+        else:
+            charm_name = self.build_charm(None)
+            charms.append(charm_name)
+
+        return charms
 
     def _load_juju_ignore(self):
         ignore = JujuIgnore(default_juju_ignore)
@@ -314,14 +371,14 @@ class Builder:
             if retcode:
                 raise CommandError("problems installing dependencies")
 
-    def handle_package(self):
+    def handle_package(self, bases_config: Optional[BasesConfiguration] = None):
         """Handle the final package creation."""
         logger.debug("Parsing the project's metadata")
         with (self.charmdir / CHARM_METADATA).open("rt", encoding="utf8") as fh:
             metadata = yaml.safe_load(fh)
 
         logger.debug("Creating the package itself")
-        zipname = format_charm_file_name(metadata["name"], None)
+        zipname = format_charm_file_name(metadata["name"], bases_config)
         zipfh = zipfile.ZipFile(zipname, "w", zipfile.ZIP_DEFLATED)
         for dirpath, dirnames, filenames in os.walk(self.buildpath, followlinks=True):
             dirpath = pathlib.Path(dirpath)

--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -188,18 +188,24 @@ class Builder:
                     matches, reason = check_if_base_matches_host(build_on)
                     if matches:
                         logger.debug(
-                            f"Building for 'bases[{i}]' as host matches 'build-on[{j}]'."
+                            "Building for 'bases[%d]' as host matches 'build-on[%d]'.",
+                            i,
+                            j,
                         )
                         charm_name = self.build_charm(bases_config)
                         charms.append(charm_name)
                         break
                     else:
                         logger.debug(
-                            f"Host does not match 'bases[{i}].build-on[{j}]' ({reason})"
+                            "Host does not match 'bases[%d].build-on[%d]' (%s)",
+                            i,
+                            j,
+                            reason,
                         )
                 else:
                     logger.warning(
-                        f"No suitable 'build-on' environment found in 'bases[{i}]' configuration."
+                        "No suitable 'build-on' environment found in 'bases[%d]' configuration.",
+                        i,
                     )
 
             if not charms:

--- a/tests/test_bases.py
+++ b/tests/test_bases.py
@@ -1,0 +1,104 @@
+# Copyright 2021 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For further info, check https://github.com/canonical/charmcraft
+
+
+from unittest.mock import patch
+
+import pytest
+
+from charmcraft.config import Base
+from charmcraft.bases import check_if_base_matches_host, get_host_as_base
+from charmcraft.utils import OSPlatform
+
+
+@pytest.fixture
+def mock_get_os_platform():
+    os_platform = OSPlatform(
+        system="host-OS", release="host-CHANNEL", machine="host-ARCH"
+    )
+    with patch(
+        "charmcraft.bases.get_os_platform", return_value=os_platform
+    ) as mock_platform:
+        yield mock_platform
+
+
+@pytest.fixture
+def mock_get_host_architecture():
+    with patch(
+        "charmcraft.bases.get_host_architecture", return_value="host-ARCH"
+    ) as mock_host_arch:
+        yield mock_host_arch
+
+
+def test_get_host_as_base(mock_get_os_platform, mock_get_host_architecture):
+    assert get_host_as_base() == Base(
+        name="host-os",
+        channel="host-CHANNEL",
+        architectures=["host-ARCH"],
+    )
+
+
+def test_check_if_bases_matches_host_matches(
+    mock_get_os_platform, mock_get_host_architecture
+):
+    base = Base(name="host-os", channel="host-CHANNEL", architectures=["host-ARCH"])
+    assert check_if_base_matches_host(base) == (True, None)
+
+    base = Base(
+        name="host-os",
+        channel="host-CHANNEL",
+        architectures=["other-ARCH", "host-ARCH"],
+    )
+    assert check_if_base_matches_host(base) == (True, None)
+
+
+def test_check_if_bases_matches_host_name_mismatch(
+    mock_get_os_platform, mock_get_host_architecture
+):
+    base = Base(
+        name="test-other-os", channel="host-CHANNEL", architectures=["host-ARCH"]
+    )
+
+    assert check_if_base_matches_host(base) == (
+        False,
+        "name 'test-other-os' does not match host 'host-os'",
+    )
+
+
+def test_check_if_bases_matches_host_channel_mismatch(
+    mock_get_os_platform, mock_get_host_architecture
+):
+    base = Base(name="host-os", channel="other-CHANNEL", architectures=["host-ARCH"])
+
+    assert check_if_base_matches_host(base) == (
+        False,
+        "channel 'other-CHANNEL' does not match host 'host-CHANNEL'",
+    )
+
+
+def test_check_if_bases_matches_host_arch_mismatch(
+    mock_get_os_platform, mock_get_host_architecture
+):
+    base = Base(
+        name="host-os",
+        channel="host-CHANNEL",
+        architectures=["other-ARCH", "other-ARCH2"],
+    )
+
+    assert check_if_base_matches_host(base) == (
+        False,
+        "host architecture 'host-ARCH' not in base architectures ['other-ARCH', 'other-ARCH2']",
+    )


### PR DESCRIPTION
- Intoduce bases module with `get_host_as_base()` and
  `check_if_base_matches_host()`.

- Extend build/pack to support `bases` configuration if present
  and managed-mode is enabled.  Error if unable to build for any of
  the configured bases.  Warn for each bases config that cannot be
  built for.  Provide additional debug logging on matching behavior
  to help diagnose matching issues when they occur.

- Update run() to return a list of charms built rather than just
  the charm file name.

Note bases are currently required with the use of managed mode until
we introduce the default bases configuration.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>