### PR TITLE
config/build: set default bases configuration with DNs (CRAFT-265, CRAFT-266)

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -71,10 +71,26 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y python3-pip python3-setuptools python3-wheel
+      - name: Install LXD dependency on 18.04
+        if: ${{ matrix.os == 'ubuntu-18.04' }}
+        run: |
+          sudo apt remove -y lxd
+          sudo snap install lxd
+      - name: Refresh LXD dependency on 20.04
+        if: ${{ matrix.os == 'ubuntu-20.04' }}
+        run: |
+          sudo snap refresh lxd
+      - name: Configured LXD
+        run: |
+          sudo groupadd --force --system lxd
+          sudo usermod --append --groups lxd $USER
+          sudo snap start lxd
+          sudo lxd waitready --timeout=30
+          sudo lxd init --auto
       - name: Run smoke tests
         run: |
           mkdir -p charm-smoke-test
           cd charm-smoke-test
           charmcraft -v init --author testuser
-          charmcraft -v build
+          sg lxd -c "charmcraft -v build"
           test -f *.charm

--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -146,7 +146,7 @@ class Builder:
         self.config = config
         self.metadata = parse_metadata_yaml(self.charmdir)
 
-    def build_charm(self, bases_config: Optional[BasesConfiguration]) -> str:
+    def build_charm(self, bases_config: BasesConfiguration) -> str:
         """Build the charm.
 
         :param bases_config: Bases configuration to use for build.

--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -185,7 +185,7 @@ class Builder:
         charms: List[str] = []
         is_managed_mode = is_charmcraft_running_in_managed_mode()
 
-        if not (self.charmdir / "charmcraft.yaml").exists() and not is_managed_mode:
+        if not (self.charmdir / "charmcraft.yaml").exists():
             notify_deprecation("dn02")
 
         for bases_index, bases_config in enumerate(self.config.bases):

--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -30,6 +30,7 @@ from craft_providers import Executor
 from charmcraft.bases import check_if_base_matches_host
 from charmcraft.cmdbase import BaseCommand, CommandError
 from charmcraft.config import Base, BasesConfiguration, Config
+from charmcraft.deprecations import notify_deprecation
 from charmcraft.env import (
     get_managed_environment_project_path,
     is_charmcraft_running_in_managed_mode,
@@ -182,65 +183,64 @@ class Builder:
         :returns: List of charm files created.
         """
         charms: List[str] = []
+        is_managed_mode = is_charmcraft_running_in_managed_mode()
 
-        if self.config.bases:
-            for bases_index, bases_config in enumerate(self.config.bases):
-                if bases_indices and bases_index not in bases_indices:
-                    logger.debug(
-                        "Ingoring 'bases[%d]' due to --base-index usage.",
-                        bases_index,
-                    )
-                    continue
+        if not (self.charmdir / "charmcraft.yaml").exists() and not is_managed_mode:
+            notify_deprecation("dn02")
 
-                for build_on_index, build_on in enumerate(bases_config.build_on):
-                    if is_charmcraft_running_in_managed_mode():
-                        matches, reason = check_if_base_matches_host(build_on)
-                    else:
-                        matches, reason = is_base_providable(build_on)
+        for bases_index, bases_config in enumerate(self.config.bases):
+            if bases_indices and bases_index not in bases_indices:
+                logger.debug(
+                    "Ingoring 'bases[%d]' due to --base-index usage.",
+                    bases_index,
+                )
+                continue
 
-                    if matches:
-                        logger.debug(
-                            "Building for 'bases[%d]' as host matches 'build-on[%d]'.",
-                            bases_index,
-                            build_on_index,
-                        )
-                        if is_charmcraft_running_in_managed_mode():
-                            charm_name = self.build_charm(bases_config)
-                        else:
-                            with launched_environment(
-                                charm_name=self.metadata.name,
-                                project_path=self.charmdir,
-                                base=build_on,
-                                bases_index=bases_index,
-                                build_on_index=build_on_index,
-                            ) as instance:
-                                charm_name = self.pack_charm_in_instance(
-                                    instance, bases_index
-                                )
-
-                        charms.append(charm_name)
-                        break
-                    else:
-                        logger.debug(
-                            "Host does not match 'bases[%d].build-on[%d]' (%s)",
-                            bases_index,
-                            build_on_index,
-                            reason,
-                        )
+            for build_on_index, build_on in enumerate(bases_config.build_on):
+                if is_managed_mode:
+                    matches, reason = check_if_base_matches_host(build_on)
                 else:
