### PR TITLE
build: log reason to ignore build-on entry to info (CRAFT-350)

### DIFF
--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -234,8 +234,8 @@ class Builder:
                     charms.append(charm_name)
                     break
                 else:
-                    logger.debug(
-                        "Host does not match 'bases[%d].build-on[%d]' (%s)",
+                    logger.info(
+                        "Ignoring 'bases[%d].build-on[%d]': %s.",
                         bases_index,
                         build_on_index,
                         reason,

--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -200,7 +200,7 @@ class Builder:
         for bases_index, bases_config in enumerate(self.config.bases):
             if bases_indices and bases_index not in bases_indices:
                 logger.debug(
-                    "Ingoring 'bases[%d]' due to --base-index usage.",
+                    "Skipping 'bases[%d]' due to --base-index usage.",
                     bases_index,
                 )
                 continue
@@ -235,7 +235,7 @@ class Builder:
                     break
                 else:
                     logger.info(
-                        "Ignoring 'bases[%d].build-on[%d]': %s.",
+                        "Skipping 'bases[%d].build-on[%d]': %s.",
                         bases_index,
                         build_on_index,
                         reason,

--- a/tests/commands/test_build.py
+++ b/tests/commands/test_build.py
@@ -967,7 +967,7 @@ def test_build_error_no_match_with_charmcraft_yaml(
     records = [r.message for r in caplog.records]
 
     assert (
-        "Ignoring 'bases[0].build-on[0]': "
+        "Skipping 'bases[0].build-on[0]': "
         "name 'unmatched-name' does not match host 'xname'."
     ) in records
     assert (
@@ -975,7 +975,7 @@ def test_build_error_no_match_with_charmcraft_yaml(
         in records
     )
     assert (
-        "Ignoring 'bases[1].build-on[0]': "
+        "Skipping 'bases[1].build-on[0]': "
         "channel 'unmatched-channel' does not match host 'xchannel'."
     ) in records
     assert (
@@ -983,7 +983,7 @@ def test_build_error_no_match_with_charmcraft_yaml(
         in records
     )
     assert (
-        "Ignoring 'bases[2].build-on[0]': "
+        "Skipping 'bases[2].build-on[0]': "
         "host architecture 'xarch' not in base architectures "
         "['unmatched-arch1', 'unmatched-arch2']."
     ) in records

--- a/tests/commands/test_build.py
+++ b/tests/commands/test_build.py
@@ -967,25 +967,25 @@ def test_build_error_no_match_with_charmcraft_yaml(
     records = [r.message for r in caplog.records]
 
     assert (
-        "Host does not match 'bases[0].build-on[0]' "
-        "(name 'unmatched-name' does not match host 'xname')"
+        "Ignoring 'bases[0].build-on[0]': "
+        "name 'unmatched-name' does not match host 'xname'."
     ) in records
     assert (
         "No suitable 'build-on' environment found in 'bases[0]' configuration."
         in records
     )
     assert (
-        "Host does not match 'bases[1].build-on[0]' "
-        "(channel 'unmatched-channel' does not match host 'xchannel')"
+        "Ignoring 'bases[1].build-on[0]': "
+        "channel 'unmatched-channel' does not match host 'xchannel'."
     ) in records
     assert (
         "No suitable 'build-on' environment found in 'bases[1]' configuration."
         in records
     )
     assert (
-        "Host does not match 'bases[2].build-on[0]' "
-        "(host architecture 'xarch' not in base "
-        "architectures ['unmatched-arch1', 'unmatched-arch2'])"
+        "Ignoring 'bases[2].build-on[0]': "
+        "host architecture 'xarch' not in base architectures "
+        "['unmatched-arch1', 'unmatched-arch2']."
     ) in records
     assert (
         "No suitable 'build-on' environment found in 'bases[2]' configuration."


### PR DESCRIPTION
This information was being logged to debug, but should be made
available to user regardless if erroring out.  Log it as informational.

Also tweak the language to be more generic rather than intended
for managed/destructive mode (host isn't matched for provided
environments).

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>