### PR TITLE
Fetch any defined schemas during charmcraft build

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+skipsdist = True
+
+[testenv]
+setenv =
+	PYTHONPATH={toxinidir}:{toxinidir}/lib
+deps =
+	-rrequirements-dev.txt
+
+[testenv:unit]
+commands = 
+	pytest -vv tests/


### PR DESCRIPTION
The [serialized-data-interface library](https://github.com/canonical/serialized-data-interface) currently fetches any defined schemas at runtime, which [fails in proxy environments](https://github.com/canonical/serialized-data-interface/issues/9).

This change allows schemas to be fetched at build time instead.

Also includes commit that adds support for running tests via `tox`.