### PR TITLE
pack: introduce support for --bases-index to specify targets (CRAFT-148)

### DIFF
--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -437,8 +437,7 @@ class Validator:
         """Process the received options."""
         result = {}
         for opt in self._options:
-            print(parsed_args)
-            meth = getattr(self, "validate_" + opt.replace("-", "_"))
+            meth = getattr(self, "validate_" + opt)
             result[opt] = meth(getattr(parsed_args, opt, None))
         return result
 

--- a/charmcraft/commands/pack.py
+++ b/charmcraft/commands/pack.py
@@ -117,6 +117,13 @@ class PackCommand(BaseCommand):
                 "times); defaults to 'requirements.txt'"
             ),
         )
+        parser.add_argument(
+            "--bases-index",
+            action="append",
+            type=int,
+            help="Index of 'bases' configuration to build (can be used multiple "
+            "times); defaults to all",
+        )
 
     def run(self, parsed_args):
         """Run the command."""
@@ -137,7 +144,7 @@ class PackCommand(BaseCommand):
     def _pack_charm(self, parsed_args):
         """Pack a charm."""
         # adapt arguments to use the build infrastructure
-        parsed_args = Namespace(
+        build_args = Namespace(
             **{
                 "from": self.config.project.dirpath,
                 "entrypoint": parsed_args.entrypoint,
@@ -147,10 +154,10 @@ class PackCommand(BaseCommand):
 
         # mimic the "build" command
         validator = build.Validator()
-        args = validator.process(parsed_args)
+        args = validator.process(build_args)
         logger.debug("working arguments: %s", args)
         builder = build.Builder(args, self.config)
-        builder.run()
+        builder.run(parsed_args.bases_index)
 
     def _pack_bundle(self):
         """Pack a bundle."""

--- a/charmcraft/commands/pack.py
+++ b/charmcraft/commands/pack.py
@@ -149,6 +149,7 @@ class PackCommand(BaseCommand):
                 "from": self.config.project.dirpath,
                 "entrypoint": parsed_args.entrypoint,
                 "requirement": parsed_args.requirement,
+                "bases_indices": parsed_args.bases_index,
             }
         )
 

--- a/charmcraft/commands/pack.py
+++ b/charmcraft/commands/pack.py
@@ -154,7 +154,7 @@ class PackCommand(BaseCommand):
         )
 
         # mimic the "build" command
-        validator = build.Validator()
+        validator = build.Validator(self.config)
         args = validator.process(build_args)
         logger.debug("working arguments: %s", args)
         builder = build.Builder(args, self.config)

--- a/tests/commands/test_build.py
+++ b/tests/commands/test_build.py
@@ -19,6 +19,7 @@ import filecmp
 import logging
 import os
 import pathlib
+import re
 import socket
 import subprocess
 import sys
@@ -168,6 +169,15 @@ def test_validator_from_isdir(tmp_path):
     expected_msg = "Charm directory is not really a directory: '{}'".format(testfile)
     with pytest.raises(CommandError, match=expected_msg):
         validator.validate_from(testfile)
+
+
+@pytest.mark.parametrize("bases_indices", [[-1], [0, -1], [0, 1, -1]])
+def test_validator_bases_index_invalid(bases_indices):
+    """'entrypoint' param: checks that the file exists."""
+    validator = Validator()
+    expected_msg = re.escape("Bases index '-1' is invalid (must be >= 0).")
+    with pytest.raises(CommandError, match=expected_msg):
+        validator.validate_bases_indices(bases_indices)
 
 
 def test_validator_entrypoint_simple(tmp_path):
@@ -635,15 +645,9 @@ def test_build_bases_index_scenarios(basic_project, monkeypatch, caplog):
     # Invalid indices.
     with pytest.raises(
         CommandError,
-        match=r"Specified base index '3' is out of range.",
+        match=r"No bases configuration found for specified index '3'.",
     ):
         builder.run([3])
-
-    with pytest.raises(
-        CommandError,
-        match=r"Specified base index '-1' is out of range.",
-    ):
-        builder.run([-1])
 
 
 @patch(

--- a/tests/commands/test_pack.py
+++ b/tests/commands/test_pack.py
@@ -445,6 +445,7 @@ def test_charm_parameters_validator(config, tmp_path):
                 "from": tmp_path,
                 "requirement": "test-reqs",
                 "entrypoint": "test-epoint",
+                "bases_indices": [],
             }
         )
     )

--- a/tests/commands/test_pack.py
+++ b/tests/commands/test_pack.py
@@ -455,7 +455,7 @@ def test_charm_builder_infrastructure_called(config):
     """Check that build.Builder is properly called."""
     config.set(type="charm")
     with patch("charmcraft.commands.build.Validator", autospec=True) as validator_mock:
-        validator_mock().process.return_value = "processed args"
+        validator_mock(config).process.return_value = "processed args"
         with patch("charmcraft.commands.build.Builder") as builder_class_mock:
             builder_class_mock.return_value = builder_instance_mock = MagicMock()
             PackCommand("group", config).run(noargs)

--- a/tests/commands/test_pack.py
+++ b/tests/commands/test_pack.py
@@ -35,7 +35,7 @@ from charmcraft.commands.pack import (
 from charmcraft.utils import useful_filepath, SingleOptionEnsurer
 
 # empty namespace
-noargs = Namespace(entrypoint=None, requirement=None)
+noargs = Namespace(entrypoint=None, requirement=None, bases_index=[])
 
 
 @pytest.fixture
@@ -428,7 +428,7 @@ def test_charm_parameters_entrypoint(config):
 
 def test_charm_parameters_validator(config, tmp_path):
     """Check that build.Builder is properly called."""
-    args = Namespace(requirement="test-reqs", entrypoint="test-epoint")
+    args = Namespace(requirement="test-reqs", entrypoint="test-epoint", bases_index=[])
     config.set(
         type="charm",
         project=Project(dirpath=tmp_path, started_at=datetime.datetime.utcnow()),
@@ -459,4 +459,4 @@ def test_charm_builder_infrastructure_called(config):
             builder_class_mock.return_value = builder_instance_mock = MagicMock()
             PackCommand("group", config).run(noargs)
     builder_class_mock.assert_called_with("processed args", config)
-    builder_instance_mock.run.assert_called_with()
+    builder_instance_mock.run.assert_called_with([])


### PR DESCRIPTION
Allow the user to specify --bases-index <index> to limit the targets
being built.  Pass this through pack's run() so we don't have to
further extend the deprecated pack's arguments.

These indices are validated at runtime because the current Validator
does not have the config available to validate against.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>