### PR TITLE
Ensure all checkers have usable text and url.

### DIFF
--- a/charmcraft/linters.py
+++ b/charmcraft/linters.py
@@ -131,9 +131,7 @@ class Framework:
     def text(self):
         """Return a text in function of the result state."""
         if self.result is None:
-            raise RuntimeError(
-                "Cannot access text before running the Framework checker."
-            )
+            return None
         return self.result_texts[self.result]
 
     def _get_imports(self, filepath: pathlib.Path) -> Generator[List[str], None, None]:
@@ -268,8 +266,8 @@ def analyze(
                     check_type=cls.check_type,
                     name=cls.name,
                     result=IGNORED,
-                    url=None,
-                    text=None,
+                    url=cls.url,
+                    text=cls.text,
                 )
             )
             continue


### PR DESCRIPTION

The text and url attributes, even if they get dinamic, need to be safe values, as they may be accessed without running the checker (when ignored) or even after crashing.

Beyond providing a specific test case for the change, I made explicit the attributes access for those situations in other tests.
