### PR TITLE
providers: install git as required dependency (CRAFT-346)

### DIFF
--- a/charmcraft/providers.py
+++ b/charmcraft/providers.py
@@ -326,6 +326,7 @@ class CharmcraftBuilddBaseConfiguration(bases.BuilddBase):
                     "apt-get",
                     "install",
                     "-y",
+                    "git",
                     "python3-pip",
                     "python3-setuptools",
                 ],
@@ -334,7 +335,7 @@ class CharmcraftBuilddBaseConfiguration(bases.BuilddBase):
             )
         except subprocess.CalledProcessError as error:
             raise bases.BaseConfigurationError(
-                brief="Failed to install python3-pip and python3-setuptools.",
+                brief="Failed to install the required dependencies.",
             ) from error
 
         try:

--- a/charmcraft/providers.py
+++ b/charmcraft/providers.py
@@ -321,6 +321,8 @@ class CharmcraftBuilddBaseConfiguration(bases.BuilddBase):
         super().setup(executor=executor, retry_wait=retry_wait, timeout=timeout)
 
         try:
+            # XXX Patterson 2021-07-02: craft-parts will determine/install these
+            # deps as a matter of the plugin(s) and source(s) being used.
             executor.execute_run(
                 [
                     "apt-get",

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -128,7 +128,7 @@ def test_base_configuration_setup(mock_executor, mock_inject, monkeypatch, alias
 
     assert mock_executor.mock_calls == [
         call.execute_run(
-            ["apt-get", "install", "-y", "python3-pip", "python3-setuptools"],
+            ["apt-get", "install", "-y", "git", "python3-pip", "python3-setuptools"],
             check=True,
             capture_output=True,
         ),
@@ -143,7 +143,7 @@ def test_base_configuration_setup(mock_executor, mock_inject, monkeypatch, alias
 
 def test_base_configuration_setup_apt_error(mock_executor):
     alias = bases.BuilddBaseAlias.FOCAL
-    apt_cmd = ["apt-get", "install", "-y", "python3-pip", "python3-setuptools"]
+    apt_cmd = ["apt-get", "install", "-y", "git", "python3-pip", "python3-setuptools"]
     mock_executor.execute_run.side_effect = subprocess.CalledProcessError(
         -1,
         apt_cmd,
@@ -155,7 +155,7 @@ def test_base_configuration_setup_apt_error(mock_executor):
 
     with pytest.raises(
         bases.BaseConfigurationError,
-        match=r"Failed to install python3-pip and python3-setuptools.",
+        match=r"Failed to install the required dependencies.",
     ) as exc_info:
         config.setup(executor=mock_executor)
 


### PR DESCRIPTION
Git may be required to install python dependencies for projects.
Instead of using git from the snap, install the native git on
the host as a required dependency.  Future work on craft-parts
may aborb this dependency.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>