### PR TITLE
pack: fetch logs from managed instance on error (CRAFT-333)

### DIFF
--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -40,6 +40,7 @@ from charmcraft.logsetup import message_handler
 from charmcraft.manifest import create_manifest
 from charmcraft.metadata import parse_metadata_yaml
 from charmcraft.providers import (
+    capture_logs_from_instance,
     ensure_provider_is_available,
     is_base_providable,
     launched_environment,
@@ -254,6 +255,10 @@ class Builder:
 
     def pack_charm_in_instance(self, instance: Executor, bases_index: int) -> str:
         """Pack instance in Charm."""
+        charm_name = format_charm_file_name(
+            self.metadata.name, self.config.bases[bases_index]
+        )
+
         try:
             cmd = ["charmcraft", "pack", "--bases-index", str(bases_index)]
 
@@ -264,16 +269,17 @@ class Builder:
 
             instance.execute_run(
                 cmd,
+                check=True,
                 cwd=get_managed_environment_project_path().as_posix(),
             )
         except subprocess.CalledProcessError as error:
+            capture_logs_from_instance(instance)
+
             raise CommandError(
                 f"Failed to build charm for bases index '{bases_index}'."
             ) from error
 
-        return format_charm_file_name(
-            self.metadata.name, self.config.bases[bases_index]
-        )
+        return charm_name
 
     def _load_juju_ignore(self):
         ignore = JujuIgnore(default_juju_ignore)

--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -258,15 +258,14 @@ class Builder:
         charm_name = format_charm_file_name(
             self.metadata.name, self.config.bases[bases_index]
         )
+        cmd = ["charmcraft", "pack", "--bases-index", str(bases_index)]
+
+        if message_handler.mode == message_handler.VERBOSE:
+            cmd.append("--verbose")
+        elif message_handler.mode == message_handler.QUIET:
+            cmd.append("--quiet")
 
         try:
-            cmd = ["charmcraft", "pack", "--bases-index", str(bases_index)]
-
-            if message_handler.mode == message_handler.VERBOSE:
-                cmd.append("--verbose")
-            elif message_handler.mode == message_handler.QUIET:
-                cmd.append("--quiet")
-
             instance.execute_run(
                 cmd,
                 check=True,
@@ -274,7 +273,6 @@ class Builder:
             )
         except subprocess.CalledProcessError as error:
             capture_logs_from_instance(instance)
-
             raise CommandError(
                 f"Failed to build charm for bases index '{bases_index}'."
             ) from error

--- a/charmcraft/env.py
+++ b/charmcraft/env.py
@@ -25,6 +25,11 @@ import sys
 from charmcraft.cmdbase import CommandError
 
 
+def get_managed_environment_log_path():
+    """Path for charmcraft log when running in managed environment."""
+    return pathlib.Path("/tmp/charmcraft.log")
+
+
 def get_managed_environment_project_path():
     """Path for project when running in managed environment."""
     return pathlib.Path("/root/project")

--- a/charmcraft/logsetup.py
+++ b/charmcraft/logsetup.py
@@ -28,6 +28,7 @@ from charmcraft.env import (
 
 FORMATTER_SIMPLE = "%(message)s"
 FORMATTER_DETAILED = "%(asctime)s  %(name)-40s %(levelname)-8s %(message)s"
+FORMATTER_DETAILED_MANAGED = "mm %(asctime)s  %(name)-40s %(levelname)-8s %(message)s"
 
 logger = logging.getLogger("charmcraft")
 enabled_loggers = [
@@ -88,9 +89,7 @@ class _MessageHandler:
 
         file_handler = logging.FileHandler(self._log_filepath, mode="w")
 
-        log_format = FORMATTER_DETAILED
-        if managed_mode:
-            log_format = "mm " + log_format
+        log_format = FORMATTER_DETAILED_MANAGED if managed_mode else FORMATTER_DETAILED
 
         file_handler.setFormatter(logging.Formatter(log_format))
         file_handler.setLevel(0)  # log eeeeeverything

--- a/charmcraft/logsetup.py
+++ b/charmcraft/logsetup.py
@@ -21,6 +21,10 @@ import os
 import tempfile
 
 from charmcraft import __version__
+from charmcraft.env import (
+    get_managed_environment_log_path,
+    is_charmcraft_running_in_managed_mode,
+)
 
 FORMATTER_SIMPLE = "%(message)s"
 FORMATTER_DETAILED = "%(asctime)s  %(name)-40s %(levelname)-8s %(message)s"
@@ -76,10 +80,19 @@ class _MessageHandler:
 
     def _set_filehandler(self):
         """Set the file handler to log everything to the temp file."""
-        _, self._log_filepath = tempfile.mkstemp(prefix="charmcraft-log-")
+        managed_mode = is_charmcraft_running_in_managed_mode()
+        if managed_mode:
+            self._log_filepath = str(get_managed_environment_log_path())
+        else:
+            _, self._log_filepath = tempfile.mkstemp(prefix="charmcraft-log-")
 
-        file_handler = logging.FileHandler(self._log_filepath)
-        file_handler.setFormatter(logging.Formatter(FORMATTER_DETAILED))
+        file_handler = logging.FileHandler(self._log_filepath, mode="w")
+
+        log_format = FORMATTER_DETAILED
+        if managed_mode:
+            log_format = "mm " + log_format
+
+        file_handler.setFormatter(logging.Formatter(log_format))
         file_handler.setLevel(0)  # log eeeeeverything
         for enabled_logger in enabled_loggers:
             enabled_logger.addHandler(file_handler)

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -23,6 +23,12 @@ from charmcraft import env
 from charmcraft.cmdbase import CommandError
 
 
+def test_get_managed_environment_log_path():
+    dirpath = env.get_managed_environment_log_path()
+
+    assert dirpath == pathlib.Path("/tmp/charmcraft.log")
+
+
 def test_get_managed_environment_project_path():
     dirpath = env.get_managed_environment_project_path()
 


### PR DESCRIPTION
Catch error when failing to pack a Charm, retrieving the logs from
the managed instance for easier inspection by the user.

- Update logger to write to /tmp/charmcraft.log so that it can be
readily retrieved by the host Charmcraft instance.  Provide this
path with a new env.get_managed_environment_log_path() interface.
Additionally, ensure the log file is truncated with mode='w' so
the instance logs are only for the last run.

- prefix logs in managed instance with "mm "

- add providers.capture_logs_from_instance() to providers to retrieve
  logs and send them to logger.debug()

- update build to use this mechanism

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>