### PR TITLE
providers: account for project path in instance name (CRAFT-334)

### DIFF
--- a/charmcraft/commands/clean.py
+++ b/charmcraft/commands/clean.py
@@ -41,9 +41,9 @@ class CleanCommand(BaseCommand):
 
     def run(self, parsed_args):
         """Run the command."""
-        metadata = parse_metadata_yaml(self.config.project.dirpath)
+        project_path = self.config.project.dirpath
+        metadata = parse_metadata_yaml(project_path)
         logger.debug("Cleaning project %r.", metadata.name)
 
-        clean_project_environments(metadata.name)
-
+        clean_project_environments(metadata.name, project_path)
         logger.info("Cleaned project %r.", metadata.name)

--- a/tests/commands/test_clean.py
+++ b/tests/commands/test_clean.py
@@ -47,4 +47,4 @@ def test_clean(
         (logging.DEBUG, "Cleaning project 'foo'."),
         (logging.INFO, "Cleaned project 'foo'."),
     ]
-    assert mock_clean_project_environments.mock_calls == [mock.call("foo")]
+    assert mock_clean_project_environments.mock_calls == [mock.call("foo", tmp_path)]


### PR DESCRIPTION
If Charmcraft were to build the same project [name] simultaneously in
two different directories, collisions on the containers in use may
occur.

To account for this, this PR uses the project directory's inode in the
container name.  This will ensure uniqueness for projects in multiple
paths, but also seamlessly handle project directory moves that don't
cross the filesystem boundary, the common case.

Note that 'clean' command will not affect other project directories,
so the clean must occur in the original directory.  To handle any
potentially unassociated containers, future work will include more
sweeping purge capabilities for the clean command.  This is not unique
to the introduction of the use of the directory inode, but is
exacerbated by it.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>