### PR TITLE
providers: introduce get_command_environment() to build env (CRAFT-262)

### DIFF
--- a/charmcraft/providers.py
+++ b/charmcraft/providers.py
@@ -17,13 +17,27 @@
 """Build environment provider support for charmcraft."""
 
 import logging
+import os
 import subprocess
-from typing import Optional
+from typing import Dict, Optional
 
 from craft_providers import Executor, bases
 from craft_providers.actions import snap_installer
 
 logger = logging.getLogger(__name__)
+
+
+def get_command_environment() -> Dict[str, str]:
+    """Construct the required environment."""
+    env = bases.buildd.default_command_environment()
+    env["CHARMCRAFT_MANAGED_MODE"] = "1"
+
+    # Pass-through host environment that target may need.
+    for env_key in ["http_proxy", "https_proxy", "no_proxy"]:
+        if env_key in os.environ:
+            env[env_key] = os.environ[env_key]
+
+    return env
 
 
 class CharmcraftBuilddBaseConfiguration(bases.BuilddBase):

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -115,7 +115,8 @@ def test_base_configuration_setup_snap_injection_error(mock_executor, mock_injec
 
 
 def test_get_command_environment_minimal(monkeypatch):
-    monkeypatch.setattr(os, "environ", {})
+    monkeypatch.setenv("IGNORE_ME", "or-im-failing")
+    monkeypatch.setenv("PATH", "not-using-host-path")
 
     env = providers.get_command_environment()
 
@@ -126,8 +127,8 @@ def test_get_command_environment_minimal(monkeypatch):
 
 
 def test_get_command_environment_all_opts(monkeypatch):
-    monkeypatch.setattr(os, "environ", {})
-
+    monkeypatch.setenv("IGNORE_ME", "or-im-failing")
+    monkeypatch.setenv("PATH", "not-using-host-path")
     monkeypatch.setenv("http_proxy", "test-http-proxy")
     monkeypatch.setenv("https_proxy", "test-https-proxy")
     monkeypatch.setenv("no_proxy", "test-no-proxy")


### PR DESCRIPTION
Add get_command_environment() method to build and return the command
environment to use when executing commands in the provided container.

Starting with the default buildd environment, add:

- CHARMCRAFT_MANAGED_MODE=1

- [http|https|no]_proxy settings if found in current Charmcraft process.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>