### PR TITLE
providers: constrain buildable environments (CRAFT-263)

### DIFF
--- a/charmcraft/providers.py
+++ b/charmcraft/providers.py
@@ -18,12 +18,50 @@
 
 import logging
 import subprocess
-from typing import Optional
+from typing import Optional, Tuple, Union
 
 from craft_providers import Executor, bases
 from craft_providers.actions import snap_installer
 
+from charmcraft.config import Base
+from charmcraft.utils import get_host_architecture
+
 logger = logging.getLogger(__name__)
+
+BASE_CHANNEL_TO_BUILDD_IMAGE_ALIAS = {
+    "18.04": bases.BuilddBaseAlias.BIONIC,
+    "20.04": bases.BuilddBaseAlias.FOCAL,
+}
+
+
+def is_base_providable(base: Base) -> Tuple[bool, Union[str, None]]:
+    """Check if provider can provide an environment matching given base.
+
+    :param base: Base to check.
+
+    :returns: Tuple of bool indicating whether it is a match, with optional
+              reason if not a match.
+    """
+    host_arch = get_host_architecture()
+    if host_arch not in base.architectures:
+        return (
+            False,
+            f"host architecture {host_arch!r} not in base architectures {base.architectures!r}",
+        )
+
+    if base.name != "ubuntu":
+        return (
+            False,
+            f"name {base.name!r} is not yet supported (must be 'ubuntu')",
+        )
+
+    if base.channel not in BASE_CHANNEL_TO_BUILDD_IMAGE_ALIAS.keys():
+        return (
+            False,
+            f"channel {base.channel!r} is not yet supported (must be '18.04' or '20.04')",
+        )
+
+    return True, None
 
 
 class CharmcraftBuilddBaseConfiguration(bases.BuilddBase):

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -23,6 +23,7 @@ from craft_providers import Executor, bases
 from craft_providers.actions import snap_installer
 
 from charmcraft import providers
+from charmcraft.config import Base
 
 
 @pytest.fixture(autouse=True)
@@ -100,3 +101,43 @@ def test_base_configuration_setup_snap_injection_error(mock_executor, mock_injec
         config.setup(executor=mock_executor)
 
     assert exc_info.value.__cause__ is not None
+
+
+@pytest.mark.parametrize(
+    "name,channel,architectures,expected_valid,expected_reason",
+    [
+        ("ubuntu", "18.04", ["host-arch"], True, None),
+        ("ubuntu", "20.04", ["host-arch"], True, None),
+        ("ubuntu", "20.04", ["extra-arch", "host-arch"], True, None),
+        (
+            "not-ubuntu",
+            "20.04",
+            ["host-arch"],
+            False,
+            "name 'not-ubuntu' is not yet supported (must be 'ubuntu')",
+        ),
+        (
+            "ubuntu",
+            "10.04",
+            ["host-arch"],
+            False,
+            "channel '10.04' is not yet supported (must be '18.04' or '20.04')",
+        ),
+        (
+            "ubuntu",
+            "20.04",
+            ["other-arch"],
+            False,
+            "host architecture 'host-arch' not in base architectures ['other-arch']",
+        ),
+    ],
+)
+def test_is_base_providable(
+    monkeypatch, name, channel, architectures, expected_valid, expected_reason
+):
+    monkeypatch.setattr(providers, "get_host_architecture", lambda: "host-arch")
+    base = Base(name=name, channel=channel, architectures=architectures)
+
+    valid, reason = providers.is_base_providable(base)
+
+    assert (valid, reason) == (expected_valid, expected_reason)


### PR DESCRIPTION
Initial support for provided environments includes:
- Ubuntu 18.04
- Ubuntu 20.04

The host architecture must be included in the base's architectures,
which may change in the future when LXD clusters are supported with
multiple architectures.

Add is_base_providable() interface to perform this check and add
BASE_CHANNEL_TO_BUILDD_IMAGE_ALIAS to track supported channel ->
alias mappings.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>