### PR TITLE
metadata: refactor parsing into own module (CRAFT-311)

### DIFF
--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -23,9 +23,7 @@ import pathlib
 import shutil
 import subprocess
 import zipfile
-from typing import Any, Dict, List, Optional
-
-import yaml
+from typing import List, Optional
 
 from charmcraft.bases import check_if_base_matches_host
 from charmcraft.cmdbase import BaseCommand, CommandError
@@ -33,12 +31,12 @@ from charmcraft.config import Base, BasesConfiguration, Config
 from charmcraft.env import is_charmcraft_running_in_managed_mode
 from charmcraft.jujuignore import JujuIgnore, default_juju_ignore
 from charmcraft.manifest import create_manifest
+from charmcraft.metadata import parse_metadata_yaml
 from charmcraft.utils import make_executable
 
 logger = logging.getLogger(__name__)
 
 # Some constants that are used through the code.
-CHARM_METADATA = "metadata.yaml"
 BUILD_DIRNAME = "build"
 VENV_DIRNAME = "venv"
 
@@ -139,7 +137,7 @@ class Builder:
         self.buildpath = self.charmdir / BUILD_DIRNAME
         self.ignore_rules = self._load_juju_ignore()
         self.config = config
-        self.metadata = self.parse_metadata()
+        self.metadata = parse_metadata_yaml(self.charmdir)
 
     def build_charm(self, bases_config: Optional[BasesConfiguration]) -> str:
         """Build the charm.
@@ -391,7 +389,7 @@ class Builder:
     def handle_package(self, bases_config: Optional[BasesConfiguration] = None):
         """Handle the final package creation."""
         logger.debug("Creating the package itself")
-        zipname = format_charm_file_name(self.metadata["name"], bases_config)
+        zipname = format_charm_file_name(self.metadata.name, bases_config)
         zipfh = zipfile.ZipFile(zipname, "w", zipfile.ZIP_DEFLATED)
         for dirpath, dirnames, filenames in os.walk(self.buildpath, followlinks=True):
             dirpath = pathlib.Path(dirpath)
@@ -401,19 +399,6 @@ class Builder:
 
         zipfh.close()
         return zipname
-
-    def parse_metadata(self) -> Dict[str, Any]:
-        """Parse project's metadata.yaml.
-
-        :returns: Metadata dictionary object, if it exists.
-        """
-        logger.debug("Parsing the project's metadata")
-        metadata_path = self.charmdir / CHARM_METADATA
-        if not metadata_path.exists():
-            raise CommandError("Missing mandatory metadata.yaml.")
-
-        with metadata_path.open("rt", encoding="utf8") as fh:
-            return yaml.safe_load(fh)
 
 
 class Validator:

--- a/charmcraft/config.py
+++ b/charmcraft/config.py
@@ -155,7 +155,7 @@ def printable_field_location_split(location: str) -> Tuple[str, str]:
     return field_name, "top-level"
 
 
-def format_pydantic_errors(errors):
+def format_pydantic_errors(errors, *, file_name: str = "charmcraft.yaml"):
     """Format errors.
 
     Example 1: Single error.
