### PR TITLE
env: use new setting-up-charmcraft page for installation URL (CRAFT-273)

### DIFF
--- a/charmcraft/env.py
+++ b/charmcraft/env.py
@@ -73,5 +73,5 @@ def ensure_charmcraft_environment_is_supported():
     ):
         raise CommandError(
             "For a supported user experience, please use the Charmcraft snap. "
-            "For more information, please see https://snapcraft.io/charmcraft"
+            "For more information, please see https://juju.is/docs/sdk/setting-up-charmcraft"
         )

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -170,7 +170,7 @@ def test_ensure_environment_is_supported_error(monkeypatch):
         CommandError,
         match=(
             "For a supported user experience, please use the Charmcraft snap. "
-            "For more information, please see https://snapcraft.io/charmcraft"
+            "For more information, please see https://juju.is/docs/sdk/setting-up-charmcraft"
         ),
     ):
         env.ensure_charmcraft_environment_is_supported()


### PR DESCRIPTION
Signed-off-by: Chris Patterson <chris.patterson@canonical.com>