### PR TITLE
parts: add entrypoint and requirements properties to charm plugin (CRAFT-393)

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,7 +31,7 @@ jobs:
           case "${{ matrix.os }}" in
             ubuntu-*)
               sudo apt update
-              sudo apt install -y python3-pip python3-venv libapt-pkg-dev
+              sudo apt install -y python3-pip python3-setuptools python3-wheel python3-venv libapt-pkg-dev
               ;;
           esac
           python3 -m venv ${HOME}/.venv

--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -241,7 +241,10 @@ class Builder:
         # verify if deprecated --requirement is used and update the plugin property
         if self._charm_part.get("charm-requirements"):
             if self.requirement_paths:
-                raise CommandError("requirements already defined in charmcraft.yaml")
+                raise CommandError(
+                    "--requirement not supported when charm-requirements "
+                    "specified in charmcraft.yaml"
+                )
         else:
             if self.requirement_paths:
                 self._charm_part["charm-requirements"] = [str(p) for p in self.requirement_paths]
@@ -256,7 +259,10 @@ class Builder:
         # verify if deprecated --entrypoint is used and update the plugin property
         if self._charm_part.get("charm-entrypoint"):
             if self.entrypoint:
-                raise CommandError("entrypoint already defined in charmcraft.yaml")
+                raise CommandError(
+                    "--entrypoint not supported when charm-entrypoint "
+                    "specified in charmcraft.yaml"
+                )
         else:
             if self.entrypoint:
                 rel_entrypoint = self.entrypoint.relative_to(self.charmdir)

--- a/charmcraft/commands/pack.py
+++ b/charmcraft/commands/pack.py
@@ -22,10 +22,11 @@ import pathlib
 import zipfile
 from argparse import Namespace
 
+from charmcraft import parts
 from charmcraft.cmdbase import BaseCommand, CommandError
 from charmcraft.commands import build
 from charmcraft.manifest import create_manifest
-from charmcraft.parts import PartsLifecycle, Step
+from charmcraft.parts import Step
 from charmcraft.utils import SingleOptionEnsurer, load_yaml, useful_filepath
 
 logger = logging.getLogger(__name__)
@@ -186,7 +187,7 @@ class PackCommand(BaseCommand):
 
         # run the parts lifecycle
         logger.debug("Parts definition: %s", config_parts)
