### PR TITLE
providers: introduce charmcraft base configuration (CRAFT-261)

### DIFF
--- a/charmcraft/providers.py
+++ b/charmcraft/providers.py
@@ -1,0 +1,122 @@
+# Copyright 2021 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For further info, check https://github.com/canonical/charmcraft
+
+"""Build environment provider support for charmcraft."""
+
+import logging
+import subprocess
+from typing import Optional
+
+from craft_providers import Executor, bases
+from craft_providers.actions import snap_installer
+
+logger = logging.getLogger(__name__)
+
+
+class CharmcraftBuilddBaseConfiguration(bases.BuilddBase):
+    """Base configuration for Charmcraft.
+
+    :cvar compatibility_tag: Tag/Version for variant of build configuration and
+        setup.  Any change to this version would indicate that prior [versioned]
+        instances are incompatible and must be cleaned.  As such, any new value
+        should be unique to old values (e.g. incrementing).
+    :cvar instance_config_path: Path to persistent environment configuration
+        used for compatibility checks (or other data).  Set to
+        /etc/craft-instance.conf, but may be overridden for application-specific
+        reasons.
+    :cvar instance_config_class: Class defining instance configuration.  May be
+        overridden with an application-specific subclass of InstanceConfiguration
+        to enable application-specific extensions.
+
+    :param alias: Base alias / version.
+    :param environment: Environment to set in /etc/environment.
+    :param hostname: Hostname to configure.
+    """
+
+    compatibility_tag: str = f"charmcraft-{bases.BuilddBase.compatibility_tag}.0"
+
+    def setup(
+        self,
+        *,
+        executor: Executor,
+        retry_wait: float = 0.25,
+        timeout: Optional[float] = None,
+    ) -> None:
+        """Prepare base instance for use by the application.
+
+        Wait for environment to become ready and configure it.  At completion of
+        setup, the executor environment should have networking up and have all
+        of the installed dependencies required for subsequent use by the
+        application.
+
+        Setup may be called more than once in a given instance to refresh/update
+        the environment.
+
+        If timeout is specified, abort operation if time has been exceeded.
+
+        Guarantees provided by buildd's setup:
+
+            - configured /etc/environment
+
+            - configured hostname
+
+            - networking available (IP & DNS resolution)
+
+            - apt cache up-to-date
+
+            - snapd configured and ready
+
+            - system services are started and ready
+
+        Additional guarantees provided by Charmcraft's setup:
+
+            - charmcraft installed
+
+        :param executor: Executor for target container.
+        :param retry_wait: Duration to sleep() between status checks (if
+            required).
+        :param timeout: Timeout in seconds.
+
+        :raises BaseCompatibilityError: if instance is incompatible.
+        :raises BaseConfigurationError: on other unexpected error.
+        """
+        super().setup(executor=executor, retry_wait=retry_wait, timeout=timeout)
+
+        try:
+            executor.execute_run(
+                [
+                    "apt-get",
+                    "install",
+                    "-y",
+                    "python3-pip",
+                    "python3-setuptools",
+                ],
+                check=True,
+                capture_output=True,
+            )
+        except subprocess.CalledProcessError as error:
+            raise bases.BaseConfigurationError(
+                brief="Failed to install python3-pip and python3-setuptools.",
+            ) from error
+
+        try:
+            snap_installer.inject_from_host(
+                executor=executor, snap_name="charmcraft", classic=True
+            )
+        except snap_installer.SnapInstallationError as error:
+            raise bases.BaseConfigurationError(
+                brief="Failed to inject host Charmcraft snap into target environment.",
+            ) from error

--- a/charmcraft/providers.py
+++ b/charmcraft/providers.py
@@ -32,18 +32,9 @@ class CharmcraftBuilddBaseConfiguration(bases.BuilddBase):
     :cvar compatibility_tag: Tag/Version for variant of build configuration and
         setup.  Any change to this version would indicate that prior [versioned]
         instances are incompatible and must be cleaned.  As such, any new value