-                    logger.warning(
-                        "No suitable 'build-on' environment found in 'bases[%d]' configuration.",
-                        bases_index,
-                    )
+                    matches, reason = is_base_providable(build_on)
 
-            if not charms:
-                raise CommandError(
-                    "No suitable 'build-on' environment found in any 'bases' configuration."
+                if matches:
+                    logger.debug(
+                        "Building for 'bases[%d]' as host matches 'build-on[%d]'.",
+                        bases_index,
+                        build_on_index,
+                    )
+                    if is_managed_mode:
+                        charm_name = self.build_charm(bases_config)
+                    else:
+                        with launched_environment(
+                            charm_name=self.metadata.name,
+                            project_path=self.charmdir,
+                            base=build_on,
+                            bases_index=bases_index,
+                            build_on_index=build_on_index,
+                        ) as instance:
+                            charm_name = self.pack_charm_in_instance(
+                                instance, bases_index
+                            )
+
+                    charms.append(charm_name)
+                    break
+                else:
+                    logger.debug(
+                        "Host does not match 'bases[%d].build-on[%d]' (%s)",
+                        bases_index,
+                        build_on_index,
+                        reason,
+                    )
+            else:
+                logger.warning(
+                    "No suitable 'build-on' environment found in 'bases[%d]' configuration.",
+                    bases_index,
                 )
 
-        else:
-            charm_name = self.build_charm(None)
-            charms.append(charm_name)
+        if not charms:
+            raise CommandError(
+                "No suitable 'build-on' environment found in any 'bases' configuration."
+            )
 
         return charms
 

--- a/charmcraft/commands/pack.py
+++ b/charmcraft/commands/pack.py
@@ -186,7 +186,7 @@ class PackCommand(BaseCommand):
 
         # pack everything
         project = self.config.project
-        manifest_filepath = create_manifest(project.dirpath, project.started_at)
+        manifest_filepath = create_manifest(project.dirpath, project.started_at, None)
         try:
             paths = get_paths_to_include(self.config)
             zipname = project.dirpath / (bundle_name + ".zip")

--- a/charmcraft/config.py
+++ b/charmcraft/config.py
@@ -336,6 +336,7 @@ class Config(ModelConfigDefaults, validate_all=False):
             # type will simplify user facing errors.
             bases = obj.get("bases")
             if bases is None:
+                notify_deprecation("dn03")
                 # Set default bases to Ubuntu 20.04 to match strict snap's
                 # effective behavior.
                 bases = [
@@ -345,8 +346,6 @@ class Config(ModelConfigDefaults, validate_all=False):
                         "architectures": [get_host_architecture()],
                     }
                 ]
-                if not is_charmcraft_running_in_managed_mode():
-                    notify_deprecation("dn03")
 
             # Expand short-form bases if only the bases is a valid list. If it
             # is not a valid list, parse_obj() will properly handle the error.

--- a/charmcraft/config.py
+++ b/charmcraft/config.py
@@ -266,7 +266,14 @@ class Config(ModelConfigDefaults, validate_all=False):
     type: Optional[str]
     charmhub: CharmhubConfig = CharmhubConfig()
     parts: Parts = Parts()
-    bases: Optional[List[BasesConfiguration]] = None
+    bases: List[BasesConfiguration] = [
+        BasesConfiguration(
+            **{
+                "build-on": [Base(name="ubuntu", channel="20.04")],
+                "run-on": [Base(name="ubuntu", channel="20.04")],
+            }
+        )
+    ]
 
     project: Project
 
@@ -328,7 +335,22 @@ class Config(ModelConfigDefaults, validate_all=False):
             # base configurations.  Doing it here rather than a Union
             # type will simplify user facing errors.
             bases = obj.get("bases")
