### PR TITLE
build: integrate craft-parts lifecycle (CRAFT-89, CRAFT-367, CRAFT-357)

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,10 +28,30 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install charmcraft and dependencies
         run: |
+          case "${{ matrix.os }}" in
+            ubuntu-*)
+              sudo apt update
+              sudo apt install -y python3-pip python3-venv libapt-pkg-dev
+              ;;
+          esac
+          python3 -m venv ${HOME}/.venv
+          source ${HOME}/.venv/bin/activate
+          pip install -U pip wheel setuptools
+          case "${{ matrix.os }}" in
+            ubuntu-18.04)
+              # pip 20.2 breaks python3-apt, so pin the version before building
+              pip install pip==20.1
+              pip install -U -r requirements-bionic.txt
+              ;;
+            ubuntu-20.04)
+              pip install -U -r requirements-focal.txt
+              ;;
+          esac
           pip install -U -r requirements-dev.txt
           pip install -e .
       - name: Run tests
         run: |
+          source ${HOME}/.venv/bin/activate
           pytest -ra tests
 
   snap-build:

--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -398,9 +398,7 @@ class Builder:
 
         return charm_name
 
-    def handle_package(
-        self, prime_dir, bases_config: Optional[BasesConfiguration] = None
-    ):
+    def handle_package(self, prime_dir, bases_config: Optional[BasesConfiguration] = None):
         """Handle the final package creation."""
         logger.debug("Creating the package itself")
         zipname = format_charm_file_name(self.metadata.name, bases_config)

--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -250,8 +250,10 @@ class Builder:
         """
         # add entrypoint
         if str(entrypoint) == entrypoint.name:
+            # the entry point is in the root of the project, just include it
             self._prime.append(str(entrypoint))
         else:
+            # the entry point is in a subdir, include the whole subtree
             self._prime.append(str(entrypoint.parts[0]))
 
         # add venv if there are requirements

--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -20,11 +20,10 @@ import logging
 import os
 import pathlib
 import subprocess
-import sys
 import zipfile
 from typing import List, Optional
 
-from charmcraft import charm_builder, linters
+from charmcraft import linters
 from charmcraft.bases import check_if_base_matches_host
 from charmcraft.cmdbase import BaseCommand, CommandError
 from charmcraft.config import Base, BasesConfiguration, Config
@@ -37,6 +36,7 @@ from charmcraft.env import (
 from charmcraft.logsetup import message_handler
 from charmcraft.manifest import create_manifest
 from charmcraft.metadata import parse_metadata_yaml
+from charmcraft.parts import PartsLifecycle, Step
 from charmcraft.providers import (
     capture_logs_from_instance,
     ensure_provider_is_available,
@@ -64,6 +64,23 @@ JUJU_DISPATCH_PATH="${{JUJU_DISPATCH_PATH:-$0}}" PYTHONPATH=lib:venv ./{entrypoi
 # The minimum set of hooks to be provided for compatibility with old Juju
 MANDATORY_HOOK_NAMES = {"install", "start", "upgrade-charm"}
 HOOKS_DIR = "hooks"
+
+CHARM_FILES = [
+    "metadata.yaml",
+    DISPATCH_FILENAME,
+    HOOKS_DIR,
+]
+
+CHARM_OPTIONAL = [
+    "config.yaml",
+    "metrics.yaml",
+    "actions.yaml",
+    "lxd-profile.yaml",
+    "templates",
+    "version",
+    "lib",
+    "mod",
+]
 
 
 def _format_run_on_base(base: Base) -> str:
@@ -135,6 +152,10 @@ class Builder:
         self.config = config
         self.metadata = parse_metadata_yaml(self.charmdir)
 
+        self._parts = self.config.parts.copy()
+        self._charm_part = self._parts.setdefault("charm", {})
+        self._prime = self._charm_part.setdefault("prime", [])
+
     def show_linting_results(self, linting_results):
         """Manage the linters results, show some in different conditions, decide if continue."""
         attribute_results = []
@@ -184,60 +205,65 @@ class Builder:
         """
         logger.debug("Building charm in %r", str(self.buildpath))
 
-        build_env = dict(LANG="C.UTF-8", LC_ALL="C.UTF-8")
-        for key in [
-            "PATH",
-            "SNAP",
-            "SNAP_ARCH",
-            "SNAP_NAME",
-            "SNAP_VERSION",
-            "http_proxy",
-            "https_proxy",
-            "no_proxy",
-        ]:
-            if key in os.environ:
-                build_env[key] = os.environ[key]
+        entrypoint = self.entrypoint.relative_to(self.charmdir)
 
-        env_flags = [f"{key}={value}" for key, value in build_env.items()]
+        # add charm files to the prime filter
+        self._set_prime_filter(entrypoint)
 
-        # invoke the charm builder
-        build_cmd = [
-            "env",
-            "-i",
-            *env_flags,
-            sys.executable,
-            "-I",
-            charm_builder.__file__,
-            "--charmdir",
-            str(self.charmdir),
-            "--builddir",
-            str(self.buildpath),
-        ]
+        # set source for buiding
+        self._charm_part["source"] = str(self.charmdir)
 
-        if self.entrypoint:
-            build_cmd.extend(["--entrypoint", str(self.entrypoint)])
-
-        for req in self.requirement_paths:
-            build_cmd.extend(["-r", str(req)])
-
-        retcode = polite_exec(build_cmd)
-        if retcode:
-            raise CommandError("problems running charm builder")
+        # run the parts lifecycle
+        logger.debug("Parts definition: %s", self._parts)
+        lifecycle = PartsLifecycle(
+            self._parts,
+            work_dir=self.buildpath,
+            entrypoint=entrypoint,
+            requirements=[str(p) for p in self.requirement_paths],
+        )
+        lifecycle.run(Step.PRIME)
 
         # run linters and show the results
-        linting_results = linters.analyze(self.config, self.buildpath)
+        linting_results = linters.analyze(self.config, lifecycle.prime_dir)
         self.show_linting_results(linting_results)
 
         create_manifest(
-            self.buildpath,
+            lifecycle.prime_dir,
             self.config.project.started_at,
             bases_config,
             linting_results,
         )
 
-        zipname = self.handle_package(bases_config)
+        zipname = self.handle_package(lifecycle.prime_dir, bases_config)
         logger.info("Created '%s'.", zipname)
         return zipname
