### PR TITLE
init command: populate default charmcraft.yaml (CRAFT-330)

### DIFF
--- a/charmcraft/commands/init.py
+++ b/charmcraft/commands/init.py
@@ -38,6 +38,7 @@ It will setup the following tree of files and directories:
 ├── metadata.yaml        - Charm operator package description
 ├── README.md            - Frontpage for your charmhub.io/charm/
 ├── actions.yaml         - Day-2 action declarations, e.g. backup, restore
+├── charmcraft.yaml      - Charm build configuration
 ├── config.yaml          - Config schema for your operator
 ├── LICENSE              - Your charm license, we recommend Apache 2
 ├── requirements.txt     - PyPI dependencies for your charm, with `ops`

--- a/charmcraft/templates/init/charmcraft.yaml.j2
+++ b/charmcraft/templates/init/charmcraft.yaml.j2
@@ -1,4 +1,5 @@
-# Learn more about config at: https://juju.is/docs/sdk/config
+# Learn more about charmcraft.yaml configuration at:
+# https://juju.is/docs/sdk/charmcraft-config
 type: "charm"
 bases:
   - build-on:

--- a/charmcraft/templates/init/charmcraft.yaml.j2
+++ b/charmcraft/templates/init/charmcraft.yaml.j2
@@ -1,0 +1,9 @@
+# Learn more about config at: https://juju.is/docs/sdk/config
+type: "charm"
+bases:
+  - build-on:
+    - name: "ubuntu"
+      channel: "20.04"
+    run-on:
+    - name: "ubuntu"
+      channel: "20.04"

--- a/tests/commands/test_init.py
+++ b/tests/commands/test_init.py
@@ -61,6 +61,7 @@ def test_all_the_files(tmp_path, config):
         "LICENSE",
         "README.md",
         "actions.yaml",
+        "charmcraft.yaml",
         "config.yaml",
         "metadata.yaml",
         "requirements-dev.txt",


### PR DESCRIPTION
Initialize charmcraft.yaml with type "charm" and an Ubuntu 20.04
bases configuration.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>