### PR TITLE
providers: handle unexpected case where instance never logs (CRAFT-345)

### DIFF
--- a/charmcraft/providers.py
+++ b/charmcraft/providers.py
@@ -58,7 +58,12 @@ def capture_logs_from_instance(instance: Executor) -> None:
     local_log_path = pathlib.Path(tmp_path)
     instance_log_path = get_managed_environment_log_path()
 
-    instance.pull_file(source=instance_log_path, destination=local_log_path)
+    try:
+        instance.pull_file(source=instance_log_path, destination=local_log_path)
+    except FileNotFoundError:
+        logger.debug("No logs found in instance.")
+        return
+
     logs = local_log_path.read_text()
     local_log_path.unlink()
 


### PR DESCRIPTION
If the managed instance never gets to creating the log, for whatever
reason, catch the FileNotFoundError and log it.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>