-        should be unique to old values (e.g. incrementing).
-    :cvar instance_config_path: Path to persistent environment configuration
-        used for compatibility checks (or other data).  Set to
-        /etc/craft-instance.conf, but may be overridden for application-specific
-        reasons.
-    :cvar instance_config_class: Class defining instance configuration.  May be
-        overridden with an application-specific subclass of InstanceConfiguration
-        to enable application-specific extensions.
-
-    :param alias: Base alias / version.
-    :param environment: Environment to set in /etc/environment.
-    :param hostname: Hostname to configure.
+        should be unique to old values (e.g. incrementing).  Charmcraft extends
+        the buildd tag to include its own version indicator (.0) and namespace
+        ("charmcraft").
     """
 
     compatibility_tag: str = f"charmcraft-{bases.BuilddBase.compatibility_tag}.0"
@@ -57,31 +48,7 @@ class CharmcraftBuilddBaseConfiguration(bases.BuilddBase):
     ) -> None:
         """Prepare base instance for use by the application.
 
-        Wait for environment to become ready and configure it.  At completion of
-        setup, the executor environment should have networking up and have all
-        of the installed dependencies required for subsequent use by the
-        application.
-
-        Setup may be called more than once in a given instance to refresh/update
-        the environment.
-
-        If timeout is specified, abort operation if time has been exceeded.
-
-        Guarantees provided by buildd's setup:
-
-            - configured /etc/environment
-
-            - configured hostname
-
-            - networking available (IP & DNS resolution)
-
-            - apt cache up-to-date
-
-            - snapd configured and ready
-
-            - system services are started and ready
-
-        Additional guarantees provided by Charmcraft's setup:
+        In addition to the guarantees provided by buildd:
 
             - charmcraft installed
 

--- a/charmcraft/providers.py
+++ b/charmcraft/providers.py
@@ -85,6 +85,8 @@ class CharmcraftBuilddBaseConfiguration(bases.BuilddBase):
 
             - charmcraft installed
 
+            - python3 pip and setuptools installed
+
         :param executor: Executor for target container.
         :param retry_wait: Duration to sleep() between status checks (if
             required).

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ cffi==1.14.5
 chardet==4.0.0
 click==8.0.1
 coverage==5.5
-craft-providers==0.0.1
+craft-providers==0.0.2
 flake8==3.9.2
 humanize==3.9.0
 idna==2.10

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,6 +6,7 @@ cffi==1.14.5
 chardet==4.0.0
 click==8.0.1
 coverage==5.5
+craft-providers==0.0.1
 flake8==3.9.2
 humanize==3.9.0
 idna==2.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ attrs==21.2.0
 certifi==2021.5.30
 cffi==1.14.5
 chardet==4.0.0
+craft-providers==0.0.1
 humanize==3.9.0
 idna==2.10
 Jinja2==3.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ attrs==21.2.0
 certifi==2021.5.30
 cffi==1.14.5
 chardet==4.0.0