+
+    def _set_prime_filter(self, entrypoint: pathlib.Path):
+        """Add mandatory and optional charm files to the prime filter.
+
+        The prime filter should contain:
+        - The charm entry point, or the directory containing it if it's
+          not directly in the project dir.
+        - A set of mandatory charm files, including metadata.yaml, the
+          dispatcher and the hooks directory.
+        - A set of optional charm files.
+        """
+        # add entrypoint
+        if str(entrypoint) == entrypoint.name:
+            self._prime.append(str(entrypoint))
+        else:
+            self._prime.append(str(entrypoint.parts[0]))
+
+        # add venv if there are requirements
+        if self.requirement_paths:
+            self._prime.append(VENV_DIRNAME)
+
+        # add mandatory and optional charm files
+        self._prime.extend(CHARM_FILES)
+        for fn in CHARM_OPTIONAL:
+            path = self.charmdir / fn
+            if path.exists():
+                self._prime.append(fn)
 
     def run(
         self, bases_indices: Optional[List[int]] = None, destructive_mode: bool = False
@@ -372,16 +398,18 @@ class Builder:
 
         return charm_name
 
-    def handle_package(self, bases_config: Optional[BasesConfiguration] = None):
+    def handle_package(
+        self, prime_dir, bases_config: Optional[BasesConfiguration] = None
+    ):
         """Handle the final package creation."""
         logger.debug("Creating the package itself")
         zipname = format_charm_file_name(self.metadata.name, bases_config)
         zipfh = zipfile.ZipFile(zipname, "w", zipfile.ZIP_DEFLATED)
-        for dirpath, dirnames, filenames in os.walk(self.buildpath, followlinks=True):
+        for dirpath, dirnames, filenames in os.walk(prime_dir, followlinks=True):
             dirpath = pathlib.Path(dirpath)
             for filename in filenames:
                 filepath = dirpath / filename
-                zipfh.write(str(filepath), str(filepath.relative_to(self.buildpath)))
+                zipfh.write(str(filepath), str(filepath.relative_to(prime_dir)))
 
         zipfh.close()
         return zipname

--- a/charmcraft/commands/pack.py
+++ b/charmcraft/commands/pack.py
@@ -54,7 +54,7 @@ def get_paths_to_include(config):
     # the extra files (relative paths)
     bundle = config.parts.get("bundle")
     if bundle is not None:
-        for spec in bundle.prime:
+        for spec in bundle.get("prime", []):
             fpaths = sorted(fpath for fpath in dirpath.glob(spec) if fpath.is_file())
             logger.debug("Including per prime config %r: %s.", spec, fpaths)
             allpaths.update(fpaths)

--- a/charmcraft/config.py
+++ b/charmcraft/config.py
@@ -73,6 +73,7 @@ from charmcraft.env import (
     get_managed_environment_project_path,
     is_charmcraft_running_in_managed_mode,
 )
+from charmcraft.parts import validate_part
 from charmcraft.utils import get_host_architecture, load_yaml
 
 
@@ -239,29 +240,6 @@ def format_pydantic_errors(errors, *, file_name: str = "charmcraft.yaml"):
     return "\n".join(combined)
 
 
-class Part(ModelConfigDefaults):
-    """Definition of part to build."""
-
-    prime: List[RelativePath] = []
-
-
-class Parts(ModelConfigDefaults):
-    """Definition of parts to build."""
-
-    bundle: Part = Part()
-
-    def get(self, part_name) -> Part:
-        """Get part by name.
-
-        :returns: Part if exists, None if not.
-
-        :raises KeyError: if part does not exist.
-        """
-        if part_name == "bundle":
-            return self.bundle
-        raise KeyError(part_name)
-
-
 # XXX Facundo 2020-05-31: for backwards compatibility, we'll support the user writing
 # these attributes using underscores; when that period is done we remove the
 # `allow_population_by_field_name` parameter here in the class definition and only
@@ -324,7 +302,7 @@ class Config(ModelConfigDefaults, validate_all=False):
 
     type: Optional[str]
     charmhub: CharmhubConfig = CharmhubConfig()
-    parts: Parts = Parts()
+    parts: Dict[str, Any] = {}
     bases: List[BasesConfiguration] = [
         BasesConfiguration(
             **{
@@ -343,6 +321,25 @@ class Config(ModelConfigDefaults, validate_all=False):
         if charm_type not in ["bundle", "charm"]:
             raise ValueError("must be either 'charm' or 'bundle'")
         return charm_type
+
+    @pydantic.validator("parts", pre=True)
+    def validate_charm_parts(cls, parts):
+        """Verify parts type (craft-parts will re-validate this)."""
+        if not isinstance(parts, dict):
+            raise TypeError("value must be a dictionary")
+        for name, part in parts.items():
+            if not isinstance(part, dict):
+                raise TypeError(f"part {name!r} must be a dictionary")
+            # implicit plugin fixup
+            if "plugin" not in part:
+                part["plugin"] = name
+        return parts
+
+    @pydantic.validator("parts", each_item=True)
+    def validate_charm_part(cls, item):
+        """Verify each part (craft-parts will re-validate this)."""
+        validate_part(item)
+        return item
 
     @classmethod
     def expand_short_form_bases(cls, bases: List[Dict[str, Any]]) -> None:

--- a/charmcraft/config.py
+++ b/charmcraft/config.py
@@ -332,7 +332,11 @@ class Config(ModelConfigDefaults, validate_all=False):
                 raise TypeError(f"part {name!r} must be a dictionary")
             # implicit plugin fixup
             if "plugin" not in part:
-                part["plugin"] = name
+                # XXX: remove special case after including the bundle plugin
+                if name == "bundle":
+                    part["plugin"] = "nil"
+                else:
+                    part["plugin"] = name
         return parts
 
     @pydantic.validator("parts", each_item=True)

--- a/charmcraft/logsetup.py
+++ b/charmcraft/logsetup.py
@@ -34,6 +34,7 @@ logger = logging.getLogger("charmcraft")
 enabled_loggers = [
     logger,
     logging.getLogger("craft_providers"),
+    logging.getLogger("craft_parts"),
 ]
 
 

--- a/charmcraft/main.py
+++ b/charmcraft/main.py
@@ -25,6 +25,7 @@ from charmcraft import config, env, helptexts
 from charmcraft.cmdbase import BaseCommand, CommandError
 from charmcraft.commands import build, clean, init, pack, store, version
 from charmcraft.logsetup import message_handler
+from charmcraft.parts import setup_parts
 
 logger = logging.getLogger(__name__)
 
@@ -358,6 +359,7 @@ def main(argv=None):
     # process
     try:
         env.ensure_charmcraft_environment_is_supported()
+        setup_parts()
         dispatcher = Dispatcher(argv[1:], COMMAND_GROUPS)
         dispatcher.run()
     except CommandError as err:

--- a/charmcraft/manifest.py
+++ b/charmcraft/manifest.py
@@ -24,7 +24,6 @@ from typing import Optional, List
 import yaml
 
 from charmcraft import __version__, config, linters
-from charmcraft.cmdbase import CommandError
 
 logger = logging.getLogger(__name__)
 
@@ -72,9 +71,5 @@ def create_manifest(
     content["analysis"] = {"attributes": attributes_info}
 
     filepath = basedir / "manifest.yaml"
-    if filepath.exists():
-        raise CommandError(
-            "Cannot write the manifest as there is already a 'manifest.yaml' in disk."
-        )
     filepath.write_text(yaml.dump(content))
     return filepath

--- a/charmcraft/parts.py
+++ b/charmcraft/parts.py
@@ -203,9 +203,7 @@ class PartsLifecycle:
             # invalidate build if packing a charm and entrypoint changed
             if "charm" in self._all_parts:
                 entrypoint = os.path.normpath(self._lcm.project_info.entrypoint)
-                dis_entrypoint = os.path.normpath(
-                    _get_dispatch_entrypoint(self.prime_dir)
-                )
+                dis_entrypoint = os.path.normpath(_get_dispatch_entrypoint(self.prime_dir))
                 if entrypoint != dis_entrypoint:
                     self._lcm.clean(Step.BUILD, part_names=["charm"])
                     self._lcm.reload_state()

--- a/charmcraft/parts.py
+++ b/charmcraft/parts.py
@@ -1,0 +1,243 @@
+# Copyright 2021 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For further info, check https://github.com/canonical/charmcraft
+
+"""Craft-parts setup, lifecycle and plugins."""
+
+import logging
+import os
+import pathlib
+import shlex
+import sys
+from typing import Any, Dict, List, Set
+
+from craft_parts import LifecycleManager, Step, plugins
+from craft_parts.parts import PartSpec
+from craft_parts.errors import PartsError
+from xdg import BaseDirectory  # type: ignore
+
+from charmcraft import charm_builder
+from charmcraft.cmdbase import CommandError
+
+logger = logging.getLogger(__name__)
+
+
+class CharmPluginProperties(plugins.PluginProperties, plugins.PluginModel):
+    """Properties used in charm building."""
+
+    source: str = ""
+    # TODO: add charm plugin properties
+
+    @classmethod
+    def unmarshal(cls, data: Dict[str, Any]):
+        """Populate charm properties from the part specification.
+
+        :param data: A dictionary containing part properties.
+
+        :return: The populated plugin properties data object.
+
+        :raise pydantic.ValidationError: If validation fails.
+        """
+        plugin_data = plugins.extract_plugin_properties(
+            data, plugin_name="charm", required=["source"]
+        )
+        return cls(**plugin_data)
+
+
+class CharmPlugin(plugins.Plugin):
+    """Build the charm and prepare for packing.
+
+    The craft-parts charm plugin prepares the charm payload for packing. Common
+    plugin and source keywords can be used.
+
+    Extra files to be included in the charm payload must be listed under
+    the ``prime`` file filter.
+    """
+
+    properties_class = CharmPluginProperties
+
+    @classmethod
+    def get_build_snaps(cls) -> Set[str]:
+        """Return a set of required snaps to install in the build environment."""
+        return set()
+
+    def get_build_packages(self) -> Set[str]:
+        """Return a set of required packages to install in the build environment."""
+        return {
+            "python3-pip",
+            "python3-setuptools",
+            "python3-wheel",
+        }
+
+    def get_build_environment(self) -> Dict[str, str]:
+        """Return a dictionary with the environment to use in the build step."""
+        return {}
+
+    def get_build_commands(self) -> List[str]:
+        """Return a list of commands to run during the build step."""
+        build_env = dict(LANG="C.UTF-8", LC_ALL="C.UTF-8")
+        for key in [
+            "PATH",
+            "SNAP",
+            "SNAP_ARCH",
+            "SNAP_NAME",
+            "SNAP_VERSION",
+            "http_proxy",
+            "https_proxy",
+            "no_proxy",
+        ]:
+            if key in os.environ:
+                build_env[key] = os.environ[key]
+
+        env_flags = [f"{key}={value}" for key, value in build_env.items()]
+
+        # invoke the charm builder
+        build_cmd = [
+            "env",
+            "-i",
+            *env_flags,
+            sys.executable,
+            "-I",
+            charm_builder.__file__,
+            "--charmdir",
+            str(self._part_info.part_build_dir),
+            "--builddir",
+            str(self._part_info.part_install_dir),
+        ]
+
+        if self._part_info.entrypoint:
+            entrypoint = self._part_info.part_build_dir / self._part_info.entrypoint
+            build_cmd.extend(["--entrypoint", str(entrypoint)])
+
+        for req in self._part_info.requirements:
+            build_cmd.extend(["-r", req])
+
+        commands = [" ".join(shlex.quote(i) for i in build_cmd)]
+
+        return commands
+
+
+def setup_parts():
+    """Initialize craft-parts plugins."""
+    plugins.register({"charm": CharmPlugin})
+
+
+def validate_part(data: Dict[str, Any]) -> None:
+    """Validate the given part data against common and plugin models.
+
+    :param data: The part data to validate.
+    """
+    if not isinstance(data, dict):
+        raise TypeError("value must be a dictionary")
+
+    # copy the original data, we'll modify it
+    spec = data.copy()
+
+    plugin_name = spec.get("plugin", "")
+    if not plugin_name:
+        raise ValueError("'plugin' not defined")
+
+    plugin_class = plugins.get_plugin_class(plugin_name)
+
+    # validate plugin properties
+    plugin_class.properties_class.unmarshal(spec)
+
+    # validate common part properties
+    plugins.strip_plugin_properties(spec, plugin_name=plugin_name)
+    PartSpec(**spec)
+
+
+class PartsLifecycle:
+    """Create and manage the parts lifecycle."""
+
+    def __init__(
+        self,
+        all_parts: Dict[str, Any],
+        *,
+        work_dir: pathlib.Path,
+        entrypoint: pathlib.Path,
+        requirements: List[pathlib.Path],
+    ):
+        self._all_parts = all_parts
+
+        # set the cache dir for parts package management
+        cache_dir = BaseDirectory.save_cache_path("charmcraft")
+
+        try:
+            self._lcm = LifecycleManager(
+                {"parts": all_parts},
+                application_name="charmcraft",
+                work_dir=work_dir,
+                cache_dir=cache_dir,
+                ignore_local_sources=["*.charm"],
+                entrypoint=entrypoint,
+                requirements=requirements,
+            )
+            self._lcm.refresh_packages_list()
+        except PartsError as err:
+            raise CommandError(err)
+
+    @property
+    def prime_dir(self) -> pathlib.Path:
+        """Return the parts prime directory path."""
+        return self._lcm.project_info.prime_dir
+
+    def run(self, target_step: Step) -> None:
+        """Run the parts lifecycle.
+
+        :param target_step: The final step to execute.
+        """
+        try:
+            # invalidate build if packing a charm and entrypoint changed
+            if "charm" in self._all_parts:
+                entrypoint = os.path.normpath(self._lcm.project_info.entrypoint)
+                dis_entrypoint = os.path.normpath(
+                    _get_dispatch_entrypoint(self.prime_dir)
+                )
+                if entrypoint != dis_entrypoint:
+                    self._lcm.clean(Step.BUILD, part_names=["charm"])
+                    self._lcm.reload_state()
+
+            actions = self._lcm.plan(target_step)
+            logger.debug("Parts actions: %s", actions)
+            with self._lcm.action_executor() as aex:
+                aex.execute(actions)
+        except RuntimeError as err:
+            raise RuntimeError(f"Parts processing internal error: {err}") from err
+        except OSError as err:
+            msg = err.strerror
+            if err.filename:
+                msg = f"{err.filename}: {msg}"
+            raise CommandError(f"Parts processing error: {msg}") from err
+        except Exception as err:
+            raise CommandError(f"Parts processing error: {err}") from err
+
+
+def _get_dispatch_entrypoint(dirname: pathlib.Path) -> str:
+    """Read the entrypoint from the dispatch file."""
+    dispatch = dirname / charm_builder.DISPATCH_FILENAME
+    entrypoint_str = ""
+    try:
+        with dispatch.open("rt", encoding="utf8") as fh:
+            last_line = None
+            for line in fh:
+                if line.strip():
+                    last_line = line
+            if last_line:
+                entrypoint_str = shlex.split(last_line)[-1]
+    except (IOError, UnicodeDecodeError):
+        return ""
+
+    return entrypoint_str

--- a/charmcraft/parts.py
+++ b/charmcraft/parts.py
@@ -145,7 +145,7 @@ def validate_part(data: Dict[str, Any]) -> None:
     # copy the original data, we'll modify it
     spec = data.copy()
 
-    plugin_name = spec.get("plugin", "")
+    plugin_name = spec.get("plugin")
     if not plugin_name:
         raise ValueError("'plugin' not defined")
 

--- a/charmcraft/parts.py
+++ b/charmcraft/parts.py
@@ -75,7 +75,11 @@ class CharmPlugin(plugins.Plugin):
 
     def get_build_packages(self) -> Set[str]:
         """Return a set of required packages to install in the build environment."""
-        return {}
+        return {
+            "python3-pip",
+            "python3-setuptools",
+            "python3-wheel",
+        }
 
     def get_build_environment(self) -> Dict[str, str]:
         """Return a dictionary with the environment to use in the build step."""

--- a/charmcraft/parts.py
+++ b/charmcraft/parts.py
@@ -75,11 +75,7 @@ class CharmPlugin(plugins.Plugin):
 
     def get_build_packages(self) -> Set[str]:
         """Return a set of required packages to install in the build environment."""
-        return {
-            "python3-pip",
-            "python3-setuptools",
-            "python3-wheel",
-        }
+        return {}
 
     def get_build_environment(self) -> Dict[str, str]:
         """Return a dictionary with the environment to use in the build step."""

--- a/charmcraft/providers.py
+++ b/charmcraft/providers.py
@@ -21,7 +21,6 @@ import logging
 import os
 import pathlib
 import re
-import subprocess
 import tempfile
 from typing import Dict, List, Optional, Tuple, Union
 
@@ -319,27 +318,6 @@ class CharmcraftBuilddBaseConfiguration(bases.BuilddBase):
         :raises BaseConfigurationError: on other unexpected error.
         """
         super().setup(executor=executor, retry_wait=retry_wait, timeout=timeout)
-
-        try:
-            # XXX Patterson 2021-07-02: craft-parts will determine/install these
-            # deps as a matter of the plugin(s) and source(s) being used.
-            executor.execute_run(
-                [
-                    "apt-get",
-                    "install",
-                    "-y",
-                    "git",
-                    "python3-pip",
-                    "python3-setuptools",
-                    "python3-wheel",
-                ],
-                check=True,
-                capture_output=True,
-            )
-        except subprocess.CalledProcessError as error:
-            raise bases.BaseConfigurationError(
-                brief="Failed to install the required dependencies.",
-            ) from error
 
         try:
             snap_installer.inject_from_host(

--- a/charmcraft/providers.py
+++ b/charmcraft/providers.py
@@ -322,7 +322,7 @@ class CharmcraftBuilddBaseConfiguration(bases.BuilddBase):
 
         try:
             # XXX Claudio 2021-07-22: craft-parts uses sudo, install it until
-            # we adjust it to detect if running as superuser is needed.
+            # we adjust it to detect if changing to superuser is needed.
             executor.execute_run(
                 [
                     "apt-get",

--- a/charmcraft/providers.py
+++ b/charmcraft/providers.py
@@ -21,6 +21,7 @@ import logging
 import os
 import pathlib
 import re
+import subprocess
 import tempfile
 from typing import Dict, List, Optional, Tuple, Union
 
@@ -318,6 +319,24 @@ class CharmcraftBuilddBaseConfiguration(bases.BuilddBase):
         :raises BaseConfigurationError: on other unexpected error.
         """
         super().setup(executor=executor, retry_wait=retry_wait, timeout=timeout)
+
+        try:
+            # XXX Claudio 2021-07-22: craft-parts uses sudo, install it until
+            # we adjust it to detect if running as superuser is needed.
+            executor.execute_run(
+                [
+                    "apt-get",
+                    "install",
+                    "-y",
+                    "sudo",
+                ],
+                check=True,
+                capture_output=True,
+            )
+        except subprocess.CalledProcessError as error:
+            raise bases.BaseConfigurationError(
+                brief="Failed to install the required dependencies.",
+            ) from error
 
         try:
             snap_installer.inject_from_host(

--- a/requirements-bionic.txt
+++ b/requirements-bionic.txt
@@ -1,0 +1,1 @@
+http://archive.ubuntu.com/ubuntu/pool/main/p/python-apt/python-apt_1.6.5ubuntu0.5.tar.xz; sys_platform == 'linux'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ cffi==1.14.6
 charset-normalizer==2.0.3
 click==8.0.1
 coverage==5.5
-craft-parts @ https://github.com/canonical/craft-parts/archive/refs/tags/v1.0-alpha.1.tar.gz
+craft-parts @ https://github.com/canonical/craft-parts/archive/refs/tags/v1.0-alpha.2.tar.gz
 craft-providers==1.0.1
 flake8==3.9.2
 humanize==3.10.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,6 +6,7 @@ cffi==1.14.6
 charset-normalizer==2.0.3
 click==8.0.1
 coverage==5.5
+craft-parts @ https://github.com/canonical/craft-parts/archive/refs/tags/v1.0-alpha.1.tar.gz
 craft-providers==1.0.1
 flake8==3.9.2
 humanize==3.10.0
@@ -21,11 +22,13 @@ ops==1.2.0
 packaging==21.0
 pathspec==0.9.0
 pluggy==0.13.1
+progressbar==2.5
 protobuf==3.17.3
 py==1.10.0
 pycodestyle==2.7.0
 pycparser==2.20
 pydantic==1.8.2
+pydantic-yaml==0.4.2
 pydocstyle==6.1.1
 pyflakes==2.3.1
 pymacaroons==0.13.0
@@ -36,12 +39,14 @@ pyrsistent==0.18.0
 pytest==6.2.4
 python-dateutil==2.8.2
 pytz==2021.1
+pyxdg==0.27
 PyYAML==5.4.1
 regex==2021.7.6
 requests==2.26.0
 requests-toolbelt==0.9.1
 requests-unixsocket==0.2.0
 responses==0.13.3
+semver==2.13.0
 six==1.16.0
 snowballstemmer==2.1.0
 tabulate==0.8.9

--- a/requirements-focal.txt
+++ b/requirements-focal.txt
@@ -1,0 +1,1 @@
+http://archive.ubuntu.com/ubuntu/pool/main/p/python-apt/python-apt_2.0.0ubuntu0.20.04.5.tar.xz; sys_platform == 'linux'

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ attrs==21.2.0
 certifi==2021.5.30
 cffi==1.14.6
 charset-normalizer==2.0.3
-craft-parts @ https://github.com/canonical/craft-parts/archive/refs/tags/v1.0-alpha.1.tar.gz
+craft-parts @ https://github.com/canonical/craft-parts/archive/refs/tags/v1.0-alpha.2.tar.gz
 craft-providers==1.0.1
 humanize==3.10.0
 idna==3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ attrs==21.2.0
 certifi==2021.5.30
 cffi==1.14.6
 charset-normalizer==2.0.3
+craft-parts @ https://github.com/canonical/craft-parts/archive/refs/tags/v1.0-alpha.1.tar.gz
 craft-providers==1.0.1
 humanize==3.10.0
 idna==3.2
@@ -10,19 +11,23 @@ Jinja2==3.0.1
 jsonschema==3.2.0
 macaroonbakery==1.3.1
 MarkupSafe==2.0.1
+progressbar==2.5
 protobuf==3.17.3
 pycparser==2.20
 pydantic==1.8.2
+pydantic-yaml==0.4.2
 pymacaroons==0.13.0
 PyNaCl==1.4.0
 pyRFC3339==1.1
 pyrsistent==0.18.0
 python-dateutil==2.8.2
 pytz==2021.1
+pyxdg==0.27
 PyYAML==5.4.1
 requests==2.26.0
 requests-toolbelt==0.9.1
 requests-unixsocket==0.2.0
+semver==2.13.0
 six==1.16.0
 tabulate==0.8.9
 typing-extensions==3.10.0.0

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ with open("README.md", "rt", encoding="utf8") as fh:
 install_requires = [
     "appdirs",
     "attrs",
+    "craft-parts @ https://github.com/canonical/craft-parts/archive/refs/tags/v1.0-alpha.1.tar.gz",
     "craft-providers",
     "humanize>=2.6.0",
     "jsonschema",

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ with open("README.md", "rt", encoding="utf8") as fh:
 install_requires = [
     "appdirs",
     "attrs",
-    "craft-parts @ https://github.com/canonical/craft-parts/archive/refs/tags/v1.0-alpha.1.tar.gz",
+    "craft-parts @ https://github.com/canonical/craft-parts/archive/refs/tags/v1.0-alpha.2.tar.gz",
     "craft-providers",
     "humanize>=2.6.0",
     "jsonschema",

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -93,11 +93,16 @@ parts:
     source: .
     plugin: python
     requirements:
+      - requirements-focal.txt
       - requirements.txt
     build-packages:
       - libffi-dev
+      - libapt-pkg-dev
     stage-packages:
       - git
+      - apt
+      - apt-transport-https
+      - apt-utils
     # snapcraft uses venv, which doesn't pull in wheel (as opposed to virtualenv)
     # so then 'pip install PyYAML' gets cross.
     python-packages: [wheel]

--- a/tests/commands/test_build.py
+++ b/tests/commands/test_build.py
@@ -541,8 +541,7 @@ def test_build_basic_complete_structure(basic_project, caplog, monkeypatch, conf
     assert (
         manifest["charmcraft-started-at"] == config.project.started_at.isoformat() + "Z"
     )
-    # XXX: temporarily disabled until we land craft-parts PR #98
-    # assert caplog.records == []
+    assert caplog.records == []
 
 
 def test_build_error_without_metadata_yaml(basic_project, monkeypatch):

--- a/tests/commands/test_build.py
+++ b/tests/commands/test_build.py
@@ -541,7 +541,8 @@ def test_build_basic_complete_structure(basic_project, caplog, monkeypatch, conf
     assert (
         manifest["charmcraft-started-at"] == config.project.started_at.isoformat() + "Z"
     )
-    assert caplog.records == []
+    # XXX: temporarily disabled until we land craft-parts PR #98
+    # assert caplog.records == []
 
 
 def test_build_error_without_metadata_yaml(basic_project, monkeypatch):

--- a/tests/commands/test_build.py
+++ b/tests/commands/test_build.py
@@ -29,7 +29,7 @@ from unittest.mock import call, patch
 import pytest
 import yaml
 
-from charmcraft import charm_builder, linters
+from charmcraft import linters
 from charmcraft.bases import get_host_as_base
 from charmcraft.cmdbase import CommandError
 from charmcraft.commands.build import (
@@ -1206,76 +1206,6 @@ def test_build_error_no_match_with_charmcraft_yaml(
     )
 
 
-def test_build_invoke_charm_builder(tmp_path, config, monkeypatch):
-    """Check transferred metadata and simple entrypoint, also return proper linked entrypoint."""
-    build_dir = tmp_path / BUILD_DIRNAME
-    build_dir.mkdir()
-
-    metadata = tmp_path / CHARM_METADATA
-    metadata.write_text("name: crazycharm")
-
-    entrypoint = tmp_path / "crazycharm.py"
-    entrypoint.touch()
-
-    builder = Builder(
-        {
-            "from": tmp_path,
-            "entrypoint": entrypoint,
-            "requirement": [tmp_path / "req1.txt", tmp_path / "req2.txt"],
-            "force": False,
-        },
-        config,
-    )
-
-    monkeypatch.setenv("CHARMCRAFT_MANAGED_MODE", "1")
-    monkeypatch.setenv("PATH", "/some/path")
-    monkeypatch.setenv("SNAP", "snap_value")
-    monkeypatch.setenv("SNAP_ARCH", "snap_arch_value")
-    monkeypatch.setenv("SNAP_NAME", "snap_name_value")
-    monkeypatch.setenv("SNAP_VERSION", "snap_version_value")
-    monkeypatch.setenv("http_proxy", "http_proxy_value")
-    monkeypatch.setenv("https_proxy", "https_proxy_value")
-    monkeypatch.setenv("no_proxy", "no_proxy_value")
-    with patch("charmcraft.commands.build.polite_exec") as mock_run:
-        mock_run.side_effect = [1]
-        with patch(
-            "charmcraft.commands.build.check_if_base_matches_host",
-            return_value=(True, None),
-        ):
-            with pytest.raises(CommandError, match="problems running charm builder"):
-                builder.run()
-
-    mock_run.assert_called_with(
-        [
-            "env",
-            "-i",
-            "LANG=C.UTF-8",
-            "LC_ALL=C.UTF-8",
-            "PATH=/some/path",
-            "SNAP=snap_value",
-            "SNAP_ARCH=snap_arch_value",
-            "SNAP_NAME=snap_name_value",
-            "SNAP_VERSION=snap_version_value",
-            "http_proxy=http_proxy_value",
-            "https_proxy=https_proxy_value",
-            "no_proxy=no_proxy_value",
-            sys.executable,
-            "-I",
-            charm_builder.__file__,
-            "--charmdir",
-            str(tmp_path),
-            "--builddir",
-            str(build_dir),
-            "--entrypoint",
-            str(entrypoint),
-            "-r",
-            str(tmp_path / "req1.txt"),
-            "-r",
-            str(tmp_path / "req2.txt"),
-        ],
-    )
-
-
 def test_build_package_tree_structure(tmp_path, monkeypatch, config):
     """The zip file is properly built internally."""
     # the metadata
@@ -1332,7 +1262,7 @@ def test_build_package_tree_structure(tmp_path, monkeypatch, config):
         },
         config,
     )
-    zipname = builder.handle_package()
+    zipname = builder.handle_package(to_be_zipped_dir)
 
     # check the stuff outside is not in the zip, the stuff inside is zipped (with
     # contents!), and all relative to build dir
@@ -1370,7 +1300,7 @@ def test_build_package_name(tmp_path, monkeypatch, config):
         },
         config,
     )
-    zipname = builder.handle_package()
+    zipname = builder.handle_package(to_be_zipped_dir)
 
     assert zipname == "name-from-metadata.charm"
 
@@ -1416,7 +1346,7 @@ def test_build_using_linters_attributes(basic_project, monkeypatch, config):
                 zipnames = builder.run()
 
     # check the analyze and processing functions were called properly
-    mock_analyze.assert_called_with(config, builder.buildpath)
+    mock_analyze.assert_called_with(config, builder.buildpath / "prime")
     mock_show_lint.assert_called_with(linting_results)
 
     # the manifest should have all the results (including the ignored one)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,6 +101,31 @@ def config(tmp_path):
     return TestConfig(type="charm", parts=parts, project=project)
 
 
+@pytest.fixture
+def bundle_config(tmp_path):
+    """Provide a config class with an extra set method for the test to change it."""
+
+    class TestConfig(config_module.Config, frozen=False):
+        """The Config, but with a method to set test values."""
+
+        def set(self, prime=None, **kwargs):
+            # prime is special, so we don't need to write all this structure in all tests
+            if prime is not None:
+                self.parts["bundle"] = {"prime": prime}
+
+            # the rest is direct
+            for k, v in kwargs.items():
+                object.__setattr__(self, k, v)
+
+    project = config_module.Project(
+        dirpath=tmp_path,
+        started_at=datetime.datetime.utcnow(),
+        config_provided=True,
+    )
+
+    return TestConfig(type="bundle", project=project)
+
+
 @pytest.fixture(autouse=True)
 def clean_already_notified():
     """Clear the already-notified structure for each test.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,7 @@ import responses as responses_module
 
 from charmcraft import config as config_module
 from charmcraft import deprecations
+from charmcraft import parts
 
 
 @pytest.fixture()
@@ -38,6 +39,11 @@ def caplog_filter(caplog):
 @pytest.fixture(autouse=True, scope="session")
 def tmpdir_under_tmpdir(tmpdir_factory):
     tempfile.tempdir = str(tmpdir_factory.getbasetemp())
+
+
+@pytest.fixture(autouse=True, scope="session")
+def setup_parts():
+    parts.setup_parts()
 
 
 @pytest.fixture
@@ -73,10 +79,7 @@ def config(tmp_path):
         def set(self, prime=None, **kwargs):
             # prime is special, so we don't need to write all this structure in all tests
             if prime is not None:
-                self.parts.bundle.prime.clear()
-                self.parts.bundle.prime.extend(prime)
-            else:
-                self.parts = config_module.Parts()
+                self.parts["charm"] = {"prime": prime}
 
             # the rest is direct
             for k, v in kwargs.items():
@@ -87,7 +90,15 @@ def config(tmp_path):
         started_at=datetime.datetime.utcnow(),
         config_provided=True,
     )
-    return TestConfig(type="bundle", project=project)
+
+    # implicit plugin is added by the validator during unmarshal
+    parts = {
+        "charm": {
+            "plugin": "charm",
+        }
+    }
+
+    return TestConfig(type="charm", parts=parts, project=project)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -427,10 +427,7 @@ def test_schema_basicprime_bad_prime_type_empty(create_config, check_schema_erro
     """
     )
     check_schema_error(
-        (
-            "Bad charmcraft.yaml content:\n"
-            "- path cannot be empty in field 'parts.charm.prime[0]'"
-        )
+        ("Bad charmcraft.yaml content:\n" "- path cannot be empty in field 'parts.charm.prime[0]'")
     )
 
 

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -17,11 +17,9 @@
 import datetime
 from unittest.mock import patch
 
-import pytest
 import yaml
 
 from charmcraft import __version__, config, linters
-from charmcraft.cmdbase import CommandError
 from charmcraft.manifest import create_manifest
 from charmcraft.utils import OSPlatform
 
@@ -112,32 +110,6 @@ def test_manifest_no_bases(tmp_path):
         "charmcraft-version": __version__,
         "analysis": {"attributes": []},
     }
-
-
-def test_manifest_dont_overwrite(tmp_path):
-    """Don't overwrite the already-existing file."""
-    (tmp_path / "manifest.yaml").touch()
-    bases_config = config.BasesConfiguration(
-        **{
-            "build-on": [
-                config.Base(
-                    name="test-name",
-                    channel="test-channel",
-                ),
-            ],
-            "run-on": [
-                config.Base(
-                    name="test-name",
-                    channel="test-channel",
-                ),
-            ],
-        }
-    )
-    with pytest.raises(CommandError) as cm:
-        create_manifest(tmp_path, datetime.datetime.now(), bases_config, [])
-    assert str(cm.value) == (
-        "Cannot write the manifest as there is already a 'manifest.yaml' in disk."
-    )
 
 
 def test_manifest_checkers_multiple(tmp_path):

--- a/tests/test_parts.py
+++ b/tests/test_parts.py
@@ -1,0 +1,271 @@
+# Copyright 2020-2021 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For further info, check https://github.com/canonical/charmcraft
+
+import pathlib
+import sys
+from unittest.mock import patch
+
+import craft_parts
+import pydantic
+import pytest
+from craft_parts import Step, plugins
+
+from charmcraft import charm_builder, parts
+
+
+class TestCharmPlugin:
+    """Ensure plugin methods return expected data."""
+
+    @pytest.fixture(autouse=True)
+    def setup_method_fixture(self, tmp_path):
+        project_dirs = craft_parts.ProjectDirs(work_dir=tmp_path)
+        part = craft_parts.Part("foo", {"plugin": "charm"}, project_dirs=project_dirs)
+        project_info = craft_parts.ProjectInfo(
+            application_name="test",
+            project_dirs=project_dirs,
+            cache_dir=tmp_path,
+            entrypoint="entrypoint",
+            requirements=["reqs1.txt", "reqs2.txt"],
+        )
+        part_info = craft_parts.PartInfo(project_info=project_info, part=part)
+
+        self._plugin = plugins.get_plugin(
+            part=part,
+            part_info=part_info,
+            properties=parts.CharmPluginProperties(),
+        )
+
+    def test_get_build_package(self):
+        assert self._plugin.get_build_packages() == {
+            "python3-pip",
+            "python3-setuptools",
+            "python3-wheel",
+        }
+
+    def test_get_build_snaps(self):
+        assert self._plugin.get_build_snaps() == set()
+
+    def test_get_build_environment(self):
+        assert self._plugin.get_build_environment() == {}
+
+    def test_get_build_commands(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("PATH", "/some/path")
+        monkeypatch.setenv("SNAP", "snap_value")
+        monkeypatch.setenv("SNAP_ARCH", "snap_arch_value")
+        monkeypatch.setenv("SNAP_NAME", "snap_name_value")
+        monkeypatch.setenv("SNAP_VERSION", "snap_version_value")
+        monkeypatch.setenv("http_proxy", "http_proxy_value")
+        monkeypatch.setenv("https_proxy", "https_proxy_value")
+        monkeypatch.setenv("no_proxy", "no_proxy_value")
+
+        assert self._plugin.get_build_commands() == [
+            "env -i LANG=C.UTF-8 LC_ALL=C.UTF-8 PATH=/some/path SNAP=snap_value "
+            "SNAP_ARCH=snap_arch_value SNAP_NAME=snap_name_value "
+            "SNAP_VERSION=snap_version_value http_proxy=http_proxy_value "
+            "https_proxy=https_proxy_value no_proxy=no_proxy_value "
+            "{python} -I "
+            "{charm_builder} "
+            "--charmdir {work_dir}/parts/foo/build "
+            "--builddir {work_dir}/parts/foo/install "
+            "--entrypoint {work_dir}/parts/foo/build/entrypoint "
+            "-r reqs1.txt "
+            "-r reqs2.txt".format(
+                python=sys.executable,
+                charm_builder=charm_builder.__file__,
+                work_dir=str(tmp_path),
+            )
+        ]
+
+    def test_invalid_properties(self):
+        with pytest.raises(pydantic.ValidationError) as raised:
+            parts.CharmPlugin.properties_class.unmarshal(
+                {"source": ".", "charm-invalid": True}
+            )
+        err = raised.value.errors()
+        assert len(err) == 1
+        assert err[0]["loc"] == ("charm-invalid",)
+        assert err[0]["type"] == "value_error.extra"
+
+
+class TestPartsLifecycle:
+    """Ensure parts data correctly used in lifecycle."""
+
+    def test_prime_dir(self, tmp_path):
+        data = {
+            "plugin": "charm",
+            "source": ".",
+        }
+
+        with patch("craft_parts.LifecycleManager.refresh_packages_list"):
+            lifecycle = parts.PartsLifecycle(
+                all_parts={"charm": data},
+                work_dir="/some/workdir",
+                entrypoint="my_entrypoint",
+                requirements=["reqs1.txt", "reqs2.txt"],
+            )
+        assert lifecycle.prime_dir == pathlib.Path("/some/workdir/prime")
+
+    def test_run_new_entrypoint(self, tmp_path, monkeypatch):
+        data = {
+            "plugin": "charm",
+            "source": ".",
+        }
+
+        # create dispatcher from previous run
+        prime_dir = tmp_path / "prime"
+        prime_dir.mkdir()
+        dispatch = prime_dir / "dispatch"
+        dispatch.write_text(
+            'JUJU_DISPATCH_PATH="${JUJU_DISPATCH_PATH:-$0}" PYTHONPATH=lib:venv ./src/charm.py'
+        )
+
+        lifecycle = parts.PartsLifecycle(
+            all_parts={"charm": data},
+            work_dir=tmp_path,
+            entrypoint="my_entrypoint",
+            requirements=["reqs1.txt", "reqs2.txt"],
+        )
+
+        with patch("craft_parts.LifecycleManager.clean") as mock_clean:
+            with patch("craft_parts.LifecycleManager.plan") as mock_plan:
+                mock_plan.side_effect = SystemExit("test")
+                with pytest.raises(SystemExit, match="test"):
+                    lifecycle.run(Step.PRIME)
+
+        mock_clean.assert_called_once_with(Step.BUILD, part_names=["charm"])
+
+    def test_run_same_entrypoint(self, tmp_path, monkeypatch):
+        data = {
+            "plugin": "charm",
+            "source": ".",
+        }
+
+        # create dispatcher from previous run
+        prime_dir = tmp_path / "prime"
+        prime_dir.mkdir()
+        dispatch = prime_dir / "dispatch"
+        dispatch.write_text(
+            'JUJU_DISPATCH_PATH="${JUJU_DISPATCH_PATH:-$0}" PYTHONPATH=lib:venv ./src/charm.py'
+        )
+
+        lifecycle = parts.PartsLifecycle(
+            all_parts={"charm": data},
+            work_dir=tmp_path,
+            entrypoint="src/charm.py",
+            requirements=["reqs1.txt", "reqs2.txt"],
+        )
+
+        with patch("craft_parts.LifecycleManager.clean") as mock_clean:
+            with patch("craft_parts.LifecycleManager.plan") as mock_plan:
+                mock_plan.side_effect = SystemExit("test")
+                with pytest.raises(SystemExit, match="test"):
+                    lifecycle.run(Step.PRIME)
+
+        mock_clean.assert_not_called()
+
+    def test_run_no_previous_entrypoint(self, tmp_path, monkeypatch):
+        data = {
+            "plugin": "charm",
+            "source": ".",
+        }
+
+        lifecycle = parts.PartsLifecycle(
+            all_parts={"charm": data},
+            work_dir=tmp_path,
+            entrypoint="my_entrypoint",
+            requirements=["reqs1.txt", "reqs2.txt"],
+        )
+
+        with patch("craft_parts.LifecycleManager.clean") as mock_clean:
+            with patch("craft_parts.LifecycleManager.plan") as mock_plan:
+                mock_plan.side_effect = SystemExit("test")
+                with pytest.raises(SystemExit, match="test"):
+                    lifecycle.run(Step.PRIME)
+
+        mock_clean.assert_called_once_with(Step.BUILD, part_names=["charm"])
+
+
+class TestPartHelpers:
+    """Verify helper functions."""
+
+    def test_get_dispatch_entrypoint(self, tmp_path):
+        dispatch = tmp_path / "dispatch"
+        dispatch.write_text(
+            'JUJU_DISPATCH_PATH="${JUJU_DISPATCH_PATH:-$0}" PYTHONPATH=lib:venv ./my/entrypoint'
+        )
+        entrypoint = parts._get_dispatch_entrypoint(tmp_path)
+        assert entrypoint == "./my/entrypoint"
+
+    def test_get_dispatch_entrypoint_no_file(self, tmp_path):
+        entrypoint = parts._get_dispatch_entrypoint(tmp_path)
+        assert entrypoint == ""
+
+
+class TestPartValidation:
+    """Part data validation scenarios."""
+
+    def test_part_validation_happy(self):
+        data = {
+            "plugin": "charm",
+            "source": ".",
+        }
+        parts.validate_part(data)
+
+    def test_part_validation_no_plugin(self):
+        data = {
+            "source": ".",
+        }
+        with pytest.raises(ValueError) as raised:
+            parts.validate_part(data)
+        assert str(raised.value) == "'plugin' not defined"
+
+    def test_part_validation_bad_property(self):
+        data = {
+            "plugin": "charm",
+            "source": ".",
+            "color": "purple",
+        }
+        with pytest.raises(pydantic.ValidationError) as raised:
+            parts.validate_part(data)
+        err = raised.value.errors()
+        assert len(err) == 1
+        assert err[0]["loc"] == ("color",)
+        assert err[0]["msg"] == "extra fields not permitted"
+
+    def test_part_validation_bad_type(self):
+        data = {
+            "plugin": "charm",
+            "source": ["."],
+        }
+        with pytest.raises(pydantic.ValidationError) as raised:
+            parts.validate_part(data)
+        err = raised.value.errors()
+        assert len(err) == 1
+        assert err[0]["loc"] == ("source",)
+        assert err[0]["msg"] == "str type expected"
+
+    def test_part_validation_bad_plugin_property(self):
+        data = {
+            "plugin": "charm",
+            "charm-timeout": "never",
+            "source": ".",
+        }
+        with pytest.raises(pydantic.ValidationError) as raised:
+            parts.validate_part(data)
+        err = raised.value.errors()
+        assert len(err) == 1
+        assert err[0]["loc"] == ("charm-timeout",)
+        assert err[0]["msg"] == "extra fields not permitted"

--- a/tests/test_parts.py
+++ b/tests/test_parts.py
@@ -91,9 +91,7 @@ class TestCharmPlugin:
 
     def test_invalid_properties(self):
         with pytest.raises(pydantic.ValidationError) as raised:
-            parts.CharmPlugin.properties_class.unmarshal(
-                {"source": ".", "charm-invalid": True}
-            )
+            parts.CharmPlugin.properties_class.unmarshal({"source": ".", "charm-invalid": True})
         err = raised.value.errors()
         assert len(err) == 1
         assert err[0]["loc"] == ("charm-invalid",)

--- a/tests/test_parts.py
+++ b/tests/test_parts.py
@@ -49,7 +49,11 @@ class TestCharmPlugin:
         )
 
     def test_get_build_package(self):
-        assert self._plugin.get_build_packages() == {}
+        assert self._plugin.get_build_packages() == {
+            "python3-pip",
+            "python3-setuptools",
+            "python3-wheel",
+        }
 
     def test_get_build_snaps(self):
         assert self._plugin.get_build_snaps() == set()

--- a/tests/test_parts.py
+++ b/tests/test_parts.py
@@ -49,11 +49,7 @@ class TestCharmPlugin:
         )
 
     def test_get_build_package(self):
-        assert self._plugin.get_build_packages() == {
-            "python3-pip",
-            "python3-setuptools",
-            "python3-wheel",
-        }
+        assert self._plugin.get_build_packages() == {}
 
     def test_get_build_snaps(self):
         assert self._plugin.get_build_snaps() == set()

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -139,7 +139,6 @@ def test_base_configuration_setup(mock_executor, mock_inject, monkeypatch, alias
         ),
     ]
 
-
     assert mock_inject.mock_calls == [
         call(executor=mock_executor, snap_name="charmcraft", classic=True)
     ]

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -17,6 +17,7 @@
 import os
 import pathlib
 import re
+import subprocess
 from unittest import mock
 from unittest.mock import call
 
@@ -120,16 +121,51 @@ def clear_environment(monkeypatch):
 @pytest.mark.parametrize(
     "alias", [bases.BuilddBaseAlias.BIONIC, bases.BuilddBaseAlias.FOCAL]
 )
-def test_base_configuration_setup(mock_inject, monkeypatch, alias):
+def test_base_configuration_setup(mock_executor, mock_inject, monkeypatch, alias):
 
     config = providers.CharmcraftBuilddBaseConfiguration(alias=alias)
     config.setup(executor=mock_executor)
+
+    assert mock_executor.mock_calls == [
+        call.execute_run(
+            [
+                "apt-get",
+                "install",
+                "-y",
+                "sudo",
+            ],
+            check=True,
+            capture_output=True,
+        ),
+    ]
+
 
     assert mock_inject.mock_calls == [
         call(executor=mock_executor, snap_name="charmcraft", classic=True)
     ]
 
     assert config.compatibility_tag == "charmcraft-buildd-base-v0.0"
+
+
+def test_base_configuration_setup_apt_error(mock_executor):
+    alias = bases.BuilddBaseAlias.FOCAL
+    apt_cmd = ["apt-get", "install", "-y", "sudo"]
+    mock_executor.execute_run.side_effect = subprocess.CalledProcessError(
+        -1,
+        apt_cmd,
+        "some output",
+        "some error",
+    )
+
+    config = providers.CharmcraftBuilddBaseConfiguration(alias=alias)
+
+    with pytest.raises(
+        bases.BaseConfigurationError,
+        match=r"Failed to install the required dependencies.",
+    ) as exc_info:
+        config.setup(executor=mock_executor)
+
+    assert exc_info.value.__cause__ is not None
 
 
 def test_base_configuration_setup_snap_injection_error(mock_executor, mock_inject):

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -17,7 +17,6 @@
 import os
 import pathlib
 import re
-import subprocess
 from unittest import mock
 from unittest.mock import call
 
@@ -121,53 +120,16 @@ def clear_environment(monkeypatch):
 @pytest.mark.parametrize(
     "alias", [bases.BuilddBaseAlias.BIONIC, bases.BuilddBaseAlias.FOCAL]
 )
-def test_base_configuration_setup(mock_executor, mock_inject, monkeypatch, alias):
+def test_base_configuration_setup(mock_inject, monkeypatch, alias):
 
     config = providers.CharmcraftBuilddBaseConfiguration(alias=alias)
     config.setup(executor=mock_executor)
-
-    assert mock_executor.mock_calls == [
-        call.execute_run(
-            [
-                "apt-get",
-                "install",
-                "-y",
-                "git",
-                "python3-pip",
-                "python3-setuptools",
-                "python3-wheel",
-            ],
-            check=True,
-            capture_output=True,
-        ),
-    ]
 
     assert mock_inject.mock_calls == [
         call(executor=mock_executor, snap_name="charmcraft", classic=True)
     ]
 
     assert config.compatibility_tag == "charmcraft-buildd-base-v0.0"
-
-
-def test_base_configuration_setup_apt_error(mock_executor):
-    alias = bases.BuilddBaseAlias.FOCAL
-    apt_cmd = ["apt-get", "install", "-y", "git", "python3-pip", "python3-setuptools"]
-    mock_executor.execute_run.side_effect = subprocess.CalledProcessError(
-        -1,
-        apt_cmd,
-        "some output",
-        "some error",
-    )
-
-    config = providers.CharmcraftBuilddBaseConfiguration(alias=alias)
-
-    with pytest.raises(
-        bases.BaseConfigurationError,
-        match=r"Failed to install the required dependencies.",
-    ) as exc_info:
-        config.setup(executor=mock_executor)
-
-    assert exc_info.value.__cause__ is not None
 
 
 def test_base_configuration_setup_snap_injection_error(mock_executor, mock_inject):

--- a/tools/freeze-requirements.sh
+++ b/tools/freeze-requirements.sh
@@ -1,14 +1,33 @@
 #!/bin/bash -eux
 
+requirements_fixups() {
+  req_file="$1"
+
+  # Python apt library pinned to source.
+  sed -i '/^python-apt==/d' "$req_file"
+  sed -i 's!^craft-parts[= ].*!craft-parts @ https://github.com/canonical/craft-parts/archive/refs/tags/v1.0-alpha.1.tar.gz!' "$req_file"
+}
+
 venv_dir="$(mktemp -d)"
 
 python3 -m venv "$venv_dir"
 . "$venv_dir/bin/activate"
 
+# Pull in host python3-apt site package to avoid installation.
+site_pkgs="$(readlink -f "$venv_dir"/lib/python3.*/site-packages/)"
+temp_dir="$(mktemp -d)"
+pushd "$temp_dir"
+apt download python3-apt
+dpkg -x ./*.deb .
+cp -r usr/lib/python3/dist-packages/* "$site_pkgs"
+popd
+
 pip install -e .
 pip freeze --exclude-editable > requirements.txt
+requirements_fixups "requirements.txt"
 
 pip install -e .[dev]
 pip freeze --exclude-editable > requirements-dev.txt
+requirements_fixups "requirements-dev.txt"
 
 rm -rf "$venv_dir"

--- a/tools/freeze-requirements.sh
+++ b/tools/freeze-requirements.sh
@@ -5,7 +5,7 @@ requirements_fixups() {
 
   # Python apt library pinned to source.
   sed -i '/^python-apt==/d' "$req_file"
-  sed -i 's!^craft-parts[= ].*!craft-parts @ https://github.com/canonical/craft-parts/archive/refs/tags/v1.0-alpha.1.tar.gz!' "$req_file"
+  sed -i 's!^craft-parts[= ].*!craft-parts @ https://github.com/canonical/craft-parts/archive/refs/tags/v1.0-alpha.2.tar.gz!' "$req_file"
 }
 
 venv_dir="$(mktemp -d)"


### PR DESCRIPTION
Create and run the craft-parts lifecycle, executing the charm builder
from a craft-parts charm build plugin.
    
Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>