-        lifecycle = PartsLifecycle(
+        lifecycle = parts.PartsLifecycle(
             config_parts,
             work_dir=project.dirpath / build.BUILD_DIRNAME,
             ignore_local_sources=[bundle_name + ".zip"],

--- a/charmcraft/deprecations.py
+++ b/charmcraft/deprecations.py
@@ -37,6 +37,8 @@ _DEPRECATION_MESSAGES = {
     "dn01": "Configuration keywords are now separated using dashes.",
     "dn02": "A charmcraft.yaml configuration file is now required.",
     "dn03": "Bases configuration is now required.",
+    "dn04": "Use 'charm-entrypoint' in charmcraft.yaml parts to define the entry point.",
+    "dn05": "Use 'charm-requirements' in charmcraft.yaml parts to define requirements.",
 }
 
 # the URL to point to the deprecation entry in the documentation

--- a/charmcraft/parts.py
+++ b/charmcraft/parts.py
@@ -21,7 +21,7 @@ import os
 import pathlib
 import shlex
 import sys
-from typing import Any, Dict, List, Set
+from typing import Any, Dict, List, Set, cast
 
 from craft_parts import LifecycleManager, Step, plugins
 from craft_parts.parts import PartSpec
@@ -38,7 +38,8 @@ class CharmPluginProperties(plugins.PluginProperties, plugins.PluginModel):
     """Properties used in charm building."""
 
     source: str = ""
-    # TODO: add charm plugin properties
+    charm_entrypoint: str = ""  # TODO: add default after removing --entrypoint
+    charm_requirements: List[str] = []
 
     @classmethod
     def unmarshal(cls, data: Dict[str, Any]):
@@ -87,6 +88,8 @@ class CharmPlugin(plugins.Plugin):
 
     def get_build_commands(self) -> List[str]:
         """Return a list of commands to run during the build step."""
+        options = cast(CharmPluginProperties, self._options)
+
         build_env = dict(LANG="C.UTF-8", LC_ALL="C.UTF-8")
         for key in [
             "PATH",
@@ -117,11 +120,11 @@ class CharmPlugin(plugins.Plugin):
             str(self._part_info.part_install_dir),
         ]
 
-        if self._part_info.entrypoint:
-            entrypoint = self._part_info.part_build_dir / self._part_info.entrypoint
+        if options.charm_entrypoint:
+            entrypoint = self._part_info.part_build_dir / options.charm_entrypoint
             build_cmd.extend(["--entrypoint", str(entrypoint)])
 
-        for req in self._part_info.requirements:
+        for req in options.charm_requirements:
             build_cmd.extend(["-r", req])
 
         commands = [" ".join(shlex.quote(i) for i in build_cmd)]
@@ -213,7 +216,7 @@ def validate_part(data: Dict[str, Any]) -> None:
     plugin_class.properties_class.unmarshal(spec)
 
     # validate common part properties
-    plugins.strip_plugin_properties(spec, plugin_name=plugin_name)
+    spec = plugins.strip_plugin_properties(spec, plugin_name=plugin_name)
     PartSpec(**spec)
 
 
@@ -226,9 +229,8 @@ class PartsLifecycle:
         *,
         work_dir: pathlib.Path,
         ignore_local_sources: List[str],
-        **kwargs,
     ):
-        self._all_parts = all_parts
+        self._all_parts = all_parts.copy()
 
         # set the cache dir for parts package management
         cache_dir = BaseDirectory.save_cache_path("charmcraft")
@@ -240,7 +242,6 @@ class PartsLifecycle:
                 work_dir=work_dir,
                 cache_dir=cache_dir,
                 ignore_local_sources=ignore_local_sources,
-                **kwargs,
             )
             self._lcm.refresh_packages_list()
         except PartsError as err:
@@ -259,7 +260,8 @@ class PartsLifecycle:
         try:
             # invalidate build if packing a charm and entrypoint changed
             if "charm" in self._all_parts:
-                entrypoint = os.path.normpath(self._lcm.project_info.entrypoint)
+                charm_part = self._all_parts["charm"]
+                entrypoint = os.path.normpath(charm_part["charm-entrypoint"])
                 dis_entrypoint = os.path.normpath(_get_dispatch_entrypoint(self.prime_dir))
                 if entrypoint != dis_entrypoint:
                     self._lcm.clean(Step.BUILD, part_names=["charm"])

--- a/charmcraft/parts.py
+++ b/charmcraft/parts.py
@@ -216,8 +216,8 @@ def validate_part(data: Dict[str, Any]) -> None:
     plugin_class.properties_class.unmarshal(spec)
 
     # validate common part properties
-    spec = plugins.strip_plugin_properties(spec, plugin_name=plugin_name)
-    PartSpec(**spec)
+    part_spec = plugins.extract_part_properties(spec, plugin_name=plugin_name)
+    PartSpec(**part_spec)
 
 
 class PartsLifecycle:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ cffi==1.14.6
 charset-normalizer==2.0.3
 click==8.0.1
 coverage==5.5
-craft-parts @ https://github.com/canonical/craft-parts/archive/refs/tags/v1.0-alpha.2.tar.gz
+craft-parts @ https://github.com/canonical/craft-parts/archive/refs/tags/v1.0-alpha.3.tar.gz
 craft-providers==1.0.1
 flake8==3.9.2
 humanize==3.10.0
@@ -51,6 +51,6 @@ six==1.16.0
 snowballstemmer==2.1.0
 tabulate==0.8.9
 toml==0.10.2
-tomli==1.0.4
+tomli==1.1.0
 typing-extensions==3.10.0.0
 urllib3==1.26.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ attrs==21.2.0
 certifi==2021.5.30
 cffi==1.14.6
 charset-normalizer==2.0.3
