### PR TITLE
config: default path to /root/project when in managed mode (CRAFT-300)

### DIFF
--- a/charmcraft/config.py
+++ b/charmcraft/config.py
@@ -63,6 +63,7 @@ import pydantic
 
 from charmcraft.cmdbase import CommandError
 from charmcraft.deprecations import notify_deprecation
+from charmcraft.env import is_charmcraft_running_in_managed_mode, get_managed_environment_project_path
 from charmcraft.utils import get_host_architecture, load_yaml
 
 
@@ -349,7 +350,10 @@ class Config(ModelConfigDefaults, validate_all=False):
 def load(dirpath):
     """Load the config from charmcraft.yaml in the indicated directory."""
     if dirpath is None:
-        dirpath = pathlib.Path.cwd()
+        if is_charmcraft_running_in_managed_mode():
+            dirpath = get_managed_environment_project_path()
+        else:
+            dirpath = pathlib.Path.cwd()
     else:
         dirpath = pathlib.Path(dirpath).expanduser().resolve()
 

--- a/charmcraft/config.py
+++ b/charmcraft/config.py
@@ -63,7 +63,10 @@ import pydantic
 
 from charmcraft.cmdbase import CommandError
 from charmcraft.deprecations import notify_deprecation
-from charmcraft.env import is_charmcraft_running_in_managed_mode, get_managed_environment_project_path
+from charmcraft.env import (
+    get_managed_environment_project_path,
+    is_charmcraft_running_in_managed_mode,
+)
 from charmcraft.utils import get_host_architecture, load_yaml
 
 

--- a/charmcraft/config.py
+++ b/charmcraft/config.py
@@ -377,6 +377,7 @@ def load(dirpath):
     if any("_" in x for x in content.get("charmhub", {}).keys()):
         # underscores in config attribs deprecated on 2021-05-31
         notify_deprecation("dn01")
+
     return Config.unmarshal(
         content,
         project=Project(

--- a/charmcraft/env.py
+++ b/charmcraft/env.py
@@ -19,9 +19,15 @@
 
 import distutils.util
 import os
+import pathlib
 import sys
 
 from charmcraft.cmdbase import CommandError
+
+
+def get_managed_environment_project_path():
+    """Path for project when running in managed environment."""
+    return pathlib.Path("/root/project")
 
 
 def is_charmcraft_running_from_snap():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -17,19 +17,14 @@
 import datetime
 import logging
 import os
+import pathlib
 from textwrap import dedent
 from unittest.mock import patch
 
 import pytest
 
 from charmcraft.cmdbase import CommandError
-from charmcraft.config import (
-    Base,
-    BasesConfiguration,
-    CharmhubConfig,
-    Part,
-    load,
-)
+from charmcraft.config import Base, BasesConfiguration, CharmhubConfig, Part, load
 from charmcraft.utils import get_host_architecture
 
 
@@ -64,6 +59,20 @@ def test_load_current_directory(create_config, monkeypatch):
     assert config.project.dirpath == tmp_path
     assert config.project.config_provided
     assert config.project.started_at == fake_utcnow
+
+
+def test_load_managed_mode_directory(create_config, monkeypatch, tmp_path):
+    """Validate managed-mode default directory is /root/project."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("CHARMCRAFT_MANAGED_MODE", "1")
+
+    # Patch out Config (and Project) to prevent directory validation checks.
+    with patch("charmcraft.config.Config"):
+        with patch("charmcraft.config.Project") as mock_project:
+            with patch("charmcraft.config.load_yaml"):
+                load(None)
+
+    assert mock_project.call_args.kwargs["dirpath"] == pathlib.Path("/root/project")
 
 
 def test_load_specific_directory_ok(create_config):

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -14,12 +14,19 @@
 #
 # For further info, check https://github.com/canonical/charmcraft
 
+import pathlib
 import sys
 
 import pytest
 
 from charmcraft import env
 from charmcraft.cmdbase import CommandError
+
+
+def test_get_managed_environment_project_path():
+    dirpath = env.get_managed_environment_project_path()
+
+    assert dirpath == pathlib.Path("/root/project")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Add get_managed_environment_project_path() to get managed directory
path.  When in managed-mode, default to it.  Note that it could still
be overwritten by using --project-dir.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>