### PR TITLE
build/pack: pass --verbose or --quiet as needed (CRAFT-322)

### DIFF
--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -35,6 +35,7 @@ from charmcraft.env import (
     is_charmcraft_running_in_managed_mode,
 )
 from charmcraft.jujuignore import JujuIgnore, default_juju_ignore
+from charmcraft.logsetup import message_handler
 from charmcraft.manifest import create_manifest
 from charmcraft.metadata import parse_metadata_yaml
 from charmcraft.providers import is_base_providable, launched_environment
@@ -247,8 +248,15 @@ class Builder:
     def pack_charm_in_instance(self, instance: Executor, bases_index: int) -> str:
         """Pack instance in Charm."""
         try:
+            cmd = ["charmcraft", "pack", "--bases-index", str(bases_index)]
+
+            if message_handler.mode == message_handler.VERBOSE:
+                cmd.append("--verbose")
+            elif message_handler.mode == message_handler.QUIET:
+                cmd.append("--quiet")
+
             instance.execute_run(
-                ["charmcraft", "pack", "--bases-index", str(bases_index)],
+                cmd,
                 cwd=get_managed_environment_project_path().as_posix(),
             )
         except subprocess.CalledProcessError as error:

--- a/charmcraft/logsetup.py
+++ b/charmcraft/logsetup.py
@@ -58,6 +58,8 @@ class _MessageHandler:
         for k in self._modes:
             setattr(self, k.upper(), k)
 
+        self.mode = self.NORMAL
+
     def init(self, initial_mode):
         """Initialize internal structures; this must be done before start logging."""
         self._set_filehandler()

--- a/tests/commands/test_build.py
+++ b/tests/commands/test_build.py
@@ -78,16 +78,6 @@ def basic_project(tmp_path):
     yield tmp_path
 
 
-@pytest.fixture(autouse=True)
-def set_message_handler_mode():
-    message_handler.mode = message_handler.NORMAL
-
-    def set_mode(mode):
-        message_handler.mode = mode
-
-    return set_mode
-
-
 # --- Validator tests
 
 
@@ -649,10 +639,10 @@ def test_build_multiple_with_charmcraft_yaml(basic_project, monkeypatch, caplog)
     ],
 )
 def test_build_bases_index_scenarios_provider(
-    basic_project, monkeypatch, caplog, set_message_handler_mode, mode, cmd_flags
+    basic_project, monkeypatch, caplog, mode, cmd_flags
 ):
     """Test cases for base-index parameter."""
-    set_message_handler_mode(mode)
+    monkeypatch.setattr(message_handler, "mode", mode)
     host_base = get_host_as_base()
     host_arch = host_base.architectures[0]
     charmcraft_file = basic_project / "charmcraft.yaml"

--- a/tests/commands/test_build.py
+++ b/tests/commands/test_build.py
@@ -45,6 +45,7 @@ from charmcraft.commands.build import (
     relativise,
 )
 from charmcraft.config import Base, BasesConfiguration, load
+from charmcraft.logsetup import message_handler
 from charmcraft.metadata import CHARM_METADATA
 
 
@@ -75,6 +76,16 @@ def basic_project(tmp_path):
     charm_script.write_bytes(b"all the magic")
 
     yield tmp_path
+
+
+@pytest.fixture(autouse=True)
+def set_message_handler_mode():
+    message_handler.mode = message_handler.NORMAL
+
+    def set_mode(mode):
+        message_handler.mode = mode
+
+    return set_mode
 
 
 # --- Validator tests
@@ -609,8 +620,19 @@ def test_build_multiple_with_charmcraft_yaml(basic_project, monkeypatch, caplog)
     assert "Building for 'bases[2]' as host matches 'build-on[0]'." in records
 
 
-def test_build_bases_index_scenarios_provider(basic_project, monkeypatch, caplog):
+@pytest.mark.parametrize(
+    "mode,cmd_flags",
+    [
+        (message_handler.VERBOSE, ["--verbose"]),
+        (message_handler.QUIET, ["--quiet"]),
+        (message_handler.NORMAL, []),
+    ],
+)
+def test_build_bases_index_scenarios_provider(
+    basic_project, monkeypatch, caplog, set_message_handler_mode, mode, cmd_flags
+):
     """Test cases for base-index parameter."""
+    set_message_handler_mode(mode)
     host_base = get_host_as_base()
     host_arch = host_base.architectures[0]
     charmcraft_file = basic_project / "charmcraft.yaml"
@@ -660,7 +682,8 @@ def test_build_bases_index_scenarios_provider(basic_project, monkeypatch, caplog
             call()
             .__enter__()
             .execute_run(
-                ["charmcraft", "pack", "--bases-index", "0"], cwd="/root/project"
+                ["charmcraft", "pack", "--bases-index", "0"] + cmd_flags,
+                cwd="/root/project",
             ),
             call().__exit__(None, None, None),
         ]
