### PR TITLE
providers: introduce launch_environment() (CRAFT-312)

### DIFF
--- a/charmcraft/providers.py
+++ b/charmcraft/providers.py
@@ -110,7 +110,7 @@ def get_command_environment() -> Dict[str, str]:
 
 
 @contextlib.contextmanager
-def launch_environment(
+def launched_environment(
     *,
     charm_name: str,
     project_path: pathlib.Path,

--- a/charmcraft/providers.py
+++ b/charmcraft/providers.py
@@ -16,15 +16,19 @@
 
 """Build environment provider support for charmcraft."""
 
+import contextlib
 import logging
 import os
+import pathlib
 import subprocess
 from typing import Dict, Optional, Tuple, Union
 
-from craft_providers import Executor, bases
+from craft_providers import Executor, bases, lxd
 from craft_providers.actions import snap_installer
+from craft_providers.lxd.remotes import configure_buildd_image_remote
 
 from charmcraft.config import Base
+from charmcraft.env import get_managed_environment_project_path
 from charmcraft.utils import get_host_architecture
 
 logger = logging.getLogger(__name__)
@@ -103,6 +107,66 @@ def get_command_environment() -> Dict[str, str]:
             env[env_key] = os.environ[env_key]
 
     return env
+
+
+@contextlib.contextmanager
+def launch_environment(
+    *,
+    charm_name: str,
+    project_path: pathlib.Path,
+    base: Base,
+    bases_index: int,
+    build_on_index: int,
+    lxd_project: str = "charmcraft",
+    lxd_remote: str = "local",
+):
+    """Launch environment for specified base.
+
+    :param charm_name: Name of project.
+    :param project_path: Path to project.
+    :param base: Base to create.
+    :param bases_index: Index of `bases:` entry.
+    :param build_on_index: Index of `build-on` within bases entry.
+    """
+    alias = BASE_CHANNEL_TO_BUILDD_IMAGE_ALIAS[base.channel]
+    target_arch = get_host_architecture()
+
+    instance_name = get_instance_name(
+        bases_index=bases_index,
+        build_on_index=build_on_index,
+        project_name=charm_name,
+        target_arch=target_arch,
+    )
+
+    environment = get_command_environment()
+    image_remote = configure_buildd_image_remote()
+    base_configuration = CharmcraftBuilddBaseConfiguration(
+        alias=alias, environment=environment, hostname=instance_name
+    )
+    instance = lxd.launch(
+        name=instance_name,
+        base_configuration=base_configuration,
+        image_name=base.channel,
+        image_remote=image_remote,
+        auto_clean=True,
+        auto_create_project=True,
+        map_user_uid=True,
+        use_snapshots=True,
+        project=lxd_project,
+        remote=lxd_remote,
+    )
+
+    # Mount project.
+    instance.mount(
+        host_source=project_path, target=get_managed_environment_project_path()
+    )
+
+    yield instance
+
+    # Unmount everything.
+    instance.unmount_all()
+
+    instance.stop()
 
 
 class CharmcraftBuilddBaseConfiguration(bases.BuilddBase):

--- a/charmcraft/providers.py
+++ b/charmcraft/providers.py
@@ -161,12 +161,12 @@ def launched_environment(
         host_source=project_path, target=get_managed_environment_project_path()
     )
 
-    yield instance
-
-    # Unmount everything.
-    instance.unmount_all()
-
-    instance.stop()
+    try:
+        yield instance
+    finally:
+        # Ensure to unmount everything and stop instance upon completion.
+        instance.unmount_all()
+        instance.stop()
 
 
 class CharmcraftBuilddBaseConfiguration(bases.BuilddBase):

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -226,7 +226,7 @@ def test_is_base_providable(
     "channel,alias",
     [("18.04", bases.BuilddBaseAlias.BIONIC), ("20.04", bases.BuilddBaseAlias.FOCAL)],
 )
-def test_launch_environment(
+def test_launched_environment(
     channel, alias, mock_configure_buildd_image_remote, mock_lxd, monkeypatch, tmp_path
 ):
     expected_environment = {
@@ -240,7 +240,7 @@ def test_launch_environment(
     with mock.patch(
         "charmcraft.providers.CharmcraftBuilddBaseConfiguration"
     ) as mock_base_config:
-        with providers.launch_environment(
+        with providers.launched_environment(
             charm_name="test-charm",
             project_path=tmp_path,
             base=base,

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -15,6 +15,7 @@
 # For further info, check https://github.com/canonical/charmcraft
 
 import os
+import pathlib
 import subprocess
 from unittest import mock
 from unittest.mock import call
@@ -31,6 +32,15 @@ from charmcraft.config import Base
 def bypass_buildd_base_setup(monkeypatch):
     """Patch out inherited setup steps."""
     monkeypatch.setattr(bases.BuilddBase, "setup", lambda *args, **kwargs: None)
+
+
+@pytest.fixture()
+def mock_configure_buildd_image_remote():
+    with mock.patch(
+        "charmcraft.providers.configure_buildd_image_remote",
+        return_value="buildd-remote",
+    ) as mock_remote:
+        yield mock_remote
 
 
 @pytest.fixture
@@ -210,3 +220,65 @@ def test_is_base_providable(
     valid, reason = providers.is_base_providable(base)
 
     assert (valid, reason) == (expected_valid, expected_reason)
+
+
+@pytest.mark.parametrize(
+    "channel,alias",
+    [("18.04", bases.BuilddBaseAlias.BIONIC), ("20.04", bases.BuilddBaseAlias.FOCAL)],
+)
+def test_launch_environment(
+    channel, alias, mock_configure_buildd_image_remote, mock_lxd, monkeypatch, tmp_path
+):
+    expected_environment = {
+        "CHARMCRAFT_MANAGED_MODE": "1",
+        "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin",
+    }
+
+    monkeypatch.setattr(providers, "get_host_architecture", lambda: "host-arch")
+    base = Base(name="ubuntu", channel=channel, architectures=["host-arch"])
+
+    with mock.patch(
+        "charmcraft.providers.CharmcraftBuilddBaseConfiguration"
+    ) as mock_base_config:
+        with providers.launch_environment(
+            charm_name="test-charm",
+            project_path=tmp_path,
+            base=base,
+            bases_index=1,
+            build_on_index=2,
+            lxd_project="charmcraft",
+            lxd_remote="local",
+        ) as instance:
+            assert instance is not None
+            assert mock_configure_buildd_image_remote.mock_calls == [mock.call()]
+            assert mock_lxd.mock_calls == [
+                mock.call.launch(
+                    name="charmcraft-test-charm-1-2-host-arch",
+                    base_configuration=mock_base_config.return_value,
+                    image_name=channel,
+                    image_remote="buildd-remote",
+                    auto_clean=True,
+                    auto_create_project=True,
+                    map_user_uid=True,
+                    use_snapshots=True,
+                    project="charmcraft",
+                    remote="local",
+                ),
+                mock.call.launch().mount(
+                    host_source=tmp_path, target=pathlib.Path("/root/project")
+                ),
+            ]
+            assert mock_base_config.mock_calls == [
+                call(
+                    alias=alias,
+                    environment=expected_environment,
+                    hostname="charmcraft-test-charm-1-2-host-arch",
+                )
+            ]
+
+            mock_lxd.reset_mock()
+
+        assert mock_lxd.mock_calls == [
+            mock.call.launch().unmount_all(),
+            mock.call.launch().stop(),
+        ]


### PR DESCRIPTION
Launch lxc container and configure for use with charmcraft,
adding/configuring the buildd remote as necessary.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>