### PR TITLE
Refactored the upload-resource command for it's new behaviour (CRAFT-240)

### DIFF
--- a/charmcraft/commands/store/__init__.py
+++ b/charmcraft/commands/store/__init__.py
@@ -1353,7 +1353,9 @@ class UploadResourceCommand(BaseCommand):
             resource_filepath = parsed_args.filepath
             resource_filepath_is_temp = False
             resource_type = ResourceType.file
-            logger.debug("Uploading resource directly from file %s", resource_filepath)
+            logger.debug(
+                "Uploading resource directly from file %r.", str(resource_filepath)
+            )
         elif parsed_args.image:
             image_digest = parsed_args.image
             credentials = store.get_oci_registry_credentials(
@@ -1361,7 +1363,7 @@ class UploadResourceCommand(BaseCommand):
             )
             image_name = credentials.image_name.split("/", 1)[1]
             logger.debug(
-                "Uploading resource from image %s @ %s", image_name, image_digest
+                "Uploading resource from image %s @ %s.", image_name, image_digest
             )
 
             # build the image handler
@@ -1376,19 +1378,19 @@ class UploadResourceCommand(BaseCommand):
             # check if the specific image is already in Canonical's registry
             already_uploaded = ih.check_in_registry(image_digest)
             if already_uploaded:
-                logger.info("Using OCI image from Canonical's registry")
+                logger.info("Using OCI image from Canonical's registry.")
             else:
                 # upload it from local registry
-                logger.info("Remote image not found, uploading from local registry")
+                logger.info("Remote image not found, uploading from local registry.")
                 image_digest = ih.upload_from_local(image_digest)
                 if image_digest is None:
                     logger.info(
                         "Image with digest %s is not available in the Canonical's registry "
-                        "nor locally",
+                        "nor locally.",
                         parsed_args.image,
                     )
                     return