-craft-parts @ https://github.com/canonical/craft-parts/archive/refs/tags/v1.0-alpha.2.tar.gz
+craft-parts @ https://github.com/canonical/craft-parts/archive/refs/tags/v1.0-alpha.3.tar.gz
 craft-providers==1.0.1
 humanize==3.10.0
 idna==3.2

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ with open("README.md", "rt", encoding="utf8") as fh:
 install_requires = [
     "appdirs",
     "attrs",
-    "craft-parts @ https://github.com/canonical/craft-parts/archive/refs/tags/v1.0-alpha.2.tar.gz",
+    "craft-parts @ https://github.com/canonical/craft-parts/archive/refs/tags/v1.0-alpha.3.tar.gz",
     "craft-providers",
     "humanize>=2.6.0",
     "jsonschema",

--- a/tests/commands/test_build.py
+++ b/tests/commands/test_build.py
@@ -249,16 +249,13 @@ def test_validator_entrypoint_simple(tmp_path, config):
     assert resp == testfile
 
 
-def test_validator_entrypoint_default(tmp_path, config):
+def test_validator_entrypoint_none(tmp_path, config):
     """'entrypoint' param: default value."""
-    default_entrypoint = tmp_path / "src" / "charm.py"
-    default_entrypoint.parent.mkdir()
-    default_entrypoint.touch(mode=0o777)
 
     validator = Validator(config)
     validator.basedir = tmp_path
     resp = validator.validate_entrypoint(None)
-    assert resp == default_entrypoint
+    assert resp is None
 
 
 def test_validator_entrypoint_absolutized(tmp_path, monkeypatch, config):
@@ -348,15 +345,12 @@ def test_validator_requirement_multiple(tmp_path, config):
     assert resp == [testfile1, testfile2]
 
 
-def test_validator_requirement_default_present_ok(tmp_path, config):
+def test_validator_requirement_none(tmp_path, config):
     """'requirement' param: default value when a requirements.txt is there and readable."""
-    default_requirement = tmp_path / "requirements.txt"
-    default_requirement.touch()
-
     validator = Validator(config)
     validator.basedir = tmp_path
     resp = validator.validate_requirement(None)
-    assert resp == [default_requirement]
+    assert resp == []
 
 
 def test_validator_requirement_default_present_not_readable(tmp_path, config):
@@ -1268,6 +1262,499 @@ def test_build_package_name(tmp_path, monkeypatch, config):
     zipname = builder.handle_package(to_be_zipped_dir)
 
     assert zipname == "name-from-metadata.charm"
+
+
+def test_build_with_entrypoint_argument_issues_dn04(basic_project, caplog, monkeypatch):
+    """Test cases for base-index parameter."""
+    config = load(basic_project)
+    builder = Builder(
+        {
+            "from": basic_project,
+            "entrypoint": basic_project / "src" / "charm.py",
+            "requirement": [],
+            "force": False,
+        },
+        config,
+    )
+
+    with patch("charmcraft.commands.build.launched_environment"):
+        builder.run()
+
+    assert (
+        "DEPRECATED: Use 'charm-entrypoint' in charmcraft.yaml parts to define the entry point."
+        in [r.message for r in caplog.records]
+    )
+
+
+def test_build_entrypoint_from_parts(basic_project, monkeypatch, caplog):
+    """Test cases for base-index parameter."""
+    host_base = get_host_as_base()
+    charmcraft_file = basic_project / "charmcraft.yaml"
+    charmcraft_file.write_text(
+        dedent(
+            f"""\
+                type: charm
+                bases:
+                  - build-on:
+                      - name: {host_base.name!r}
+                        channel: {host_base.channel!r}
+                    run-on:
+                      - name: {host_base.name!r}
+                        channel: {host_base.channel!r}
+                parts:
+                  charm:
+                    charm-entrypoint: "my_entrypoint.py"
+                    charm-requirements: ["reqs.txt"]
+                """
+        )
+    )
+    config = load(basic_project)
+    monkeypatch.chdir(basic_project)
+    builder = Builder(
+        {
+            "from": basic_project,
+            "entrypoint": None,
+            "requirement": [],
+            "force": True,
+        },
+        config,
+    )
+
+    entrypoint = basic_project / "my_entrypoint.py"
+    entrypoint.touch()
+    entrypoint.chmod(0o700)
+
+    monkeypatch.setenv("CHARMCRAFT_MANAGED_MODE", "1")
+    with patch("charmcraft.parts.PartsLifecycle", autospec=True) as mock_lifecycle:
+        mock_lifecycle.side_effect = SystemExit()
+        with pytest.raises(SystemExit):
+            builder.run([0])
+    mock_lifecycle.assert_has_calls(
+        [
+            call(
+                {
+                    "charm": {
+                        "plugin": "charm",
+                        "prime": ["my_entrypoint.py", "metadata.yaml", "dispatch", "hooks", "lib"],
+                        "charm-entrypoint": "my_entrypoint.py",
+                        "charm-requirements": ["reqs.txt"],
+                        "source": str(basic_project),
+                    }
+                },
+                work_dir=basic_project / "build",
+                ignore_local_sources=["*.charm"],
+            )
+        ]
+    )
+
+
+def test_build_entrypoint_from_commandline(basic_project, monkeypatch, caplog):
+    """Test cases for base-index parameter."""
+    host_base = get_host_as_base()
+    charmcraft_file = basic_project / "charmcraft.yaml"
+    charmcraft_file.write_text(
+        dedent(
+            f"""\
+                type: charm
+                bases:
+                  - build-on:
+                      - name: {host_base.name!r}
+                        channel: {host_base.channel!r}
+                    run-on:
+                      - name: {host_base.name!r}
+                        channel: {host_base.channel!r}
+                parts:
+                  charm:
+                     charm-requirements: ["reqs.txt"]
+                """
+        )
+    )
+    config = load(basic_project)
+    monkeypatch.chdir(basic_project)
+    builder = Builder(
+        {
+            "from": basic_project,
+            "entrypoint": basic_project / "my_entrypoint.py",
+            "requirement": [],
+            "force": True,
+        },
+        config,
+    )
+
+    entrypoint = basic_project / "my_entrypoint.py"
+    entrypoint.touch()
+    entrypoint.chmod(0o700)
+
+    monkeypatch.setenv("CHARMCRAFT_MANAGED_MODE", "1")
+    with patch("charmcraft.parts.PartsLifecycle", autospec=True) as mock_lifecycle:
+        mock_lifecycle.side_effect = SystemExit()
+        with pytest.raises(SystemExit):
+            builder.run([0])
+    mock_lifecycle.assert_has_calls(
+        [
+            call(
+                {
+                    "charm": {
+                        "plugin": "charm",
+                        "prime": ["my_entrypoint.py", "metadata.yaml", "dispatch", "hooks", "lib"],
+                        "charm-entrypoint": "my_entrypoint.py",
+                        "charm-requirements": ["reqs.txt"],
+                        "source": str(basic_project),
+                    }
+                },
+                work_dir=basic_project / "build",
+                ignore_local_sources=["*.charm"],
+            )
+        ]
+    )
+
+
+def test_build_entrypoint_default(basic_project, monkeypatch, caplog):
+    """Test cases for base-index parameter."""
+    host_base = get_host_as_base()
+    charmcraft_file = basic_project / "charmcraft.yaml"
+    charmcraft_file.write_text(
+        dedent(
+            f"""\
+                type: charm
+                bases:
+                  - build-on:
+                      - name: {host_base.name!r}
+                        channel: {host_base.channel!r}
+                    run-on:
+                      - name: {host_base.name!r}
+                        channel: {host_base.channel!r}
+                parts:
+                  charm:
+                     charm-requirements: ["reqs.txt"]
+                """
+        )
+    )
+    config = load(basic_project)
+    monkeypatch.chdir(basic_project)
+    builder = Builder(
+        {
+            "from": basic_project,
+            "entrypoint": None,
+            "requirement": [],
+            "force": True,
+        },
+        config,
+    )
+
+    monkeypatch.setenv("CHARMCRAFT_MANAGED_MODE", "1")
+    with patch("charmcraft.parts.PartsLifecycle", autospec=True) as mock_lifecycle:
+        mock_lifecycle.side_effect = SystemExit()
+        with pytest.raises(SystemExit):
+            builder.run([0])
+    mock_lifecycle.assert_has_calls(
+        [
+            call(
+                {
+                    "charm": {
+                        "plugin": "charm",
+                        "prime": ["src", "metadata.yaml", "dispatch", "hooks", "lib"],
+                        "charm-entrypoint": "src/charm.py",
+                        "charm-requirements": ["reqs.txt"],
+                        "source": str(basic_project),
+                    }
+                },
+                work_dir=basic_project / "build",
+                ignore_local_sources=["*.charm"],
+            )
+        ]
+    )
+
+
+def test_build_entrypoint_from_both(basic_project, monkeypatch, caplog):
+    """Test cases for base-index parameter."""
+    host_base = get_host_as_base()
+    charmcraft_file = basic_project / "charmcraft.yaml"
+    charmcraft_file.write_text(
+        dedent(
+            f"""\
+                type: charm
+                bases:
+                  - build-on:
+                      - name: {host_base.name!r}
+                        channel: {host_base.channel!r}
+                    run-on:
+                      - name: {host_base.name!r}
+                        channel: {host_base.channel!r}
+
+                parts:
+                  charm:
+                    charm-entrypoint: "my_entrypoint.py"
+                    charm-requirements: ["reqs.txt"]
+                """
+        )
+    )
+    config = load(basic_project)
+    monkeypatch.chdir(basic_project)
+    builder = Builder(
+        {
+            "from": basic_project,
+            "entrypoint": basic_project / "my_entrypoint.py",
+            "requirement": [],
+            "force": True,
+        },
+        config,
+    )
+
+    entrypoint = basic_project / "my_entrypoint.py"
+    entrypoint.touch()
+    entrypoint.chmod(0o700)
+
+    monkeypatch.setenv("CHARMCRAFT_MANAGED_MODE", "1")
+    with pytest.raises(CommandError) as raised:
+        builder.run([0])
+    assert str(raised.value) == "entrypoint already defined in charmcraft.yaml"
+
+
+def test_build_with_requirement_argment_issues_dn05(basic_project, caplog, monkeypatch):
+    """Test cases for base-index parameter."""
+    config = load(basic_project)
+    builder = Builder(
+        {
+            "from": basic_project,
+            "entrypoint": None,
+            "requirement": ["reqs.txt"],
+            "force": False,
+        },
+        config,
+    )
+
+    with patch("charmcraft.commands.build.launched_environment"):
+        builder.run()
+
+    assert (
+        "DEPRECATED: Use 'charm-requirements' in charmcraft.yaml parts to define requirements."
+        in [r.message for r in caplog.records]
+    )
+
+
+def test_build_requirements_from_parts(basic_project, monkeypatch, caplog):
+    """Test cases for base-index parameter."""
+    host_base = get_host_as_base()
+    charmcraft_file = basic_project / "charmcraft.yaml"
+    charmcraft_file.write_text(
+        dedent(
+            f"""\
+                type: charm
+                bases:
+                  - build-on:
+                      - name: {host_base.name!r}
+                        channel: {host_base.channel!r}
+                    run-on:
+                      - name: {host_base.name!r}
+                        channel: {host_base.channel!r}
+
+                parts:
+                  charm:
+                    charm-entrypoint: src/charm.py
+                    charm-requirements: ["reqs.txt"]
+                """
+        )
+    )
+    config = load(basic_project)
+    monkeypatch.chdir(basic_project)
+    builder = Builder(
+        {
+            "from": basic_project,
+            "entrypoint": None,
+            "requirement": [],
+            "force": True,
+        },
+        config,
+    )
+
+    reqs = basic_project / "reqs.txt"
+    reqs.touch()
+
+    monkeypatch.setenv("CHARMCRAFT_MANAGED_MODE", "1")
+    with patch("charmcraft.parts.PartsLifecycle", autospec=True) as mock_lifecycle:
+        mock_lifecycle.side_effect = SystemExit()
+        with pytest.raises(SystemExit):
+            builder.run([0])
+    mock_lifecycle.assert_has_calls(
+        [
+            call(
+                {
+                    "charm": {
+                        "plugin": "charm",
+                        "prime": ["src", "metadata.yaml", "dispatch", "hooks", "lib"],
+                        "charm-entrypoint": "src/charm.py",
+                        "charm-requirements": ["reqs.txt"],
+                        "source": str(basic_project),
+                    }
+                },
+                work_dir=basic_project / "build",
+                ignore_local_sources=["*.charm"],
+            )
+        ]
+    )
+
+
+def test_build_requirements_from_commandline(basic_project, monkeypatch, caplog):
+    """Test cases for base-index parameter."""
+    host_base = get_host_as_base()
+    charmcraft_file = basic_project / "charmcraft.yaml"
+    charmcraft_file.write_text(
+        dedent(
+            f"""\
+                type: charm
+                bases:
+                  - build-on:
+                      - name: {host_base.name!r}
+                        channel: {host_base.channel!r}
+                    run-on:
+                      - name: {host_base.name!r}
+                        channel: {host_base.channel!r}
+
+                parts:
+                  charm:
+                    charm-entrypoint: src/charm.py
+                """
+        )
+    )
+    config = load(basic_project)
+    monkeypatch.chdir(basic_project)
+    builder = Builder(
+        {
+            "from": basic_project,
+            "entrypoint": None,
+            "requirement": ["reqs.txt"],
+            "force": True,
+        },
+        config,
+    )
+
+    reqs = basic_project / "reqs.txt"
+    reqs.touch()
+
+    monkeypatch.setenv("CHARMCRAFT_MANAGED_MODE", "1")
+    with patch("charmcraft.parts.PartsLifecycle", autospec=True) as mock_lifecycle:
+        mock_lifecycle.side_effect = SystemExit()
+        with pytest.raises(SystemExit):
+            builder.run([0])
+    mock_lifecycle.assert_has_calls(
+        [
+            call(
+                {
+                    "charm": {
+                        "plugin": "charm",
+                        "prime": ["src", "metadata.yaml", "dispatch", "hooks", "lib"],
+                        "charm-entrypoint": "src/charm.py",
+                        "charm-requirements": ["reqs.txt"],
+                        "source": str(basic_project),
+                    }
+                },
+                work_dir=basic_project / "build",
+                ignore_local_sources=["*.charm"],
+            )
+        ]
+    )
+
+
+def test_build_requirements_default(basic_project, monkeypatch, caplog):
+    """Test cases for base-index parameter."""
+    host_base = get_host_as_base()
+    charmcraft_file = basic_project / "charmcraft.yaml"
+    charmcraft_file.write_text(
+        dedent(
+            f"""\
+                type: charm
+                bases:
+                  - build-on:
+                      - name: {host_base.name!r}
+                        channel: {host_base.channel!r}
+                    run-on:
+                      - name: {host_base.name!r}
+                        channel: {host_base.channel!r}
+
+                parts:
+                  charm:
+                    charm-entrypoint: src/charm.py
+                """
+        )
+    )
+    config = load(basic_project)
+    monkeypatch.chdir(basic_project)
+    builder = Builder(
+        {
+            "from": basic_project,
+            "entrypoint": None,
+            "requirement": [],
+            "force": True,
+        },
+        config,
+    )
+
+    monkeypatch.setenv("CHARMCRAFT_MANAGED_MODE", "1")
+    with patch("charmcraft.parts.PartsLifecycle", autospec=True) as mock_lifecycle:
+        mock_lifecycle.side_effect = SystemExit()
+        with pytest.raises(SystemExit):
+            builder.run([0])
+    mock_lifecycle.assert_has_calls(
+        [
+            call(
+                {
+                    "charm": {
+                        "plugin": "charm",
+                        "prime": ["src", "metadata.yaml", "dispatch", "hooks", "lib"],
+                        "charm-entrypoint": "src/charm.py",
+                        "charm-requirements": [],
+                        "source": str(basic_project),
+                    }
+                },
+                work_dir=basic_project / "build",
+                ignore_local_sources=["*.charm"],
+            )
+        ]
+    )
+
+
+def test_build_requirements_from_both(basic_project, monkeypatch, caplog):
+    """Test cases for base-index parameter."""
+    host_base = get_host_as_base()
+    charmcraft_file = basic_project / "charmcraft.yaml"
+    charmcraft_file.write_text(
+        dedent(
+            f"""\
+                type: charm
+                bases:
+                  - build-on:
+                      - name: {host_base.name!r}
+                        channel: {host_base.channel!r}
+                    run-on:
+                      - name: {host_base.name!r}
+                        channel: {host_base.channel!r}
+
+                parts:
+                  charm:
+                    charm-requirements: ["reqs.txt"]
+                """
+        )
+    )
+    config = load(basic_project)
+    monkeypatch.chdir(basic_project)
+    builder = Builder(
+        {
+            "from": basic_project,
+            "entrypoint": None,
+            "requirement": ["reqs.txt"],
+            "force": True,
+        },
+        config,
+    )
+
+    reqs = basic_project / "reqs.txt"
+    reqs.touch()
+
+    monkeypatch.setenv("CHARMCRAFT_MANAGED_MODE", "1")
+    with pytest.raises(CommandError) as raised:
+        builder.run([0])
+    assert str(raised.value) == "requirements already defined in charmcraft.yaml"
 
 
 def test_build_using_linters_attributes(basic_project, monkeypatch, config):

--- a/tests/commands/test_build.py
+++ b/tests/commands/test_build.py
@@ -1508,7 +1508,9 @@ def test_build_entrypoint_from_both(basic_project, monkeypatch, caplog):
     monkeypatch.setenv("CHARMCRAFT_MANAGED_MODE", "1")
     with pytest.raises(CommandError) as raised:
         builder.run([0])
-    assert str(raised.value) == "entrypoint already defined in charmcraft.yaml"
+    assert str(raised.value) == (
+        "--entrypoint not supported when charm-entrypoint specified in charmcraft.yaml"
+    )
 
 
 def test_build_with_requirement_argment_issues_dn05(basic_project, caplog, monkeypatch):
@@ -1754,7 +1756,9 @@ def test_build_requirements_from_both(basic_project, monkeypatch, caplog):
     monkeypatch.setenv("CHARMCRAFT_MANAGED_MODE", "1")
     with pytest.raises(CommandError) as raised:
         builder.run([0])
-    assert str(raised.value) == "requirements already defined in charmcraft.yaml"
+    assert str(raised.value) == (
+        "--requirement not supported when charm-requirements specified in charmcraft.yaml"
+    )
 
 
 def test_build_using_linters_attributes(basic_project, monkeypatch, config):

--- a/tests/test_parts.py
+++ b/tests/test_parts.py
@@ -38,7 +38,7 @@ class TestCharmPlugin:
             "charm-requirements": ["reqs1.txt", "reqs2.txt"],
         }
         plugin_properties = parts.CharmPluginProperties.unmarshal(spec)