-craft-providers==0.0.1
+craft-providers==0.0.2
 humanize==3.9.0
 idna==2.10
 Jinja2==3.0.1

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ with open("README.md", "rt", encoding="utf8") as fh:
 install_requires = [
     "appdirs",
     "attrs",
+    "craft-providers",
     "humanize>=2.6.0",
     "jsonschema",
     "jinja2",

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -135,6 +135,8 @@ parts:
       - pyvenv.cfg
       - lib/charmcraft
       - lib/charmcraft-*.egg-info
+      - lib/craft_providers
+      - lib/craft_providers-*.egg-info
       - lib/pip
       - lib/pip-*.dist-info
       - lib/wheel

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,0 +1,100 @@
+# Copyright 2021 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For further info, check https://github.com/canonical/charmcraft
+
+import subprocess
+from unittest import mock
+from unittest.mock import call
+
+import pytest
+from craft_providers import Executor, bases
+from craft_providers.actions import snap_installer
+
+from charmcraft import providers
+
+
+@pytest.fixture(autouse=True)
+def bypass_buildd_base_setup(monkeypatch):
+    """Patch out inherited setup steps."""
+    monkeypatch.setattr(bases.BuilddBase, "setup", lambda *args, **kwargs: None)
+
+
+@pytest.fixture
+def mock_executor():
+    yield mock.Mock(spec=Executor)
+
+
+@pytest.fixture
+def mock_inject():
+    with mock.patch(
+        "craft_providers.actions.snap_installer.inject_from_host"
+    ) as mock_inject:
+        yield mock_inject
+
+
+@pytest.mark.parametrize(
+    "alias", [bases.BuilddBaseAlias.BIONIC, bases.BuilddBaseAlias.FOCAL]
+)
+def test_base_configuration_setup(mock_executor, mock_inject, monkeypatch, alias):
+
+    config = providers.CharmcraftBuilddBaseConfiguration(alias=alias)
+    config.setup(executor=mock_executor)
+
+    assert mock_executor.mock_calls == [
+        call.execute_run(
+            ["apt-get", "install", "-y", "python3-pip", "python3-setuptools"],
+            check=True,
+            capture_output=True,
+        ),
+    ]
+
+    assert mock_inject.mock_calls == [
+        call(executor=mock_executor, snap_name="charmcraft", classic=True)
+    ]
+
+
+def test_base_configuration_setup_apt_error(mock_executor):
+    alias = bases.BuilddBaseAlias.FOCAL
+    apt_cmd = ["apt-get", "install", "-y", "python3-pip", "python3-setuptools"]
+    mock_executor.execute_run.side_effect = subprocess.CalledProcessError(
+        -1,
+        apt_cmd,
+        "some output",
+        "some error",
+    )
+
+    config = providers.CharmcraftBuilddBaseConfiguration(alias=alias)
+
+    with pytest.raises(
+        bases.BaseConfigurationError,
+        match=r"Failed to install python3-pip and python3-setuptools.",
+    ) as exc_info:
+        config.setup(executor=mock_executor)
+
+    assert exc_info.value.__cause__ is not None
+
+
+def test_base_configuration_setup_snap_injection_error(mock_executor, mock_inject):
+    alias = bases.BuilddBaseAlias.FOCAL
+    config = providers.CharmcraftBuilddBaseConfiguration(alias=alias)
+    mock_inject.side_effect = snap_installer.SnapInstallationError(brief="foo error")
+
+    with pytest.raises(
+        bases.BaseConfigurationError,
+        match=r"Failed to inject host Charmcraft snap into target environment.",
+    ) as exc_info:
+        config.setup(executor=mock_executor)
+
+    assert exc_info.value.__cause__ is not None

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -64,6 +64,8 @@ def test_base_configuration_setup(mock_executor, mock_inject, monkeypatch, alias
         call(executor=mock_executor, snap_name="charmcraft", classic=True)
     ]
 
+    assert config.compatibility_tag == "charmcraft-buildd-base-v0.0"
+
 
 def test_base_configuration_setup_apt_error(mock_executor):
     alias = bases.BuilddBaseAlias.FOCAL


### PR DESCRIPTION
- Add craft-providers dependency (version will be updated in
  future work) to project & snap.

- Add CharmcraftBuilddBaseConfiguration which extends the buildd
  image configuration with the setup code to:

  - install python3-pip

  - install python3-setuptools (required explicitly for 18.04)

  - install the Charmcraft snap by injecting the host's, which
    should be OK as the snap is currently required.  Future work
    could extend this to add a fallback to install from store using
    snap_installer.install_from_store().  Note that this injection
    is unconditional, future work will add a check to see if the
    injection is necessary prior to doing it (that is, don't inject
    if reusing an instance that has the correct version already).

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>