### PR TITLE
build: prime venv if charm-requirements defined (CRAFT-417)

### DIFF
--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -291,7 +291,7 @@ class Builder:
             self._prime.append(str(entrypoint.parts[0]))
 
         # add venv if there are requirements
-        if self.requirement_paths:
+        if self._charm_part["charm-requirements"]:
             self._prime.append(VENV_DIRNAME)
 
         # add mandatory and optional charm files


### PR DESCRIPTION
The command line switch to set requirements was deprecated in favor of
using the `charm-requirements` property in the charm part. Test it
instead of the command line variable.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>