@@ -682,7 +705,8 @@ def test_build_bases_index_scenarios_provider(basic_project, monkeypatch, caplog
             call()
             .__enter__()
             .execute_run(
-                ["charmcraft", "pack", "--bases-index", "1"], cwd="/root/project"
+                ["charmcraft", "pack", "--bases-index", "1"] + cmd_flags,
+                cwd="/root/project",
             ),
             call().__exit__(None, None, None),
         ]
@@ -705,7 +729,8 @@ def test_build_bases_index_scenarios_provider(basic_project, monkeypatch, caplog
             call()
             .__enter__()
             .execute_run(
-                ["charmcraft", "pack", "--bases-index", "0"], cwd="/root/project"
+                ["charmcraft", "pack", "--bases-index", "0"] + cmd_flags,
+                cwd="/root/project",
             ),
             call().__exit__(None, None, None),
             call(
@@ -719,7 +744,8 @@ def test_build_bases_index_scenarios_provider(basic_project, monkeypatch, caplog
             call()
             .__enter__()
             .execute_run(
-                ["charmcraft", "pack", "--bases-index", "1"], cwd="/root/project"
+                ["charmcraft", "pack", "--bases-index", "1"] + cmd_flags,
+                cwd="/root/project",
             ),
             call().__exit__(None, None, None),
         ]

--- a/tests/test_logsetup.py
+++ b/tests/test_logsetup.py
@@ -18,10 +18,10 @@ import logging
 import os
 from unittest.mock import patch
 
-from charmcraft.logsetup import _MessageHandler
-from charmcraft.cmdbase import CommandError
-
 import pytest
+
+from charmcraft.cmdbase import CommandError
+from charmcraft.logsetup import _MessageHandler
 
 
 @pytest.fixture
@@ -38,14 +38,6 @@ def create_message_handler(tmp_path):
         p.start()
         patchers.append(p)
 
-        if modes is not None:
-            if "verbose" not in modes:
-                # verbose should always be there, as it's used internally
-                modes["verbose"] = (10, "%(message)s")
-            p = patch.object(_MessageHandler, "_modes", modes)
-            p.start()
-            patchers.append(p)
-
         return _MessageHandler()
 
     yield factory
@@ -58,27 +50,48 @@ def create_message_handler(tmp_path):
 # --- Tests for the MessageHandler
 
 
-def test_mode_setting_init(create_message_handler):
-    """The internal mode is set on init and logger properly changed."""
-    test_level = 123
-    test_format = "test:: %(message)s"
-    mh = create_message_handler({"foo": (test_level, test_format)})
-    mh.init(mh.FOO)
+def test_mode_setting_init_normal(create_message_handler):
+    test_level = 20
+    test_format = "%(message)s"
+    mh = create_message_handler()
+    mh.init(mh.NORMAL)
 
-    assert mh.mode == mh.FOO
+    assert mh.mode == mh.NORMAL
+    assert mh._stderr_handler.formatter._fmt == test_format
+    assert mh._stderr_handler.level == test_level
+
+
+def test_mode_setting_init_quiet(create_message_handler):
+    test_level = 30
+    test_format = "%(message)s"
+    mh = create_message_handler()
+    mh.init(mh.QUIET)
+
+    assert mh.mode == mh.QUIET
+    assert mh._stderr_handler.formatter._fmt == test_format
+    assert mh._stderr_handler.level == test_level
+
+
+def test_mode_setting_init_verbose(create_message_handler):
+    test_level = 10
+    test_format = "%(asctime)s  %(name)-40s %(levelname)-8s %(message)s"
+    mh = create_message_handler()
+    mh.init(mh.VERBOSE)
+
+    assert mh.mode == mh.VERBOSE
     assert mh._stderr_handler.formatter._fmt == test_format
     assert mh._stderr_handler.level == test_level
 
 
 def test_mode_setting_changed(create_message_handler):
-    """The internal mode can be set later and logger properly changed."""
-    test_level = 123
-    test_format = "test:: %(message)s"
-    mh = create_message_handler({"foo": (0, ""), "bar": (test_level, test_format)})
-    mh.init(mh.FOO)
-    mh.set_mode(mh.BAR)
+    """The internal mode is set on init and logger properly changed."""
+    test_level = 10
+    test_format = "%(asctime)s  %(name)-40s %(levelname)-8s %(message)s"
+    mh = create_message_handler()
+    mh.init(mh.NORMAL)
+    mh.init(mh.VERBOSE)
 
-    assert mh.mode == mh.BAR
+    assert mh.mode == mh.VERBOSE
     assert mh._stderr_handler.formatter._fmt == test_format
     assert mh._stderr_handler.level == test_level
 


### PR DESCRIPTION
When building with provided (managed) instance, append --verbose
or --quiet as required to match the parameter given to the host
charmcraft instance.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>