@@ -172,7 +172,7 @@ def format_pydantic_errors(errors):
     - field: <some field 2>
       reason: <some reason 2>
     """
-    combined = ["Bad charmcraft.yaml content:"]
+    combined = [f"Bad {file_name} content:"]
     for error in errors:
         formatted_loc = format_pydantic_error_location(error["loc"])
         formatted_msg = format_pydantic_error_message(error["msg"])

--- a/charmcraft/metadata.py
+++ b/charmcraft/metadata.py
@@ -24,14 +24,14 @@ import pydantic
 import yaml
 
 from charmcraft.cmdbase import CommandError
-from charmcraft.config import ModelConfigDefaults, format_pydantic_errors
+from charmcraft.config import format_pydantic_errors
 
 logger = logging.getLogger(__name__)
 
 CHARM_METADATA = "metadata.yaml"
 
 
-class CharmMetadata(ModelConfigDefaults):
+class CharmMetadata(pydantic.BaseModel, frozen=True, validate_all=True):
     """Object representing metadata.yaml contents."""
 
     name: pydantic.StrictStr

--- a/charmcraft/metadata.py
+++ b/charmcraft/metadata.py
@@ -1,0 +1,68 @@
+# Copyright 2020-2021 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For further info, check https://github.com/canonical/charmcraft
+
+"""Logic related to metadata.yaml."""
+
+import logging
+import pathlib
+from typing import Any, Dict
+
+import pydantic
+import yaml
+
+from charmcraft.cmdbase import CommandError
+from charmcraft.config import ModelConfigDefaults, format_pydantic_errors
+
+logger = logging.getLogger(__name__)
+
+CHARM_METADATA = "metadata.yaml"
+
+
+class CharmMetadata(ModelConfigDefaults):
+    """Object representing metadata.yaml contents."""
+
+    name: pydantic.StrictStr
+
+    @classmethod
+    def unmarshal(cls, obj: Dict[str, Any]):
+        """Unmarshal object with necessary translations and error handling.
+
+        :returns: valid CharmMetadata.
+
+        :raises CommandError: On failure to unmarshal object.
+        """
+        try:
+            return cls.parse_obj(obj)
+        except pydantic.error_wrappers.ValidationError as error:
+            raise CommandError(
+                format_pydantic_errors(error.errors(), file_name=CHARM_METADATA)
+            )
+
+
+def parse_metadata_yaml(charm_dir: pathlib.Path) -> Dict[str, Any]:
+    """Parse project's metadata.yaml.
+
+    :returns: Metadata dictionary object, if it exists.
+    """
+    metadata_path = charm_dir / CHARM_METADATA
+    logger.debug("Parsing %r", str(metadata_path))
+
+    if not metadata_path.exists():
+        raise CommandError("Missing mandatory metadata.yaml.")
+
+    with metadata_path.open("rt", encoding="utf8") as fh:
+        metadata = yaml.safe_load(fh)
+        return CharmMetadata.unmarshal(metadata)

--- a/tests/commands/test_build.py
+++ b/tests/commands/test_build.py
@@ -35,7 +35,6 @@ from charmcraft.bases import get_host_as_base
 from charmcraft.cmdbase import CommandError
 from charmcraft.commands.build import (
     BUILD_DIRNAME,
-    CHARM_METADATA,
     DISPATCH_CONTENT,
     DISPATCH_FILENAME,
     VENV_DIRNAME,
@@ -46,6 +45,7 @@ from charmcraft.commands.build import (
     relativise,
 )
 from charmcraft.config import Base, BasesConfiguration, load
+from charmcraft.metadata import CHARM_METADATA
 
 
 @pytest.fixture

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,0 +1,52 @@
+# Copyright 2020-2021 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For further info, check https://github.com/canonical/charmcraft
+
+import re
+from textwrap import dedent
+
+import pytest
+
+from charmcraft.cmdbase import CommandError
+from charmcraft.metadata import parse_metadata_yaml
+
+
+@pytest.mark.parametrize("name", ["name1", "my-charm-foo"])
+def test_parse_metadata_yaml_valid_names(tmp_path, name):
+    metadata_file = tmp_path / "metadata.yaml"
+    metadata_file.write_text(f"name: {name}")
+
+    metadata = parse_metadata_yaml(tmp_path)
+
+    assert metadata.name == name
+
+
+@pytest.mark.parametrize("name", [1, "false", "[]"])
+def test_parse_metadata_yaml_error_invalid_names(tmp_path, name):
+    metadata_file = tmp_path / "metadata.yaml"
+    metadata_file.write_text(f"name: {name}")
+
+    expected_error_msg = dedent(
+        """\
+        Bad metadata.yaml content:
+        - string type expected in field 'name'"""
+    )
+    with pytest.raises(CommandError, match=re.escape(expected_error_msg)):
+        parse_metadata_yaml(tmp_path)
+
+
+def test_parse_metadata_yaml_error_missing(tmp_path):
+    with pytest.raises(CommandError, match=r"Missing mandatory metadata.yaml."):
+        parse_metadata_yaml(tmp_path)


### PR DESCRIPTION
Move metadata logic into its own module, migrating to pydantic
and re-using bits found for charmcraft.yaml config parser.

This will allow for re-use of metadata for commands other than
build/pack.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>