-                logger.info("Image uploaded, new remote digest: %s", image_digest)
+                logger.info("Image uploaded, new remote digest: %s.", image_digest)
 
             # all is green, get the blob to upload to Charmhub
             content = store.get_oci_image_blob(
@@ -1413,7 +1415,7 @@ class UploadResourceCommand(BaseCommand):
 
         if result.ok:
             logger.info(
-                "Revision %s created of resource %r for charm %r",
+                "Revision %s created of resource %r for charm %r.",
                 result.revision,
                 parsed_args.resource_name,
                 parsed_args.charm_name,

--- a/charmcraft/commands/store/__init__.py
+++ b/charmcraft/commands/store/__init__.py
@@ -1361,6 +1361,10 @@ class UploadResourceCommand(BaseCommand):
             credentials = store.get_oci_registry_credentials(
                 parsed_args.charm_name, parsed_args.resource_name
             )
+
+            # convert the standard OCI registry image name (which is something like
+            # 'registry.jujucharms.com/charm/45kk8smbiyn2e/redis-image') to the image
+            # name that we use internally (just remove the initial "server host" part)
             image_name = credentials.image_name.split("/", 1)[1]
             logger.debug(
                 "Uploading resource from image %s @ %s.", image_name, image_digest

--- a/charmcraft/commands/store/__init__.py
+++ b/charmcraft/commands/store/__init__.py
@@ -18,7 +18,6 @@
 
 import ast
 import hashlib
-import json
 import logging
 import pathlib
 import string
@@ -55,7 +54,6 @@ LibData = namedtuple(
     "LibData",
     "lib_id api patch content content_hash full_name path lib_name charm_name",
 )
-OCIImageSpec = namedtuple("OCIImageSpec", "organization name reference")
 
 # The token used in the 'init' command (as bytes for easier comparison)
 INIT_TEMPLATE_TOKEN = b"TEMPLATE-TODO"
@@ -1301,43 +1299,6 @@ class ListResourcesCommand(BaseCommand):
             logger.info(line)
 
 
-class _BadOCIImageSpecError(CommandError):
-    """Subclass to provide a specific error for a bad OCI Image specification."""
-
-    def __init__(self, base_error):
-        super().__init__(
-            base_error + " (the format is [organization/]name[:tag|@digest])."
-        )
-
-
-def oci_image_spec(value):
-    """Build a full OCI image spec, using defaults for non specified parts."""
-    # separate the organization
-    if "/" in value:
-        if value.count("/") > 1:
-            raise _BadOCIImageSpecError(
-                "The registry server cannot be specified as part of the image"
-            )
-        orga, value = value.split("/")
-    else:
-        orga = "library"
-
-    # get the digest XOR tag
-    if "@" in value and ":" in value:
-        raise _BadOCIImageSpecError("Cannot specify both tag and digest")
-    if "@" in value:
-        name, reference = value.split("@")
-    elif ":" in value:
-        name, reference = value.split(":")
-    else:
-        name = value
-        reference = "latest"
-
-    if not name:
-        raise _BadOCIImageSpecError("The image name is mandatory")
-    return OCIImageSpec(organization=orga, name=name, reference=reference)
-
-
 class UploadResourceCommand(BaseCommand):
     """Upload a resource to Charmhub."""
 
@@ -1352,12 +1313,10 @@ class UploadResourceCommand(BaseCommand):
         in its metadata (in a previously uploaded to Charmhub revision).
 
         The resource can be a file from your computer (use the '--filepath'
-        option) or an OCI Image (use the '--image' option).
-
-        The OCI image description uses the [organization/]name[:tag|@digest]
-        form. The name is mandatory but organization and reference (a digest
-        or a tag) are optional, defaulting to 'library' and 'latest'
-        correspondingly.
+        option) or an OCI Image (use the '--image' option to indicate the
+        image digest), which can be already in Canonical's registry and
+        used directly, or locally in your computer and will be uploaded
+        and used.
 
         Upload will take you through login if needed.
     """
@@ -1382,8 +1341,8 @@ class UploadResourceCommand(BaseCommand):
         )
         group.add_argument(
             "--image",
-            type=SingleOptionEnsurer(oci_image_spec),
-            help="The image specification with the [organization/]name[:tag|@digest] form",
+            type=SingleOptionEnsurer(str),
+            help="The digest of the OCI image",
         )
 
     def run(self, parsed_args):
@@ -1396,26 +1355,50 @@ class UploadResourceCommand(BaseCommand):
             resource_type = ResourceType.file
             logger.debug("Uploading resource directly from file %s", resource_filepath)
         elif parsed_args.image:
+            image_digest = parsed_args.image
+            credentials = store.get_oci_registry_credentials(
+                parsed_args.charm_name, parsed_args.resource_name
+            )
+            image_name = credentials.image_name.split("/", 1)[1]
             logger.debug(
-                "Uploading resource from image %s at Dockerhub", parsed_args.image
+                "Uploading resource from image %s @ %s", image_name, image_digest
             )
-            full_image_name = "/".join(
-                (parsed_args.image.organization, parsed_args.image.name)
-            )
-            registry = OCIRegistry("https://registry.hub.docker.com", full_image_name)
-            ih = ImageHandler(registry)
-            final_resource_url = ih.get_destination_url(parsed_args.image.reference)
-            logger.debug("Resource URL: %s", final_resource_url)
-            resource_type = "oci-image"
 
-            # create a JSON pointing to the unique image URL (to be uploaded to Charmhub)
-            resource_metadata = {
-                "ImageName": final_resource_url,
-            }
+            # build the image handler
+            registry = OCIRegistry(
+                self.config.charmhub.registry_url,
+                image_name,
+                username=credentials.username,
+                password=credentials.password,
+            )
+            ih = ImageHandler(registry)
+
+            # check if the specific image is already in Canonical's registry
+            already_uploaded = ih.check_in_registry(image_digest)
+            if already_uploaded:
+                logger.info("Using OCI image from Canonical's registry")
+            else:
+                # upload it from local registry
+                logger.info("Remote image not found, uploading from local registry")
+                image_digest = ih.upload_from_local(image_digest)
+                if image_digest is None:
+                    logger.info(
+                        "Image with digest %s is not available in the Canonical's registry "
+                        "nor locally",
+                        parsed_args.image,
+                    )
+                    return
+                logger.info("Image uploaded, new remote digest: %s", image_digest)
+
+            # all is green, get the blob to upload to Charmhub
+            content = store.get_oci_image_blob(
+                parsed_args.charm_name, parsed_args.resource_name, image_digest
+            )
             _, tname = tempfile.mkstemp(prefix="image-resource", suffix=".json")
             resource_filepath = pathlib.Path(tname)
             resource_filepath_is_temp = True
-            resource_filepath.write_text(json.dumps(resource_metadata))
+            resource_filepath.write_text(content)
+            resource_type = ResourceType.oci_image
 
         result = store.upload_resource(
             parsed_args.charm_name,

--- a/completion.bash
+++ b/completion.bash
@@ -121,7 +121,7 @@ _charmcraft()
                     _filedir
                     ;;
                 *)
-                    COMPREPLY=( $(compgen -W "${globals[*]} --filepath" -- "$cur") )
+                    COMPREPLY=( $(compgen -W "${globals[*]} --filepath --image" -- "$cur") )
                     ;;
             esac
             ;;

--- a/tests/commands/test_store_commands.py
+++ b/tests/commands/test_store_commands.py
@@ -18,12 +18,11 @@
 
 import datetime
 import hashlib
-import json
 import logging
 import pathlib
 import zipfile
 from argparse import Namespace, ArgumentParser
-from unittest.mock import patch, call, MagicMock
+from unittest.mock import patch, call, MagicMock, ANY
 
 import dateutil.parser
 import pytest
@@ -42,8 +41,6 @@ from charmcraft.commands.store import (
     ListRevisionsCommand,
     LoginCommand,
     LogoutCommand,
-    OCIImageSpec,
-    OCIRegistry,
     PublishLibCommand,
     RegisterBundleNameCommand,
     RegisterCharmNameCommand,
@@ -55,13 +52,13 @@ from charmcraft.commands.store import (
     _get_lib_info,
     get_name_from_metadata,
     get_name_from_zip,
-    oci_image_spec,
 )
 from charmcraft.commands.store.store import (
     Channel,
     Entity,
     Error,
     Library,
+    RegistryCredentials,
     Release,
     Resource,
     ResourceRevision,
@@ -2730,7 +2727,7 @@ def test_uploadresource_options_image_type(config):
     cmd.fill_parser(parser)
     (action,) = [action for action in parser._actions if action.dest == "image"]
     assert isinstance(action.type, SingleOptionEnsurer)
-    assert action.type.converter is oci_image_spec
+    assert action.type.converter is str
 
 
 @pytest.mark.parametrize(
@@ -2808,14 +2805,23 @@ def test_uploadresource_filepath_call_ok(caplog, store_mock, config, tmp_path):
     assert test_resource.exists()  # provided by the user, don't touch it
 
 
-def test_uploadresource_image_call_ok(caplog, store_mock, config, tmp_path):
-    """Simple upload, success result."""
+def test_uploadresource_image_call_already_uploaded(caplog, store_mock, config):
+    """Upload an oci-image resource, the image itself already being in the registry."""
     caplog.set_level(logging.DEBUG, logger="charmcraft.commands")
+
+    # fake credentials for the charm/resource, and the final json content
+    store_mock.get_oci_registry_credentials.return_value = RegistryCredentials(
+        username="testusername",
+        password="testpassword",
+        image_name="registry.staging.jujucharms.com/charm/charm-id/test-image-name",
+    )
+
+    test_json_content = "from charmhub we came, from charmhub we shall return"
+    store_mock.get_oci_image_blob.return_value = test_json_content
 
     # hack into the store mock to save for later the uploaded resource bytes
     uploaded_resource_content = None
     uploaded_resource_filepath = None
-    store_response = Uploaded(ok=True, status=200, revision=7, errors=[])
 
     def interceptor(charm_name, resource_name, resource_type, resource_filepath):
         """Intercept the call to save real content (and validate params)."""
@@ -2827,38 +2833,181 @@ def test_uploadresource_image_call_ok(caplog, store_mock, config, tmp_path):
         assert charm_name == "mycharm"
         assert resource_name == "myresource"
         assert resource_type == "oci-image"
-        return store_response
+        return Uploaded(ok=True, status=200, revision=7, errors=[])
 
     store_mock.upload_resource.side_effect = interceptor
 
-    spec = OCIImageSpec("test-orga", "test-image", "test-tag")
+    # test
+    original_image_digest = "test-digest-given-by-user"
     args = Namespace(
-        charm_name="mycharm", resource_name="myresource", filepath=None, image=spec
+        charm_name="mycharm",
+        resource_name="myresource",
+        filepath=None,
+        image=original_image_digest,
     )
-
     with patch(
         "charmcraft.commands.store.ImageHandler", autospec=True
     ) as im_class_mock:
-        im_class_mock.return_value = im_mock = MagicMock()
-        im_mock.get_destination_url.return_value = "test-final-url"
-        UploadResourceCommand("group", config).run(args)
+        with patch(
+            "charmcraft.commands.store.OCIRegistry", autospec=True
+        ) as reg_class_mock:
+            reg_class_mock.return_value = reg_mock = MagicMock()
+            im_class_mock.return_value = im_mock = MagicMock()
+            im_mock.check_in_registry.return_value = True
+            UploadResourceCommand("group", config).run(args)
+
+    # validate how OCIRegistry was instantiated
+    assert reg_class_mock.mock_calls == [
+        call(
+            config.charmhub.registry_url,
+            "charm/charm-id/test-image-name",
+            username="testusername",
+            password="testpassword",
+        )
+    ]
 
     # validate how ImageHandler was used
-    registry = OCIRegistry("https://registry.hub.docker.com", "test-orga/test-image")
     assert im_class_mock.mock_calls == [
-        call(registry),
-        call().get_destination_url("test-tag"),
+        call(reg_mock),
+        call().check_in_registry(original_image_digest),
     ]
-    assert im_mock.mock_calls == [call.get_destination_url("test-tag")]
 
     # check that the uploaded file is fine and that was cleaned
-    assert json.loads(uploaded_resource_content) == {"ImageName": "test-final-url"}
-    assert not uploaded_resource_filepath.exists()  # temporary! has to be cleaned
+    assert uploaded_resource_content == test_json_content
+    assert not uploaded_resource_filepath.exists()  # temporary! shall be cleaned
+
+    assert store_mock.mock_calls == [
+        call.get_oci_registry_credentials("mycharm", "myresource"),
+        call.get_oci_image_blob("mycharm", "myresource", original_image_digest),
+        call.upload_resource(
+            "mycharm", "myresource", "oci-image", uploaded_resource_filepath
+        ),
+    ]
 
     expected = [
-        "Uploading resource from image {} at Dockerhub".format(spec),
-        "Resource URL: test-final-url",
+        "Uploading resource from image charm/charm-id/test-image-name @ test-digest-given-by-user",
+        "Using OCI image from Canonical's registry",
         "Revision 7 created of resource 'myresource' for charm 'mycharm'",
+    ]
+    assert expected == [rec.message for rec in caplog.records]
+
+
+def test_uploadresource_image_call_upload_from_local(caplog, store_mock, config):
+    """Upload an oci-image resource, the image is upload from local to Canonical's registry."""
+    caplog.set_level(logging.DEBUG, logger="charmcraft.commands")
+
+    # fake credentials for the charm/resource, the final json content, and the upload result
+    store_mock.get_oci_registry_credentials.return_value = RegistryCredentials(
+        username="testusername",
+        password="testpassword",
+        image_name="registry.staging.jujucharms.com/charm/charm-id/test-image-name",
+    )
+
+    test_json_content = "from charmhub we came, from charmhub we shall return"
+    store_mock.get_oci_image_blob.return_value = test_json_content
+
+    store_mock.upload_resource.return_value = Uploaded(
+        ok=True, status=200, revision=7, errors=[]
+    )
+
+    # test
+    original_image_digest = "test-digest-given-by-user"
+    args = Namespace(
+        charm_name="mycharm",
+        resource_name="myresource",
+        filepath=None,
+        image=original_image_digest,
+    )
+    with patch(
+        "charmcraft.commands.store.ImageHandler", autospec=True
+    ) as im_class_mock:
+        with patch(
+            "charmcraft.commands.store.OCIRegistry", autospec=True
+        ) as reg_class_mock:
+            reg_class_mock.return_value = reg_mock = MagicMock()
+            im_class_mock.return_value = im_mock = MagicMock()
+
+            # not in the registry, and then uploaded ok
+            im_mock.check_in_registry.return_value = False
+            new_image_digest = "new-digest-after-upload"
+            im_mock.upload_from_local.return_value = new_image_digest
+
+            UploadResourceCommand("group", config).run(args)
+
+    # validate how ImageHandler was used
+    assert im_class_mock.mock_calls == [
+        call(reg_mock),
+        call().check_in_registry(original_image_digest),
+        call().upload_from_local(original_image_digest),
+    ]
+
+    assert store_mock.mock_calls == [
+        call.get_oci_registry_credentials("mycharm", "myresource"),
+        call.get_oci_image_blob("mycharm", "myresource", new_image_digest),
+        call.upload_resource("mycharm", "myresource", "oci-image", ANY),
+    ]
+
+    expected = [
+        "Uploading resource from image charm/charm-id/test-image-name @ test-digest-given-by-user",
+        "Remote image not found, uploading from local registry",
+        "Image uploaded, new remote digest: new-digest-after-upload",
+        "Revision 7 created of resource 'myresource' for charm 'mycharm'",
+    ]
+    assert expected == [rec.message for rec in caplog.records]
+
+
+def test_uploadresource_image_call_missing_everywhere(caplog, store_mock, config):
+    """Upload an oci-image resource, but the image is not found remote nor locally."""
+    caplog.set_level(logging.DEBUG, logger="charmcraft.commands")
+
+    # fake credentials for the charm/resource, the final json content, and the upload result
+    store_mock.get_oci_registry_credentials.return_value = RegistryCredentials(
+        username="testusername",
+        password="testpassword",
+        image_name="registry.staging.jujucharms.com/charm/charm-id/test-image-name",
+    )
+
+    # test
+    original_image_digest = "test-digest-given-by-user"
+    args = Namespace(
+        charm_name="mycharm",
+        resource_name="myresource",
+        filepath=None,
+        image=original_image_digest,
+    )
+    with patch(
+        "charmcraft.commands.store.ImageHandler", autospec=True
+    ) as im_class_mock:
+        with patch(
+            "charmcraft.commands.store.OCIRegistry", autospec=True
+        ) as reg_class_mock:
+            reg_class_mock.return_value = reg_mock = MagicMock()
+            im_class_mock.return_value = im_mock = MagicMock()
+
+            # not in the remote registry, not locally either
+            im_mock.check_in_registry.return_value = False
+            im_mock.upload_from_local.return_value = None
+
+            UploadResourceCommand("group", config).run(args)
+
+    # validate how ImageHandler was used
+    assert im_class_mock.mock_calls == [
+        call(reg_mock),
+        call().check_in_registry(original_image_digest),
+        call().upload_from_local(original_image_digest),
+    ]
+
+    assert store_mock.mock_calls == [
+        call.get_oci_registry_credentials("mycharm", "myresource"),
+    ]
+
+    expected = [
+        "Uploading resource from image charm/charm-id/test-image-name @ test-digest-given-by-user",
+        "Remote image not found, uploading from local registry",
+        (
+            "Image with digest test-digest-given-by-user is not available in "
+            "the Canonical's registry nor locally"
+        ),
     ]
     assert expected == [rec.message for rec in caplog.records]
 
@@ -2887,50 +3036,6 @@ def test_uploadresource_call_error(caplog, store_mock, config, tmp_path):
         "- broken: other long error text",
     ]
     assert expected == [rec.message for rec in caplog.records]
-
-
-@pytest.mark.parametrize(
-    "source,expected",
-    [
-        ("testname", OCIImageSpec("library", "testname", "latest")),
-        ("testorga/testname", OCIImageSpec("testorga", "testname", "latest")),
-        ("testname:sometag", OCIImageSpec("library", "testname", "sometag")),
-        ("testorga/testname:sometag", OCIImageSpec("testorga", "testname", "sometag")),
-        ("testname@somedigest", OCIImageSpec("library", "testname", "somedigest")),
-        (
-            "testorga/testname@somedigest",
-            OCIImageSpec("testorga", "testname", "somedigest"),
-        ),
-    ],
-)
-def test_uploadresource_ociimagespec_ok(source, expected):
-    """Check oci image spec format, different good combinations."""
-    result = oci_image_spec(source)
-    assert result == expected
-
-
-@pytest.mark.parametrize(
-    "source,partial_error_message",
-    [
-        ("testname:tag@digest", "Cannot specify both tag and digest"),
-        ("testname@digest:tag", "Cannot specify both tag and digest"),
-        ("@digest:tag", "Cannot specify both tag and digest"),
-        ("", "The image name is mandatory"),
-        (":tag", "The image name is mandatory"),
-        (
-            "server/testorga/name",
-            "The registry server cannot be specified as part of the image",
-        ),
-    ],
-)
-def test_uploadresource_ociimagespec_error(source, partial_error_message):
-    """Check oci image spec format, different bad combinations."""
-    error_message = partial_error_message + (
-        " (the format is [organization/]name[:tag|@digest])."
-    )
-    with pytest.raises(CommandError) as cm:
-        oci_image_spec(source)
-    assert str(cm.value) == error_message
 
 
 # -- tests for list resource revisions command

--- a/tests/commands/test_store_commands.py
+++ b/tests/commands/test_store_commands.py
@@ -2798,8 +2798,8 @@ def test_uploadresource_filepath_call_ok(caplog, store_mock, config, tmp_path):
         call.upload_resource("mycharm", "myresource", "file", test_resource)
     ]
     expected = [
-        "Uploading resource directly from file {}".format(test_resource),
-        "Revision 7 created of resource 'myresource' for charm 'mycharm'",
+        "Uploading resource directly from file '{}'.".format(test_resource),
+        "Revision 7 created of resource 'myresource' for charm 'mycharm'.",
     ]
     assert expected == [rec.message for rec in caplog.records]
     assert test_resource.exists()  # provided by the user, don't touch it