-        part_spec = plugins.strip_plugin_properties(spec, plugin_name="charm")
+        part_spec = plugins.extract_part_properties(spec, plugin_name="charm")
         part = craft_parts.Part(
             "foo", part_spec, project_dirs=project_dirs, plugin_properties=plugin_properties
         )

--- a/tests/test_parts.py
+++ b/tests/test_parts.py
@@ -32,20 +32,27 @@ class TestCharmPlugin:
     @pytest.fixture(autouse=True)
     def setup_method_fixture(self, tmp_path):
         project_dirs = craft_parts.ProjectDirs(work_dir=tmp_path)
-        part = craft_parts.Part("foo", {"plugin": "charm"}, project_dirs=project_dirs)
+        spec = {
+            "plugin": "charm",
+            "charm-entrypoint": "entrypoint",
+            "charm-requirements": ["reqs1.txt", "reqs2.txt"],
+        }
+        plugin_properties = parts.CharmPluginProperties.unmarshal(spec)
+        part_spec = plugins.strip_plugin_properties(spec, plugin_name="charm")
+        part = craft_parts.Part(
+            "foo", part_spec, project_dirs=project_dirs, plugin_properties=plugin_properties
+        )
         project_info = craft_parts.ProjectInfo(
             application_name="test",
             project_dirs=project_dirs,
             cache_dir=tmp_path,
-            entrypoint="entrypoint",
-            requirements=["reqs1.txt", "reqs2.txt"],
         )
         part_info = craft_parts.PartInfo(project_info=project_info, part=part)
 
         self._plugin = plugins.get_plugin(
             part=part,
             part_info=part_info,
-            properties=parts.CharmPluginProperties(),
+            properties=plugin_properties,
         )
 
     def test_get_build_package(self):
