### PR TITLE
Update the default bundle from `charmcraft init`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+## Development environment
+
+To set up an initial development environment:
+    
+    git clone https://github.com/canonical/charmcraft.git
+    cd charmcraft
+    virtualenv venv
+    . venv/bin/activate
+    pip install -r requirements-dev.txt
+
+
+## Developing against Charmcraft source
+
+Make changes as appropriate. Some existing ideas are in the
+[Github Issues](https://github.com/canonical/charmcraft/issues)
+
+To test locally:
+
+    CHARMCRAFT_DEVELOPER=1 python -m charmcraft
+
+When you're done, make sure you run the tests.
+
+You can do so with
+
+    pip install -r requirements-dev.txt
+    ./run_tests
+
+Contributions welcome!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ To set up an initial development environment:
     cd charmcraft
     virtualenv venv
     . venv/bin/activate
-    pip install -r requirements-dev.txt
+    pip install -r requirements-dev.txt -e .
 
 
 ## Developing against Charmcraft source

--- a/README.md
+++ b/README.md
@@ -144,21 +144,3 @@ latest/edge
 Use `charmcraft upload` to get a new revision number for your freshly built
 charmed operator, and `charmcraft release` to release a revision into any
 particular channel for your users.
-
-# Charmcraft source
-
-Get the source from github with:
-
-    git clone https://github.com/canonical/charmcraft.git
-    cd charmcraft
-    virtualenv venv
-    . venv/bin/activate
-    pip install -r requirements.txt
-    CHARMCRAFT_DEVELOPER=1 python -m charmcraft
-
-If you would like to run the tests you can do so with
-
-    pip install -r requirements-dev.txt
-    ./run_tests
-
-Contributions welcome!

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Get the source from github with:
     virtualenv venv
     . venv/bin/activate
     pip install -r requirements.txt
-    python -m charmcraft
+    CHARMCRAFT_DEVLOPER=1 python -m charmcraft
 
 If you would like to run the tests you can do so with
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Get the source from github with:
     virtualenv venv
     . venv/bin/activate
     pip install -r requirements.txt
-    CHARMCRAFT_DEVLOPER=1 python -m charmcraft
+    CHARMCRAFT_DEVELOPER=1 python -m charmcraft
 
 If you would like to run the tests you can do so with
 

--- a/charmcraft/commands/init.py
+++ b/charmcraft/commands/init.py
@@ -37,6 +37,7 @@ It will setup the following tree of files and directories:
 .
 ├── metadata.yaml        - Charm operator package description
 ├── README.md            - Frontpage for your charmhub.io/charm/
+├── CONTRIBUTING.md      - Instructions for how to build and develop your charm
 ├── actions.yaml         - Day-2 action declarations, e.g. backup, restore
 ├── config.yaml          - Config schema for your operator
 ├── LICENSE              - Your charm license, we recommend Apache 2

--- a/charmcraft/templates/init/CONTRIBUTING.md.j2
+++ b/charmcraft/templates/init/CONTRIBUTING.md.j2
@@ -8,6 +8,24 @@ Create and activate a virtualenv with the development requirements:
     source venv/bin/activate
     pip install -r requirements-dev.txt
 
+## Code overview
+
+TEMPLATE-TODO: 
+One of the most important things a consumer of your charm (or library)
+needs to know is what set of functionality it provides. Which categories
+does it fit into? Which events do you listen to? Which libraries do you
+consume? Which ones do you export and how are they used?
+
+## Intended use case
+
+TEMPLATE-TODO:
+Why were these decisions made? What's the scope of your charm?
+
+## Roadmap
+
+If this Charm doesn't fulfill all of the initial functionality you were
+hoping for or planning on, please add a Roadmap or TODO here
+
 ## Testing
 
 The Python operator framework includes a very nice harness for testing

--- a/charmcraft/templates/init/CONTRIBUTING.md.j2
+++ b/charmcraft/templates/init/CONTRIBUTING.md.j2
@@ -1,0 +1,16 @@
+# {{ name }}
+
+## Developing
+
+Create and activate a virtualenv with the development requirements:
+
+    virtualenv -p python3 venv
+    source venv/bin/activate
+    pip install -r requirements-dev.txt
+
+## Testing
+
+The Python operator framework includes a very nice harness for testing
+operator behaviour without full deployment. Just `run_tests`:
+
+    ./run_tests

--- a/charmcraft/templates/init/README.md.j2
+++ b/charmcraft/templates/init/README.md.j2
@@ -11,7 +11,7 @@ TODO: Provide high-level usage, such as required config or relations
 
 ## Relations
 
-TODO: Provide any relations which are provides or required by your charm
+TODO: Provide any relations which are provided or required by your charm
 
 ## OCI Images
 
@@ -20,4 +20,5 @@ TODO: Include a link to the default image your charm uses
 ## Contributing
 
 Please see the [Juju SDK docs](https://juju.is/docs/sdk) for guidelines 
-on enhancements to this charm following best practice guidelines.
+on enhancements to this charm following best practice guidelines, and
+`CONTRIBUTING.md` for developer guidance.

--- a/charmcraft/templates/init/README.md.j2
+++ b/charmcraft/templates/init/README.md.j2
@@ -9,17 +9,15 @@ TODO: Describe your charm in a few paragraphs of Markdown
 TODO: Provide high-level usage, such as required config or relations
 
 
-## Developing
+## Relations
 
-Create and activate a virtualenv with the development requirements:
+TODO: Provide any relations which are provides or required by your charm
 
-    virtualenv -p python3 venv
-    source venv/bin/activate
-    pip install -r requirements-dev.txt
+## OCI Images
 
-## Testing
+TODO: Include a link to the default image your charm uses
 
-The Python operator framework includes a very nice harness for testing
-operator behaviour without full deployment. Just `run_tests`:
+## Contributing
 
-    ./run_tests
+Please see the [Juju SDK docs](https://juju.is/docs/sdk) for guidelines 
+on enhancements to this charm following best practice guidelines.

--- a/charmcraft/templates/init/metadata.yaml.j2
+++ b/charmcraft/templates/init/metadata.yaml.j2
@@ -1,5 +1,8 @@
 # Copyright {{ year }} {{ author }}
 # See LICENSE file for licensing details.
+
+# For a complete list of supported options, see:
+# https://discourse.charmhub.io/t/charm-metadata-v2/3674/15
 name: {{ name }}
 display-name: |
   TEMPLATE-TODO: fill out a display name for the Charmcraft store
@@ -7,19 +10,6 @@ description: |
   TEMPLATE-TODO: fill out the charm's description
 summary: |
   TEMPLATE-TODO: fill out the charm's summary
-tags: |
-  TEMPLATE-TODO: fill out the tags your charm will present
-
-# TEMPLATE-TODO: replace with any services your charm provides to other charms and the interfaces it presents them on
-provides:
-  some_functionality:
-    interface: some_interface
-
-# TEMPLATE-TODO: replace with any services your charm requires from other charms and the interfaces it finds them on
-requires:
-  some_functionality:
-    interface: some_interface
-    limit: 1
 
 # TEMPLATE-TODO: replace with containers for your workload (delete for non-k8s)
 containers:

--- a/charmcraft/templates/init/metadata.yaml.j2
+++ b/charmcraft/templates/init/metadata.yaml.j2
@@ -1,10 +1,25 @@
 # Copyright {{ year }} {{ author }}
 # See LICENSE file for licensing details.
 name: {{ name }}
+display-name: |
+  TEMPLATE-TODO: fill out a display name for the Charmcraft store
 description: |
   TEMPLATE-TODO: fill out the charm's description
 summary: |
   TEMPLATE-TODO: fill out the charm's summary
+tags: |
+  TEMPLATE-TODO: fill out the tags your charm will present
+
+# TEMPLATE-TODO: replace with any services your charm provides to other charms and the interfaces it presents them on
+provides:
+  some_functionality:
+    interface: some_interface
+
+# TEMPLATE-TODO: replace with any services your charm requires from other charms and the interfaces it finds them on
+requires:
+  some_functionality:
+    interface: some_interface
+    limit: 1
 
 # TEMPLATE-TODO: replace with containers for your workload (delete for non-k8s)
 containers:
@@ -16,4 +31,3 @@ resources:
   httpbin-image:
     type: oci-image
     description: OCI image for httpbin (kennethreitz/httpbin)
-

--- a/tests/commands/test_init.py
+++ b/tests/commands/test_init.py
@@ -58,6 +58,7 @@ def test_all_the_files(tmp_path, config):
         ".flake8",
         ".gitignore",
         ".jujuignore",
+        "CONTRIBUTING.md",
         "LICENSE",
         "README.md",
         "actions.yaml",


### PR DESCRIPTION
Include examples of more relation possibilities in `metadata.yaml`, and avoid using hyphens for them in favor of underscores. Also add `display_name`

Split developer contributing instructions to a separate document so the published README doesn't have them.

Also, update the README for charmcraft itself so contributors don't have to read the source to find out why `python -m charmcraft` doesn't actually work when cloned from git