### PR TITLE
commands/pack: add --destructive-mode support (CRAFT-358)

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -103,3 +103,12 @@ jobs:
           test -f *.charm
           sg lxd -c "charmcraft -v clean --project-dir ../charm-smoke-test"
           popd
+
+          mkdir -p destructive-mode-tests
+          pushd destructive-mode-tests
+          source /etc/os-release
+          charmcraft -v init --author testuser
+          sed -i "s|20.04|$VERSION_ID|g" charmcraft.yaml
+          charmcraft -v pack --destructive-mode
+          test -f "destructive-mode-tests_ubuntu-$VERSION_ID-amd64.charm"
+          popd

--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -188,8 +188,8 @@ class Builder:
         """
         charms: List[str] = []
 
-        is_managed_mode = is_charmcraft_running_in_managed_mode()
-        if not is_managed_mode and not destructive_mode:
+        managed_mode = is_charmcraft_running_in_managed_mode()
+        if not managed_mode and not destructive_mode:
             ensure_provider_is_available()
 
         if not (self.charmdir / "charmcraft.yaml").exists():
@@ -204,7 +204,7 @@ class Builder:
                 continue
 
             for build_on_index, build_on in enumerate(bases_config.build_on):
-                if is_managed_mode or destructive_mode:
+                if managed_mode or destructive_mode:
                     matches, reason = check_if_base_matches_host(build_on)
                 else:
                     matches, reason = is_base_providable(build_on)
@@ -215,7 +215,7 @@ class Builder:
                         bases_index,
                         build_on_index,
                     )
-                    if is_managed_mode or destructive_mode:
+                    if managed_mode or destructive_mode:
                         charm_name = self.build_charm(bases_config)
                     else:
                         charm_name = self.pack_charm_in_instance(

--- a/tests/commands/test_build.py
+++ b/tests/commands/test_build.py
@@ -26,6 +26,7 @@ import sys
 import zipfile
 from collections import namedtuple
 from textwrap import dedent
+from typing import List
 from unittest.mock import call, patch
 
 import pytest
@@ -76,6 +77,39 @@ def basic_project(tmp_path):
     charm_script.write_bytes(b"all the magic")
 
     yield tmp_path
+
+
+@pytest.fixture
+def basic_project_builder(basic_project):
+    def _basic_project_builder(bases_configs: List[BasesConfiguration]):
+        charmcraft_file = basic_project / "charmcraft.yaml"
+        with charmcraft_file.open("w") as f:
+            print("type: charm", file=f)
+            print("bases:", file=f)
+            for bases_config in bases_configs:
+                print("- build-on:", file=f)
+                for base in bases_config.build_on:
+                    print(f"  - name: {base.name!r}", file=f)
+                    print(f"    channel: {base.channel!r}", file=f)
+                    print(f"    architectures: {base.architectures!r}", file=f)
+
+                print("  run-on:", file=f)
+                for base in bases_config.run_on:
+                    print(f"  - name: {base.name!r}", file=f)
+                    print(f"    channel: {base.channel!r}", file=f)
+                    print(f"    architectures: {base.architectures!r}", file=f)
+
+        config = load(basic_project)
+        return Builder(
+            {
+                "from": basic_project,
+                "entrypoint": basic_project / "src" / "charm.py",
+                "requirement": [],
+            },
+            config,
+        )
+
+    return _basic_project_builder
 
 
 @pytest.fixture
@@ -512,46 +546,43 @@ def test_build_error_without_metadata_yaml(basic_project, monkeypatch):
         )
 
 
-def test_build_with_charmcraft_yaml(basic_project, monkeypatch):
-    """Integration test: a simple structure with custom lib and normal src dir."""
+def test_build_with_charmcraft_yaml_destructive_mode(
+    basic_project_builder, caplog, monkeypatch
+):
     host_base = get_host_as_base()
-    charmcraft_file = basic_project / "charmcraft.yaml"
-    charmcraft_file.write_text(
-        dedent(
-            f"""\
-                type: charm
-                bases:
-                  - build-on:
-                      - name: {host_base.name!r}
-                        channel: {host_base.channel!r}
-                        architectures: {host_base.architectures!r}
-                    run-on:
-                      - name: {host_base.name!r}
-                        channel: {host_base.channel!r}
-                        architectures: {host_base.architectures!r}
-                """
-        )
+    builder = basic_project_builder(
+        [BasesConfiguration(**{"build-on": [host_base], "run-on": [host_base]})]
     )
 
-    config = load(basic_project)
-    monkeypatch.chdir(basic_project)
-    builder = Builder(
-        {
-            "from": basic_project,
-            "entrypoint": basic_project / "src" / "charm.py",
-            "requirement": [],
-        },
-        config,
-    )
+    zipnames = builder.run(destructive_mode=True)
 
-    # Managed bases build.
+    host_arch = host_base.architectures[0]
+    assert zipnames == [
+        f"name-from-metadata_{host_base.name}-{host_base.channel}-{host_arch}.charm"
+    ]
+
+    records = [r.message for r in caplog.records]
+    assert "Building for 'bases[0]' as host matches 'build-on[0]'." in records
+
+
+def test_build_with_charmcraft_yaml_managed_mode(
+    basic_project_builder, caplog, monkeypatch
+):
     monkeypatch.setenv("CHARMCRAFT_MANAGED_MODE", "1")
+    host_base = get_host_as_base()
+    builder = basic_project_builder(
+        [BasesConfiguration(**{"build-on": [host_base], "run-on": [host_base]})]
+    )
+
     zipnames = builder.run()
 
     host_arch = host_base.architectures[0]
     assert zipnames == [
         f"name-from-metadata_{host_base.name}-{host_base.channel}-{host_arch}.charm"
     ]
+
+    records = [r.message for r in caplog.records]
+    assert "Building for 'bases[0]' as host matches 'build-on[0]'." in records
 
 
 def test_build_checks_provider(basic_project, mock_ensure_provider_is_available):
@@ -611,55 +642,80 @@ def test_build_without_charmcraft_yaml_issues_dn02(basic_project, caplog, monkey
     ]
 
 
-def test_build_multiple_with_charmcraft_yaml(basic_project, monkeypatch, caplog):
+def test_build_multiple_with_charmcraft_yaml_destructive_mode(
+    basic_project_builder, monkeypatch, caplog
+):
     """Build multiple charms for multiple matching bases, skipping one unmatched config."""
     caplog.set_level(logging.DEBUG)
     host_base = get_host_as_base()
-    charmcraft_file = basic_project / "charmcraft.yaml"
-    charmcraft_file.write_text(
-        dedent(
-            f"""\
-                type: charm
-                bases:
-                  - build-on:
-                      - name: {host_base.name!r}
-                        channel: {host_base.channel!r}
-                        architectures: {host_base.architectures!r}
-                    run-on:
-                      - name: {host_base.name!r}
-                        channel: {host_base.channel!r}
-                        architectures: {host_base.architectures!r}
-                  - build-on:
-                      - name: unmatched-name
-                        channel: unmatched-channel
-                        architectures: [unmatched-arch1]
-                    run-on:
-                      - name: unmatched-name
-                        channel: unmatched-channel
-                        architectures: [unmatched-arch1]
-                  - build-on:
-                      - name: {host_base.name!r}
-                        channel: {host_base.channel!r}
-                        architectures: {host_base.architectures!r}
-                    run-on:
-                      - name: cross-name
-                        channel: cross-channel
-                        architectures: [cross-arch1]
-                """
-        )
+    unmatched_base = Base(
+        name="unmatched-name",
+        channel="unmatched-channel",
+        architectures=["unmatched-arch1"],
     )
-    config = load(basic_project)
-    monkeypatch.chdir(basic_project)
-    builder = Builder(
-        {
-            "from": basic_project,
-            "entrypoint": basic_project / "src" / "charm.py",
-            "requirement": [],
-        },
-        config,
+    matched_cross_base = Base(
+        name="cross-name",
+        channel="cross-channel",
+        architectures=["cross-arch1"],
+    )
+    builder = basic_project_builder(
+        [
+            BasesConfiguration(**{"build-on": [host_base], "run-on": [host_base]}),
+            BasesConfiguration(
+                **{"build-on": [unmatched_base], "run-on": [unmatched_base]}
+            ),
+            BasesConfiguration(
+                **{"build-on": [host_base], "run-on": [matched_cross_base]}
+            ),
+        ]
     )
 
-    # Managed bases build.
+    zipnames = builder.run(destructive_mode=True)
+
+    host_arch = host_base.architectures[0]
+    assert zipnames == [
+        f"name-from-metadata_{host_base.name}-{host_base.channel}-{host_arch}.charm",
+        "name-from-metadata_cross-name-cross-channel-cross-arch1.charm",
+    ]
+
+    records = [r.message for r in caplog.records]
+
+    assert "Building for 'bases[0]' as host matches 'build-on[0]'." in records
+    assert (
+        "No suitable 'build-on' environment found in 'bases[1]' configuration."
+        in records
+    )
+    assert "Building for 'bases[2]' as host matches 'build-on[0]'." in records
+
+
+def test_build_multiple_with_charmcraft_yaml_managed_mode(
+    basic_project_builder, monkeypatch, caplog
+):
+    """Build multiple charms for multiple matching bases, skipping one unmatched config."""
+    caplog.set_level(logging.DEBUG)
+    host_base = get_host_as_base()
+    unmatched_base = Base(
+        name="unmatched-name",
+        channel="unmatched-channel",
+        architectures=["unmatched-arch1"],
+    )
+    matched_cross_base = Base(
+        name="cross-name",
+        channel="cross-channel",
+        architectures=["cross-arch1"],
+    )
+    builder = basic_project_builder(
+        [
+            BasesConfiguration(**{"build-on": [host_base], "run-on": [host_base]}),
+            BasesConfiguration(
+                **{"build-on": [unmatched_base], "run-on": [unmatched_base]}
+            ),
+            BasesConfiguration(
+                **{"build-on": [host_base], "run-on": [matched_cross_base]}
+            ),
+        ]
+    )
+
     monkeypatch.setenv("CHARMCRAFT_MANAGED_MODE", "1")
     zipnames = builder.run()
 


### PR DESCRIPTION
- Add --destructive-mode bool parameter to pack command.

- Add basic_project_builder fixture for reusable project building
  code to help reduce further duplication.

- Update Builder.run() with parameter to indicate whether or not
  to build in destructive-mode.  Use it when determining how to
  appropriate build/pack charm(s).  Behavior is consistent with
  managed-mode.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>