-            if bases is not None and isinstance(bases, list):
+            if bases is None:
+                # Set default bases to Ubuntu 20.04 to match strict snap's
+                # effective behavior.
+                bases = [
+                    {
+                        "name": "ubuntu",
+                        "channel": "20.04",
+                        "architectures": [get_host_architecture()],
+                    }
+                ]
+                if not is_charmcraft_running_in_managed_mode():
+                    notify_deprecation("dn03")
+
+            # Expand short-form bases if only the bases is a valid list. If it
+            # is not a valid list, parse_obj() will properly handle the error.
+            if isinstance(bases, list):
                 cls.expand_short_form_bases(bases)
 
             return cls.parse_obj({"project": project, **obj})

--- a/charmcraft/deprecations.py
+++ b/charmcraft/deprecations.py
@@ -26,6 +26,8 @@ Then add that ID along with the deprecation title in the list below.
 
 import logging
 
+from charmcraft.env import is_charmcraft_running_in_managed_mode
+
 logger = logging.getLogger(__name__)
 
 
@@ -45,8 +47,13 @@ _ALREADY_NOTIFIED = set()
 
 
 def notify_deprecation(deprecation_id):
-    """Present proper messages to the user for the indicated deprecation id."""
-    if deprecation_id in _ALREADY_NOTIFIED:
+    """Present proper messages to the user for the indicated deprecation id.
+
+    Prevent issuing duplicate warnings to the user by ignoring notifications if:
+    - running in managed-mode
+    - already issued by running process
+    """
+    if is_charmcraft_running_in_managed_mode() or deprecation_id in _ALREADY_NOTIFIED:
         return
 
     message = _DEPRECATION_MESSAGES[deprecation_id]

--- a/charmcraft/deprecations.py
+++ b/charmcraft/deprecations.py
@@ -33,6 +33,8 @@ logger = logging.getLogger(__name__)
 # documentation)
 _DEPRECATION_MESSAGES = {
     "dn01": "Configuration keywords are now separated using dashes.",
+    "dn02": "A charmcraft.yaml configuration file is now required.",
+    "dn03": "Bases configuration is now required.",
 }
 
 # the URL to point to the deprecation entry in the documentation

--- a/charmcraft/manifest.py
+++ b/charmcraft/manifest.py
@@ -23,7 +23,7 @@ from typing import Optional
 
 import yaml
 
-from charmcraft import __version__, config, utils
+from charmcraft import __version__, config
 from charmcraft.cmdbase import CommandError
 
 logger = logging.getLogger(__name__)
@@ -32,33 +32,22 @@ logger = logging.getLogger(__name__)
 def create_manifest(
     basedir: pathlib.Path,
     started_at: datetime.datetime,
-    bases_config: Optional[config.BasesConfiguration] = None,
+    bases_config: Optional[config.BasesConfiguration],
 ):
     """Create manifest.yaml in basedir for given base configuration.
 
     :param basedir: Directory to create Charm in.
     :param started_at: Build start time.
-    :param bases_config: Relevant bases configuration.
+    :param bases_config: Relevant bases configuration, if any.
 
     :returns: Path to created manifest.yaml.
     """
-    if bases_config is None:
-        os_platform = utils.get_os_platform()
+    content = {
+        "charmcraft-version": __version__,
+        "charmcraft-started-at": started_at.isoformat() + "Z",
+    }
 
