### PR TITLE
config: add charm part to documentation (CRAFT-356)

### DIFF
--- a/charmcraft/config.py
+++ b/charmcraft/config.py
@@ -30,6 +30,11 @@ charmhub:
   registry-url = [HttpUrl] optional, defaults to "https://registry.jujucharms.com"
 
 parts:
+  charm:
+    charm-entrypoint: [string] optional, defaults to "src/charm.py"
+    charm-requirements: [list of strings] optional, defaults to ["requirements.txt"] if present
+    prime: [list of strings]
+
   bundle:
     prime: [list of strings]
 

--- a/charmcraft/parts.py
+++ b/charmcraft/parts.py
@@ -61,7 +61,16 @@ class CharmPlugin(plugins.Plugin):
     """Build the charm and prepare for packing.
 
     The craft-parts charm plugin prepares the charm payload for packing. Common
-    plugin and source keywords can be used.
+    plugin and source keywords can be used, as well as the following optional
+    plugin-specific properties:
+
+      - ``charm-entrypoint``
+        (string)
+        The path to the main charm executable, relative to the charm root.
+
+      - ``charm-requirements``
+        (list of strings)
+        List of paths to requirements files.
 
     Extra files to be included in the charm payload must be listed under
     the ``prime`` file filter.


### PR DESCRIPTION
Add charm configuration documentation to the configuration schema.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>