### PR TITLE
clean: introduce clean command (CRAFT-62)

### DIFF
--- a/charmcraft/commands/clean.py
+++ b/charmcraft/commands/clean.py
@@ -1,0 +1,49 @@
+# Copyright 2021 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For further info, check https://github.com/canonical/charmcraft
+
+"""Infrastructure for the 'clean' command."""
+
+import logging
+
+from charmcraft.cmdbase import BaseCommand
+from charmcraft.metadata import parse_metadata_yaml
+from charmcraft.providers import clean_project_environments
+
+logger = logging.getLogger(__name__)
+
+_overview = """
+Purge Charmcraft project's artifacts, including:
+
+- LXD Containers created for building charm(s)
+"""
+
+
+class CleanCommand(BaseCommand):
+    """Clean project artifacts."""
+
+    name = "clean"
+    help_msg = "Purge project artifacts"
+    overview = _overview
+    common = True
+
+    def run(self, parsed_args):
+        """Run the command."""
+        metadata = parse_metadata_yaml(self.config.project.dirpath)
+        logger.debug("Cleaning project %r.", metadata.name)
+
+        clean_project_environments(metadata.name)
+
+        logger.info("Cleaned project %r.", metadata.name)

--- a/charmcraft/main.py
+++ b/charmcraft/main.py
@@ -21,9 +21,9 @@ import logging
 import sys
 from collections import namedtuple
 
-from charmcraft import helptexts, config, env
-from charmcraft.commands import version, build, store, init, pack
-from charmcraft.cmdbase import CommandError, BaseCommand
+from charmcraft import config, env, helptexts
+from charmcraft.cmdbase import BaseCommand, CommandError
+from charmcraft.commands import build, clean, init, pack, store, version
 from charmcraft.logsetup import message_handler
 
 logger = logging.getLogger(__name__)
@@ -95,6 +95,7 @@ COMMAND_GROUPS = [
         [
             HelpCommand,
             build.BuildCommand,
+            clean.CleanCommand,
             pack.PackCommand,
             init.InitCommand,
             version.VersionCommand,

--- a/completion.bash
+++ b/completion.bash
@@ -20,7 +20,8 @@ _charmcraft()
 {
     local cur prev words cword cmd cmds
     cmds=(
-        build 
+        build
+        clean
         create-lib 
         fetch-lib 
         help init 

--- a/tests/commands/test_clean.py
+++ b/tests/commands/test_clean.py
@@ -1,0 +1,50 @@
+# Copyright 2021 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For further info, check https://github.com/canonical/charmcraft
+
+import logging
+from unittest import mock
+
+import pytest
+
+from charmcraft.commands.clean import CleanCommand
+
+
+@pytest.fixture(autouse=True)
+def mock_clean_project_environments():
+    with mock.patch(
+        "charmcraft.commands.clean.clean_project_environments", return_value=[]
+    ) as mock_clean_project_environments:
+        yield mock_clean_project_environments
+
+
+def test_clean(
+    caplog, caplog_filter, config, mock_clean_project_environments, tmp_path
+):
+    logger_name = "charmcraft.commands.clean"
+    caplog.set_level(logging.DEBUG, logger=logger_name)
+
+    metadata_yaml = tmp_path / "metadata.yaml"
+    metadata_yaml.write_text("name: foo")
+
+    cmd = CleanCommand("group", "config")
+    cmd.config = config
+    cmd.run([])
+
+    assert caplog_filter(logger_name) == [
+        (logging.DEBUG, "Cleaning project 'foo'."),
+        (logging.INFO, "Cleaned project 'foo'."),
+    ]
+    assert mock_clean_project_environments.mock_calls == [mock.call("foo")]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,11 +16,22 @@
 
 import datetime
 import tempfile
+from typing import List, Tuple
 
 import pytest
 import responses as responses_module
 
 from charmcraft import config as config_module
+
+
+@pytest.fixture()
+def caplog_filter(caplog):
+    """Simplify log checking by filtering for desired module and return list of (lvl,msg)."""
+
+    def filter(logger_name) -> List[Tuple[int, str]]:
+        return [(r.levelno, r.message) for r in caplog.records if r.name == logger_name]
+
+    return filter
 
 
 @pytest.fixture(autouse=True, scope="session")


### PR DESCRIPTION
Initial usage will clean any LXD containers created by Charmcraft
to build the project.  Future work will further extend functionality.

Add a caplog filter fixture to help with a common pattern of checking
logs for the module under test.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>