### PR TITLE
providers: add python3-wheel as dependency (CRAFT-351)

### DIFF
--- a/charmcraft/providers.py
+++ b/charmcraft/providers.py
@@ -331,6 +331,7 @@ class CharmcraftBuilddBaseConfiguration(bases.BuilddBase):
                     "git",
                     "python3-pip",
                     "python3-setuptools",
+                    "python3-wheel",
                 ],
                 check=True,
                 capture_output=True,

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -128,7 +128,15 @@ def test_base_configuration_setup(mock_executor, mock_inject, monkeypatch, alias
 
     assert mock_executor.mock_calls == [
         call.execute_run(
-            ["apt-get", "install", "-y", "git", "python3-pip", "python3-setuptools"],
+            [
+                "apt-get",
+                "install",
+                "-y",
+                "git",
+                "python3-pip",
+                "python3-setuptools",
+                "python3-wheel",
+            ],
             check=True,
             capture_output=True,
         ),


### PR DESCRIPTION
Python complains when wheel is not installed, install it in the
target instance as a build dependency.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>