@@ -119,6 +126,8 @@ class TestPartsLifecycle:
         data = {
             "plugin": "charm",
             "source": ".",
+            "charm-entrypoint": "my-entrypoint",
+            "charm-requirements": ["reqs1.txt", "reqs2.txt"],
         }
 
         # create dispatcher from previous run
@@ -133,8 +142,6 @@ class TestPartsLifecycle:
             all_parts={"charm": data},
             work_dir=tmp_path,
             ignore_local_sources=["*.charm"],
-            entrypoint="my_entrypoint",
-            requirements=["reqs1.txt", "reqs2.txt"],
         )
 
         with patch("craft_parts.LifecycleManager.clean") as mock_clean:
@@ -149,6 +156,8 @@ class TestPartsLifecycle:
         data = {
             "plugin": "charm",
             "source": ".",
+            "charm-entrypoint": "src/charm.py",
+            "charm-requirements": ["reqs1.txt", "reqs2.txt"],
         }
 
         # create dispatcher from previous run
@@ -163,8 +172,6 @@ class TestPartsLifecycle:
             all_parts={"charm": data},
             work_dir=tmp_path,
             ignore_local_sources=["*.charm"],
-            entrypoint="src/charm.py",
-            requirements=["reqs1.txt", "reqs2.txt"],
         )
 
         with patch("craft_parts.LifecycleManager.clean") as mock_clean:
@@ -179,14 +186,14 @@ class TestPartsLifecycle:
         data = {
             "plugin": "charm",
             "source": ".",
+            "charm-entrypoint": "my-entrypoint",
+            "charm-requirements": ["reqs1.txt", "reqs2.txt"],
         }
 
         lifecycle = parts.PartsLifecycle(
             all_parts={"charm": data},
             work_dir=tmp_path,
             ignore_local_sources=["*.charm"],
-            entrypoint="my_entrypoint",
-            requirements=["reqs1.txt", "reqs2.txt"],
         )
 
         with patch("craft_parts.LifecycleManager.clean") as mock_clean:

--- a/tools/freeze-requirements.sh
+++ b/tools/freeze-requirements.sh
@@ -5,7 +5,7 @@ requirements_fixups() {
 
   # Python apt library pinned to source.
   sed -i '/^python-apt==/d' "$req_file"
-  sed -i 's!^craft-parts[= ].*!craft-parts @ https://github.com/canonical/craft-parts/archive/refs/tags/v1.0-alpha.2.tar.gz!' "$req_file"
+  sed -i 's!^craft-parts[= ].*!craft-parts @ https://github.com/canonical/craft-parts/archive/refs/tags/v1.0-alpha.3.tar.gz!' "$req_file"
 }
 
 venv_dir="$(mktemp -d)"


### PR DESCRIPTION
The charm entry point and charm requirements can now be set using
charm plugin properties. Deprecation notices have been added to the
`--entrypoint` and `--requirement` command line arguments. An error is
issued if both sources of information are used at the same time.
    
Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>