### PR TITLE
Use linters' analyze from build command (CRAFT-318)

### DIFF
--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -170,7 +170,7 @@ class Builder:
         self.handle_dependencies()
 
         linting_results = []
-        # run linters, present them to the user according to their type, and decide if go on
+        # run linters, present them to the user according to their type, and fail if necessary
         linting_results = linters.analyze(self.config, self.buildpath)
         for result in linting_results:
             if result.check_type == linters.CheckType.attribute:

--- a/charmcraft/commands/pack.py
+++ b/charmcraft/commands/pack.py
@@ -193,7 +193,9 @@ class PackCommand(BaseCommand):
 
         # pack everything
         project = self.config.project
-        manifest_filepath = create_manifest(project.dirpath, project.started_at, None, [])
+        manifest_filepath = create_manifest(
+            project.dirpath, project.started_at, None, []
+        )
         try:
             paths = get_paths_to_include(self.config)
             zipname = project.dirpath / (bundle_name + ".zip")

--- a/charmcraft/commands/pack.py
+++ b/charmcraft/commands/pack.py
@@ -193,7 +193,7 @@ class PackCommand(BaseCommand):
 
         # pack everything
         project = self.config.project
-        manifest_filepath = create_manifest(project.dirpath, project.started_at, None)
+        manifest_filepath = create_manifest(project.dirpath, project.started_at, None, [])
         try:
             paths = get_paths_to_include(self.config)
             zipname = project.dirpath / (bundle_name + ".zip")