@@ -2885,9 +2885,12 @@ def test_uploadresource_image_call_already_uploaded(caplog, store_mock, config):
     ]
 
     expected = [
-        "Uploading resource from image charm/charm-id/test-image-name @ test-digest-given-by-user",
-        "Using OCI image from Canonical's registry",
-        "Revision 7 created of resource 'myresource' for charm 'mycharm'",
+        (
+            "Uploading resource from image "
+            "charm/charm-id/test-image-name @ test-digest-given-by-user."
+        ),
+        "Using OCI image from Canonical's registry.",
+        "Revision 7 created of resource 'myresource' for charm 'mycharm'.",
     ]
     assert expected == [rec.message for rec in caplog.records]
 
@@ -2948,10 +2951,13 @@ def test_uploadresource_image_call_upload_from_local(caplog, store_mock, config)
     ]
 
     expected = [
-        "Uploading resource from image charm/charm-id/test-image-name @ test-digest-given-by-user",
-        "Remote image not found, uploading from local registry",
-        "Image uploaded, new remote digest: new-digest-after-upload",
-        "Revision 7 created of resource 'myresource' for charm 'mycharm'",
+        (
+            "Uploading resource from image "
+            "charm/charm-id/test-image-name @ test-digest-given-by-user."
+        ),
+        "Remote image not found, uploading from local registry.",
+        "Image uploaded, new remote digest: new-digest-after-upload.",
+        "Revision 7 created of resource 'myresource' for charm 'mycharm'.",
     ]
     assert expected == [rec.message for rec in caplog.records]
 
@@ -3002,11 +3008,14 @@ def test_uploadresource_image_call_missing_everywhere(caplog, store_mock, config
     ]
 
     expected = [
-        "Uploading resource from image charm/charm-id/test-image-name @ test-digest-given-by-user",
-        "Remote image not found, uploading from local registry",
+        (
+            "Uploading resource from "
+            "image charm/charm-id/test-image-name @ test-digest-given-by-user."
+        ),
+        "Remote image not found, uploading from local registry.",
         (
             "Image with digest test-digest-given-by-user is not available in "
-            "the Canonical's registry nor locally"
+            "the Canonical's registry nor locally."
         ),
     ]
     assert expected == [rec.message for rec in caplog.records]


### PR DESCRIPTION
Now it will stop using Dockerhub, and the process will be:

- check if the indicated digest is in Canonical's registry; if yes, use it

- else try to upload it; the ImageHandler function will upload it and will return the new remote digest, in which case it will be used, or None, in which case an error will be presented to the user

Once the command has the image's digest from the Canonical's Registry (because it was already there, or just uploaded), will request the formal JSON to Charmhub, which will be uploaded back to Charmhub as any other resource.