### PR TITLE
build: pack charm in provided environment when using bases (CRAFT-313)

### DIFF
--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -214,7 +214,7 @@ class Builder:
                                 bases_index=bases_index,
                                 build_on_index=build_on_index,
                             ) as instance:
-                                charm_name = self.build_charm_in_instance(
+                                charm_name = self.pack_charm_in_instance(
                                     instance, bases_index
                                 )
 
@@ -244,7 +244,7 @@ class Builder:
 
         return charms
 
-    def build_charm_in_instance(self, instance: Executor, bases_index: int) -> str:
+    def pack_charm_in_instance(self, instance: Executor, bases_index: int) -> str:
         """Pack instance in Charm."""
         try:
             instance.execute_run(

--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -184,15 +184,15 @@ class Builder:
         charms: List[str] = []
 
         if self.config.bases:
-            for i, bases_config in enumerate(self.config.bases):
-                if bases_indices and i not in bases_indices:
+            for bases_index, bases_config in enumerate(self.config.bases):
+                if bases_indices and bases_index not in bases_indices:
                     logger.debug(
                         "Ingoring 'bases[%d]' due to --base-index usage.",
-                        i,
+                        bases_index,
                     )
                     continue
 
-                for j, build_on in enumerate(bases_config.build_on):
+                for build_on_index, build_on in enumerate(bases_config.build_on):
                     if is_charmcraft_running_in_managed_mode():
                         matches, reason = check_if_base_matches_host(build_on)
                     else:
@@ -201,8 +201,8 @@ class Builder:
                     if matches:
                         logger.debug(
                             "Building for 'bases[%d]' as host matches 'build-on[%d]'.",
-                            i,
-                            j,
+                            bases_index,
+                            build_on_index,
                         )
                         if is_charmcraft_running_in_managed_mode():
                             charm_name = self.build_charm(bases_config)
@@ -211,24 +211,26 @@ class Builder:
                                 charm_name=self.metadata.name,
                                 project_path=self.charmdir,
                                 base=build_on,
-                                bases_index=i,
-                                build_on_index=j,
+                                bases_index=bases_index,
+                                build_on_index=build_on_index,
                             ) as instance:
-                                charm_name = self.build_charm_in_instance(instance, i)
+                                charm_name = self.build_charm_in_instance(
+                                    instance, bases_index
+                                )
 
                         charms.append(charm_name)
                         break
                     else:
                         logger.debug(
                             "Host does not match 'bases[%d].build-on[%d]' (%s)",
-                            i,
-                            j,
+                            bases_index,
+                            build_on_index,
                             reason,
                         )
                 else:
                     logger.warning(
                         "No suitable 'build-on' environment found in 'bases[%d]' configuration.",
-                        i,
+                        bases_index,
                     )
 
             if not charms:


### PR DESCRIPTION
For each bases configuration, check if a build-on base can be
provided.  If so, launch environment and execute pack command
inside each to build charm for each viable bases config index.

Future work should extend the pack command to include the parent's
verbose or quiet mode flags for consistency.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>