--- a/charmcraft/config.py
+++ b/charmcraft/config.py
@@ -82,14 +82,18 @@ class ModelConfigDefaults(
     """Define Charmcraft's defaults for the BaseModel configuration."""
 
 
-class RelativePath(pydantic.StrictStr):
-    """Constrainted string which must be a relative path."""
+class CustomStrictStr(pydantic.StrictStr):
+    """Generic class to create custom strict strings validated by pydantic."""
 
     @classmethod
     def __get_validators__(cls):
         """Yield the relevant validators."""
         yield from super().__get_validators__()
         yield cls.validate_relative_path
+
+
+class RelativePath(CustomStrictStr):
+    """Constrainted string which must be a relative path."""
 
     @classmethod
     def validate_relative_path(cls, value: str) -> str:
@@ -111,14 +115,8 @@ class RelativePath(pydantic.StrictStr):
         return value
 
 
-class AttributeName(pydantic.StrictStr):
+class AttributeName(CustomStrictStr):
     """Constrainted string which must be the name of an attribute from linters.CHECKERS."""
-
-    @classmethod
-    def __get_validators__(cls):  #FIXME: generalize
-        """Yield the relevant validators."""
-        yield from super().__get_validators__()
-        yield cls.validate_relative_path
 
     @classmethod
     def validate_relative_path(cls, value: str) -> str:
@@ -135,14 +133,8 @@ class AttributeName(pydantic.StrictStr):
         return value
 
 
-class LinterName(pydantic.StrictStr):
+class LinterName(CustomStrictStr):
     """Constrainted string which must be the name of a linter from linters.CHECKERS."""
-
-    @classmethod
-    def __get_validators__(cls):  #FIXME: generalize
-        """Yield the relevant validators."""
-        yield from super().__get_validators__()
-        yield cls.validate_relative_path
 
     @classmethod
     def validate_relative_path(cls, value: str) -> str:

--- a/charmcraft/linters.py
+++ b/charmcraft/linters.py
@@ -202,7 +202,7 @@ CHECKERS = [
 ]
 
 
-def analyze(config: config.Config) -> List[CheckResult]:
+def analyze(config: config.Config, basedir: pathlib.Path) -> List[CheckResult]:
     """Run all checkers and linters."""
     all_results = []
     for checker_class in CHECKERS:
@@ -215,7 +215,7 @@ def analyze(config: config.Config) -> List[CheckResult]:
                 continue
 
         checker = checker_class()
-        result = checker.run(config.project.dirpath)
+        result = checker.run(basedir)
         all_results.append(
             CheckResult(
                 check_type=checker.check_type,

--- a/charmcraft/linters.py
+++ b/charmcraft/linters.py
@@ -207,11 +207,12 @@ def analyze(config: config.Config) -> List[CheckResult]:
     all_results = []
     for checker_class in CHECKERS:
         # do not run the ignored ones
-        if checker_class.check_type == CheckType.attribute and checker_class.name in config.analysis.ignore.attributes:
-            continue
-        if (checker_class.check_type == CheckType.warning or checker_class.check_type == CheckType.error) and checker_class.name in config.analysis.ignore.linters:
-            continue
-
+        if checker_class.check_type == CheckType.attribute:
+            if checker_class.name in config.analysis.ignore.attributes:
+                continue
+        if checker_class.check_type in (CheckType.warning, CheckType.error):
+            if checker_class.name in config.analysis.ignore.linters:
+                continue
 
         checker = checker_class()
         result = checker.run(config.project.dirpath)

--- a/charmcraft/linters.py
+++ b/charmcraft/linters.py
@@ -20,7 +20,7 @@ import ast
 import os
 import pathlib
 import shlex
-from collections import namedtuple
+from collections import namedtuple, defaultdict
 from typing import List, Generator
 
 from charmcraft import config
@@ -37,7 +37,7 @@ CheckResult = namedtuple("CheckResult", "name result url check_type text")
 UNKNOWN = "unknown"
 
 # shared state between checkers, to reuse analysis results and/or other intermediate information
-shared_state = {}
+shared_state = defaultdict(dict)
 
 
 class Language:
@@ -76,6 +76,7 @@ class Language:
 
         entrypoint = basedir / entrypoint_str
         if entrypoint.suffix == ".py" and os.access(entrypoint, os.X_OK):
+            shared_state[self.name]["entrypoint"] = entrypoint
             return self.Result.python
         return self.Result.unknown
 
@@ -216,6 +217,7 @@ def analyze(config: config.Config, basedir: pathlib.Path) -> List[CheckResult]:
 
         checker = checker_class()
         result = checker.run(basedir)
+        shared_state[checker.name]["result"] = result
         all_results.append(
             CheckResult(
                 check_type=checker.check_type,

--- a/charmcraft/manifest.py
+++ b/charmcraft/manifest.py
@@ -19,11 +19,11 @@
 import datetime
 import logging
 import pathlib
-from typing import Optional
+from typing import Optional, List
 
 import yaml
 
-from charmcraft import __version__, config
+from charmcraft import __version__, config, linters
 from charmcraft.cmdbase import CommandError
 
 logger = logging.getLogger(__name__)
@@ -33,6 +33,7 @@ def create_manifest(
     basedir: pathlib.Path,
     started_at: datetime.datetime,
     bases_config: Optional[config.BasesConfiguration],
+    linting_results: List[linters.CheckResult],
 ):
     """Create manifest.yaml in basedir for given base configuration.
 
@@ -61,6 +62,14 @@ def create_manifest(
             for r in bases_config.run_on
         ]
         content["bases"] = bases
+
+    # include the linters results (only for attributes)
+    attributes_info = [
+        {"name": result.name, "result": result.result}
+        for result in linting_results
+        if result.check_type == linters.CheckType.attribute
+    ]
+    content["analysis"] = {"attributes": attributes_info}
 
     filepath = basedir / "manifest.yaml"
     if filepath.exists():

--- a/tests/commands/test_build.py
+++ b/tests/commands/test_build.py
@@ -31,6 +31,7 @@ from unittest.mock import call, patch
 import pytest
 import yaml
 
+from charmcraft import linters
 from charmcraft.bases import get_host_as_base
 from charmcraft.cmdbase import CommandError
 from charmcraft.commands.build import (
@@ -2051,6 +2052,68 @@ def test_builder_with_jujuignore(tmp_path, config):
     assert not ignore.match("hi.txt", is_dir=False)
     assert ignore.match("h\xef.txt", is_dir=False)
     assert not ignore.match("myfile.c", is_dir=False)
+
+
+def test_build_using_linters_attributes(basic_project, caplog, monkeypatch, config):
+    """Use linters, log results, and save them in the manifest."""
+    caplog.set_level(logging.DEBUG, logger="charmcraft")
+    builder = Builder(
+        {
+            "from": basic_project,
+            "entrypoint": basic_project / "src" / "charm.py",
+            "requirement": [],
+        },
+        config,
+    )
+
+    # the results from the analyzer
+    linting_results = [
+        linters.CheckResult(
+            name="check-name-1",
+            check_type=linters.CheckType.attribute,
+            url="url",
+            text="text",
+            result="check-result-1",
+        ),
+        linters.CheckResult(
+            name="check-name-2",
+            check_type=linters.CheckType.attribute,
+            url="url",
+            text="text",
+            result="check-result-2",
+        ),
+    ]
+
+    monkeypatch.setenv("CHARMCRAFT_MANAGED_MODE", "1")
+    with patch(
+        "charmcraft.commands.build.check_if_base_matches_host",
+        return_value=(True, None),
+    ):
+        with patch("charmcraft.linters.analyze") as mock_analyze:
+            mock_analyze.return_value = linting_results
+            zipnames = builder.run()
+
+    # check the analyze function was called properly
+    mock_analyze.assert_called_with(config, builder.buildpath)
+
+    # logs
+    expected = [
+        "Check result: check-name-1 [attribute] check-result-1 (text; see more at url).",
+        "Check result: check-name-2 [attribute] check-result-2 (text; see more at url).",
+    ]
+    logged = [rec.message for rec in caplog.records]
+    assert all(e in logged for e in expected)
+
+    # the manifest should have these results
+    zf = zipfile.ZipFile(zipnames[0])
+    manifest = yaml.safe_load(zf.read("manifest.yaml"))
+    expected = {
+        "attributes": [
+            {"name": "check-name-1", "result": "check-result-1"},
+            {"name": "check-name-2", "result": "check-result-2"},
+        ]
+    }
+    assert manifest["analysis"] == expected
 
 
 # --- tests for relativise helper

--- a/tests/test_linters.py
+++ b/tests/test_linters.py
@@ -501,15 +501,15 @@ def test_analyze_run_everything(config):
         check_type="type2", name="name2", url="url2", text="text2", result="result2"
     )
 
-    # hack the first fake checker to validate that it receives the project's directory path
+    # hack the first fake checker to validate that it receives the indicated path
     def dir_validator(self, basedir):
-        assert basedir == config.project.dirpath
+        assert basedir == "test-buildpath"
         return "result1"
 
     FakeChecker1.run = dir_validator
 
     with patch("charmcraft.linters.CHECKERS", [FakeChecker1, FakeChecker2]):
-        result = analyze(config)
+        result = analyze(config, "test-buildpath")
 
     r1, r2 = result
     assert r1.check_type == "type1"
@@ -531,7 +531,7 @@ def test_analyze_ignore_attribute(config):
 
     config.analysis.ignore.attributes.append("name1")
     with patch("charmcraft.linters.CHECKERS", [FakeChecker1, FakeChecker2]):
-        result = analyze(config)
+        result = analyze(config, "somepath")
 
     (res,) = result
     assert res.name == "name2"
@@ -547,7 +547,7 @@ def test_analyze_ignore_linter_warning(config):
     with patch(
         "charmcraft.linters.CHECKERS", [FakeChecker1, FakeChecker2, FakeChecker3]
     ):
-        result = analyze(config)
+        result = analyze(config, "somepath")
 
     res1, res2 = result
     assert res1.name == "name1"
@@ -564,7 +564,7 @@ def test_analyze_ignore_linter_error(config):
     with patch(
         "charmcraft.linters.CHECKERS", [FakeChecker1, FakeChecker2, FakeChecker3]
     ):
-        result = analyze(config)
+        result = analyze(config, "somepath")
 
     res1, res2 = result
     assert res1.name == "name1"

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -20,7 +20,7 @@ from unittest.mock import patch
 import pytest
 import yaml
 
-from charmcraft import __version__, config
+from charmcraft import __version__, config, linters
 from charmcraft.cmdbase import CommandError
 from charmcraft.manifest import create_manifest
 from charmcraft.utils import OSPlatform
@@ -51,10 +51,22 @@ def test_manifest_simple_ok(tmp_path):
         }
     )
 
+    linting_results = [
+        linters.CheckResult(
+            name="check-name",
+            check_type=linters.CheckType.attribute,
+            url="url",
+            text="text",
+            result="check-result",
+        ),
+    ]
+
     tstamp = datetime.datetime(2020, 2, 1, 15, 40, 33)
     os_platform = OSPlatform(system="SuperUbuntu", release="40.10", machine="SomeRISC")
     with patch("charmcraft.utils.get_os_platform", return_value=os_platform):
-        result_filepath = create_manifest(tmp_path, tstamp, bases_config=bases_config)
+        result_filepath = create_manifest(
+            tmp_path, tstamp, bases_config, linting_results
+        )
 
     assert result_filepath == tmp_path / "manifest.yaml"
     saved = yaml.safe_load(result_filepath.read_text())
@@ -73,6 +85,14 @@ def test_manifest_simple_ok(tmp_path):
                 "architectures": ["arch1", "arch2"],
             },
         ],
+        "analysis": {
+            "attributes": [
+                {
+                    "name": "check-name",
+                    "result": "check-result",
+                },
+            ],
+        },
     }
     assert saved == expected
 
@@ -82,7 +102,7 @@ def test_manifest_no_bases(tmp_path):
     tstamp = datetime.datetime(2020, 2, 1, 15, 40, 33)
     os_platform = OSPlatform(system="SuperUbuntu", release="40.10", machine="SomeRISC")
     with patch("charmcraft.utils.get_os_platform", return_value=os_platform):
-        result_filepath = create_manifest(tmp_path, tstamp, None)
+        result_filepath = create_manifest(tmp_path, tstamp, None, [])
 
     saved = yaml.safe_load(result_filepath.read_text())
 
@@ -90,6 +110,7 @@ def test_manifest_no_bases(tmp_path):
     assert saved == {
         "charmcraft-started-at": "2020-02-01T15:40:33Z",
         "charmcraft-version": __version__,
+        "analysis": {"attributes": []},
     }
 
 
@@ -113,7 +134,60 @@ def test_manifest_dont_overwrite(tmp_path):
         }
     )
     with pytest.raises(CommandError) as cm:
-        create_manifest(tmp_path, datetime.datetime.now(), bases_config)
+        create_manifest(tmp_path, datetime.datetime.now(), bases_config, [])
     assert str(cm.value) == (
         "Cannot write the manifest as there is already a 'manifest.yaml' in disk."
     )
+
+
+def test_manifest_checkers_multiple(tmp_path):
+    """Multiple checkers, attributes, warnings and errors."""
+    linting_results = [
+        linters.CheckResult(
+            name="attrib-name-1",
+            check_type=linters.CheckType.attribute,
+            url="url",
+            text="text",
+            result="result-1",
+        ),
+        linters.CheckResult(
+            name="attrib-name-2",
+            check_type=linters.CheckType.attribute,
+            url="url",
+            text="text",
+            result="result-2",
+        ),
+        linters.CheckResult(
+            name="error-name",
+            check_type=linters.CheckType.error,
+            url="url",
+            text="text",
+            result="result",
+        ),
+        linters.CheckResult(
+            name="warning-name",
+            check_type=linters.CheckType.warning,
+            url="url",
+            text="text",
+            result="result",
+        ),
+    ]
+
+    tstamp = datetime.datetime(2020, 2, 1, 15, 40, 33)
+    os_platform = OSPlatform(system="SuperUbuntu", release="40.10", machine="SomeRISC")
+    with patch("charmcraft.utils.get_os_platform", return_value=os_platform):
+        result_filepath = create_manifest(tmp_path, tstamp, None, linting_results)
+
+    assert result_filepath == tmp_path / "manifest.yaml"
+    saved = yaml.safe_load(result_filepath.read_text())
+    expected = [
+        {
+            "name": "attrib-name-1",
+            "result": "result-1",
+        },
+        {
+            "name": "attrib-name-2",
+            "result": "result-2",
+        },
+    ]
+    assert saved["analysis"]["attributes"] == expected


### PR DESCRIPTION
Call linters' analyze from build command and deal with the results: so far only log the attribute ones (in the future it will deal also with warnings and errors), and use them for the manifest creation. Also changed the manifest creation function to properly save this new info.

Note: I had to fix checkers/analyze to save information in the shared state (a checkers integration test was missing).

Note 2: This PR depends on #443.