### PR TITLE
build: inform user that packing charm may take time (CRAFT-347)

### DIFF
--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -261,7 +261,7 @@ class Builder:
         elif message_handler.mode == message_handler.QUIET:
             cmd.append("--quiet")
 
-        logger.info(f"Packing charm {charm_name!r} which may take several minutes...")
+        logger.info(f"Packing charm {charm_name!r}...")
         with launched_environment(
             charm_name=self.metadata.name,
             project_path=self.charmdir,

--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -25,7 +25,6 @@ import subprocess
 import zipfile
 from typing import List, Optional
 
-from craft_providers import Executor
 
 from charmcraft.bases import check_if_base_matches_host
 from charmcraft.cmdbase import BaseCommand, CommandError
@@ -220,16 +219,11 @@ class Builder:
                     if is_managed_mode:
                         charm_name = self.build_charm(bases_config)
                     else:
-                        with launched_environment(
-                            charm_name=self.metadata.name,
-                            project_path=self.charmdir,
-                            base=build_on,
+                        charm_name = self.pack_charm_in_instance(
                             bases_index=bases_index,
+                            build_on=build_on,
                             build_on_index=build_on_index,
-                        ) as instance:
-                            charm_name = self.pack_charm_in_instance(
-                                instance, bases_index
-                            )
+                        )
 
                     charms.append(charm_name)
                     break
@@ -253,7 +247,9 @@ class Builder:
 
         return charms
 
-    def pack_charm_in_instance(self, instance: Executor, bases_index: int) -> str:
+    def pack_charm_in_instance(
+        self, *, bases_index: int, build_on: Base, build_on_index: int
+    ) -> str:
         """Pack instance in Charm."""
         charm_name = format_charm_file_name(
             self.metadata.name, self.config.bases[bases_index]
@@ -265,17 +261,25 @@ class Builder:
         elif message_handler.mode == message_handler.QUIET:
             cmd.append("--quiet")
 
-        try:
-            instance.execute_run(
-                cmd,
-                check=True,
-                cwd=get_managed_environment_project_path().as_posix(),
-            )
-        except subprocess.CalledProcessError as error:
-            capture_logs_from_instance(instance)
-            raise CommandError(
-                f"Failed to build charm for bases index '{bases_index}'."
-            ) from error
+        logger.info(f"Packing charm {charm_name!r} which may take several minutes...")
+        with launched_environment(
+            charm_name=self.metadata.name,
+            project_path=self.charmdir,
+            base=build_on,
+            bases_index=bases_index,
+            build_on_index=build_on_index,
+        ) as instance:
+            try:
+                instance.execute_run(
+                    cmd,
+                    check=True,
+                    cwd=get_managed_environment_project_path().as_posix(),
+                )
+            except subprocess.CalledProcessError as error:
+                capture_logs_from_instance(instance)
+                raise CommandError(
+                    f"Failed to build charm for bases index '{bases_index}'."
+                ) from error
 
         return charm_name
 

--- a/tests/commands/test_build.py
+++ b/tests/commands/test_build.py
@@ -753,6 +753,10 @@ def test_build_bases_index_scenarios_provider(
             ),
             call().__exit__(None, None, None),
         ]
+        assert (
+            f"Packing charm 'name-from-metadata_ubuntu-18.04-{host_arch}.charm'..."
+            in [r.message for r in caplog.records]
+        )
         mock_ensure_provider_is_available.assert_called_once()
         mock_launch.reset_mock()
 


### PR DESCRIPTION
Let the user know which charm is being packed and that it may take some
time.  Move launched_environment() logic into pack_charm_in_instance()
to have the information required (charm name) prior to launching.

Example output:

```
$ charmcraft pack
Packing charm 'foo_ubuntu-18.04-amd64.charm' which may take several minutes...
Created 'foo_ubuntu-18.04-amd64.charm'.
Packing charm 'foo_ubuntu-20.04-amd64.charm' which may take several minutes...
Created 'foo_ubuntu-20.04-amd64.charm'.
```

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>