-        # XXX Facundo 2021-03-29: the architectures list will be provided by the caller when
-        # we integrate lifecycle lib in future branches
-        architectures = [utils.get_host_architecture()]
-
-        name = os_platform.system.lower()
-        channel = os_platform.release
-        bases = [
-            {
-                "name": name,
-                "channel": channel,
-                "architectures": architectures,
-            }
-        ]
-    else:
+    if bases_config is not None:
         bases = [
             {
                 "name": r.name,
@@ -67,12 +56,8 @@ def create_manifest(
             }
             for r in bases_config.run_on
         ]
+        content["bases"] = bases
 
-    content = {
-        "charmcraft-version": __version__,
-        "charmcraft-started-at": started_at.isoformat() + "Z",
-        "bases": bases,
-    }
     filepath = basedir / "manifest.yaml"
     if filepath.exists():
         raise CommandError(

--- a/charmcraft/manifest.py
+++ b/charmcraft/manifest.py
@@ -36,6 +36,9 @@ def create_manifest(
 ):
     """Create manifest.yaml in basedir for given base configuration.
 
+    For packing bundles, `bases` will be skipped when bases_config is None.
+    Charms should always include a valid bases_config.
+
     :param basedir: Directory to create Charm in.
     :param started_at: Build start time.
     :param bases_config: Relevant bases configuration, if any.
@@ -47,6 +50,7 @@ def create_manifest(
         "charmcraft-started-at": started_at.isoformat() + "Z",
     }
 
+    # Annotate bases only if bases_config is not None.
     if bases_config is not None:
         bases = [
             {

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ cffi==1.14.5
 chardet==4.0.0
 click==8.0.1
 coverage==5.5
-craft-providers==0.0.2
+craft-providers==1.0.0
 flake8==3.9.2
 humanize==3.9.0
 idna==2.10
@@ -32,7 +32,7 @@ pymacaroons==0.13.0
 PyNaCl==1.4.0
 pyparsing==2.4.7
 pyRFC3339==1.1
-pyrsistent==0.17.3
+pyrsistent==0.18.0
 pytest==6.2.4
 python-dateutil==2.8.1
 pytz==2021.1
@@ -47,4 +47,4 @@ snowballstemmer==2.1.0
 tabulate==0.8.9
 toml==0.10.2
 typing-extensions==3.10.0.0
-urllib3==1.26.5
+urllib3==1.26.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ attrs==21.2.0
 certifi==2021.5.30
 cffi==1.14.5
 chardet==4.0.0
-craft-providers==0.0.2
+craft-providers==1.0.0
 humanize==3.9.0
 idna==2.10
 Jinja2==3.0.1
@@ -16,7 +16,7 @@ pydantic==1.8.2
 pymacaroons==0.13.0
 PyNaCl==1.4.0
 pyRFC3339==1.1
-pyrsistent==0.17.3
+pyrsistent==0.18.0
 python-dateutil==2.8.1
 pytz==2021.1
 PyYAML==5.4.1
@@ -26,4 +26,4 @@ requests-unixsocket==0.2.0
 six==1.16.0
 tabulate==0.8.9
 typing-extensions==3.10.0.0
-urllib3==1.26.5
+urllib3==1.26.6

--- a/tests/commands/test_build.py
+++ b/tests/commands/test_build.py
@@ -171,16 +171,6 @@ def test_validator_from_isdir(tmp_path, config):
         validator.validate_from(testfile)
 
 
-def test_validator_bases_index_without_bases(config):
-    """'entrypoint' param: checks that the file exists."""
-    validator = Validator(config)
-    expected_msg = re.escape(
-        "No bases configuration found, required when using --bases-index."
-    )
-    with pytest.raises(CommandError, match=expected_msg):
-        validator.validate_bases_indices([0])
-
-
 @pytest.mark.parametrize("bases_indices", [[-1], [0, -1], [0, 1, -1]])
 def test_validator_bases_index_invalid(bases_indices, config):
     """'entrypoint' param: checks that the file exists."""
@@ -440,8 +430,11 @@ def test_politeexec_crashed(caplog, tmp_path):
 # --- (real) build tests
 
 
-def test_build_basic_complete_structure(basic_project, monkeypatch, config):
+def test_build_basic_complete_structure(basic_project, caplog, monkeypatch, config):
     """Integration test: a simple structure with custom lib and normal src dir."""
+    caplog.set_level(logging.WARNING, logger="charmcraft")
+    host_base = get_host_as_base()
+    host_arch = host_base.architectures[0]
     monkeypatch.chdir(basic_project)  # so the zip file is left in the temp dir
     builder = Builder(
         {
@@ -456,8 +449,14 @@ def test_build_basic_complete_structure(basic_project, monkeypatch, config):
     metadata_file = basic_project / "metadata.yaml"
     metadata_raw = metadata_file.read_bytes()
 
-    zipnames = builder.run()
-    assert zipnames == ["name-from-metadata.charm"]
+    monkeypatch.setenv("CHARMCRAFT_MANAGED_MODE", "1")
+    with patch(
+        "charmcraft.commands.build.check_if_base_matches_host",
+        return_value=(True, None),
+    ):
+        zipnames = builder.run()
+
+    assert zipnames == [f"name-from-metadata_ubuntu-20.04-{host_arch}.charm"]
 
     # check all is properly inside the zip
     # contents!), and all relative to build dir
@@ -478,6 +477,7 @@ def test_build_basic_complete_structure(basic_project, monkeypatch, config):
     assert (
         manifest["charmcraft-started-at"] == config.project.started_at.isoformat() + "Z"
     )
+    assert caplog.records == []
 
 
 def test_build_error_without_metadata_yaml(basic_project, monkeypatch):
@@ -538,6 +538,26 @@ def test_build_with_charmcraft_yaml(basic_project, monkeypatch):
     host_arch = host_base.architectures[0]
     assert zipnames == [
         f"name-from-metadata_{host_base.name}-{host_base.channel}-{host_arch}.charm"
+    ]
+
+
+def test_build_without_charmcraft_yaml_issues_dn02(basic_project, caplog, monkeypatch):
+    """Test cases for base-index parameter."""
+    config = load(basic_project)
+    builder = Builder(
+        {
+            "from": basic_project,
+            "entrypoint": basic_project / "src" / "charm.py",
+            "requirement": [],
+        },
+        config,
+    )
+
+    with patch("charmcraft.commands.build.launched_environment"):
+        builder.run()
+
+    assert "DEPRECATED: A charmcraft.yaml configuration file is now required." in [
+        r.message for r in caplog.records
     ]
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,8 +91,13 @@ def config(tmp_path):
 
 
 @pytest.fixture(autouse=True)
-def reset_deprecation_notices(monkeypatch):
-    deprecations._ALREADY_NOTIFIED = set()
+def clean_already_notified():
+    """Clear the already-notified structure for each test.
+
+    This is needed as that structure is a module-level one (by design), so otherwise
+    it will be dirty between tests.
+    """
+    deprecations._ALREADY_NOTIFIED.clear()
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,7 @@ import pytest
 import responses as responses_module
 
 from charmcraft import config as config_module
+from charmcraft import deprecations
 
 
 @pytest.fixture(autouse=True, scope="session")
@@ -76,6 +77,11 @@ def config(tmp_path):
         config_provided=True,
     )
     return TestConfig(type="bundle", project=project)
+
+
+@pytest.fixture(autouse=True)
+def reset_deprecation_notices(monkeypatch):
+    deprecations._ALREADY_NOTIFIED = set()
 
 
 @pytest.fixture

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -533,14 +533,27 @@ def test_basicprime_empty():
 # -- tests for bases
 
 
-def test_no_bases_ok(create_config):
-    tmp_path = create_config(
+def test_no_bases_defaults_to_ubuntu_20_04_with_dn03(caplog, create_config, tmp_path):
+    caplog.set_level(logging.WARNING, logger="charmcraft")
+    create_config(
         """
         type: charm
     """
     )
+
     config = load(tmp_path)
-    assert config.bases is None
+
+    assert config.bases == [
+        BasesConfiguration(
+            **{
+                "build-on": [Base(name="ubuntu", channel="20.04")],
+                "run-on": [Base(name="ubuntu", channel="20.04")],
+            }
+        )
+    ]
+    assert "DEPRECATED: Bases configuration is now required." in [
+        rec.message for rec in caplog.records
+    ]
 
 
 def test_bases_minimal_long_form(create_config):

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -21,59 +21,12 @@ import pytest
 import yaml
 
 from charmcraft import __version__, config
-from charmcraft.manifest import create_manifest
 from charmcraft.cmdbase import CommandError
-from charmcraft.utils import (
-    ARCH_TRANSLATIONS,
-    OSPlatform,
-)
+from charmcraft.manifest import create_manifest
+from charmcraft.utils import OSPlatform
 
 
 def test_manifest_simple_ok(tmp_path):
-    """Simple construct."""
-    tstamp = datetime.datetime(2020, 2, 1, 15, 40, 33)
-    os_platform = OSPlatform(system="SuperUbuntu", release="40.10", machine="SomeRISC")
-    with patch("charmcraft.utils.get_os_platform", return_value=os_platform):
-        result_filepath = create_manifest(tmp_path, tstamp)
-
-    assert result_filepath == tmp_path / "manifest.yaml"
-    saved = yaml.safe_load(result_filepath.read_text())
-    expected = {
-        "charmcraft-started-at": "2020-02-01T15:40:33Z",
-        "charmcraft-version": __version__,
-        "bases": [
-            {
-                "name": "superubuntu",
-                "channel": "40.10",
-                "architectures": ["SomeRISC"],
-            }
-        ],
-    }
-    assert saved == expected
-
-
-def test_manifest_architecture_translated(tmp_path, monkeypatch):
-    """All known architectures must be translated."""
-    monkeypatch.setitem(ARCH_TRANSLATIONS, "weird_arch", "nice_arch")
-    os_platform = OSPlatform(system="Ubuntu", release="40.10", machine="weird_arch")
-    with patch("charmcraft.utils.get_os_platform", return_value=os_platform):
-        result_filepath = create_manifest(tmp_path, datetime.datetime.now())
-
-    saved = yaml.safe_load(result_filepath.read_text())
-    assert saved["bases"][0]["architectures"] == ["nice_arch"]
-
-
-def test_manifest_dont_overwrite(tmp_path):
-    """Don't overwrite the already-existing file."""
-    (tmp_path / "manifest.yaml").touch()
-    with pytest.raises(CommandError) as cm:
-        create_manifest(tmp_path, datetime.datetime.now())
-    assert str(cm.value) == (
-        "Cannot write the manifest as there is already a 'manifest.yaml' in disk."
-    )
-
-
-def test_manifest_using_bases_configuration(tmp_path):
     """Simple construct."""
     bases_config = config.BasesConfiguration(
         **{
@@ -122,3 +75,45 @@ def test_manifest_using_bases_configuration(tmp_path):
         ],
     }
     assert saved == expected
+
+
+def test_manifest_no_bases(tmp_path):
+    """Manifest without bases (used for bundles)."""
+    tstamp = datetime.datetime(2020, 2, 1, 15, 40, 33)
+    os_platform = OSPlatform(system="SuperUbuntu", release="40.10", machine="SomeRISC")
+    with patch("charmcraft.utils.get_os_platform", return_value=os_platform):
+        result_filepath = create_manifest(tmp_path, tstamp, None)
+
+    saved = yaml.safe_load(result_filepath.read_text())
+
+    assert result_filepath == tmp_path / "manifest.yaml"
+    assert saved == {
+        "charmcraft-started-at": "2020-02-01T15:40:33Z",
+        "charmcraft-version": __version__,
+    }
+
+
+def test_manifest_dont_overwrite(tmp_path):
+    """Don't overwrite the already-existing file."""
+    (tmp_path / "manifest.yaml").touch()
+    bases_config = config.BasesConfiguration(
+        **{
+            "build-on": [
+                config.Base(
+                    name="test-name",
+                    channel="test-channel",
+                ),
+            ],
+            "run-on": [
+                config.Base(
+                    name="test-name",
+                    channel="test-channel",
+                ),
+            ],
+        }
+    )
+    with pytest.raises(CommandError) as cm:
+        create_manifest(tmp_path, datetime.datetime.now(), bases_config)
+    assert str(cm.value) == (
+        "Cannot write the manifest as there is already a 'manifest.yaml' in disk."
+    )


### PR DESCRIPTION
Set the default bases configuration to Ubuntu 20.04 for the host's
architecture.  This will effectively end legacy builds.

Add DN02 to deprecate projects without charmcraft.yaml.

Add DN03 to deprecate projects with bases configuration.

Add reset_deprecation_notices() autouse fixture to reset global value
found in deprecations module.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>