### PR TITLE
snap: add configure hook with support for provider (CRAFT-363)

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -132,3 +132,10 @@ jobs:
           charmcraft -v pack --destructive-mode
           test -f "destructive-mode-tests_ubuntu-$VERSION_ID-amd64.charm"
           popd
+
+          sudo snap set charmcraft provider=lxd
+          sudo snap set charmcraft provider=multipass
+          if sudo snap set charmcraft provider=invalid; then
+            echo "configure script failure"
+            exit 1
+          fi

--- a/charmcraft/snap.py
+++ b/charmcraft/snap.py
@@ -16,8 +16,8 @@
 
 """Logic for snap configuration."""
 
-from dataclasses import dataclass
 import logging
+from dataclasses import dataclass
 from typing import Optional
 
 import snaphelpers

--- a/charmcraft/snap.py
+++ b/charmcraft/snap.py
@@ -16,16 +16,16 @@
 
 """Logic for snap configuration."""
 
+from dataclasses import dataclass
 import logging
 from typing import Optional
 
-import attr
 import snaphelpers
 
 logger = logging.getLogger(__name__)
 
 
-@attr.s(auto_attribs=True)
+@dataclass
 class CharmcraftSnapConfiguration:
     """Charmcraft's snap configuration options."""
 

--- a/charmcraft/snap.py
+++ b/charmcraft/snap.py
@@ -1,0 +1,63 @@
+# Copyright 2021 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For further info, check https://github.com/canonical/charmcraft
+
+"""Logic for snap configuration."""
+
+import logging
+from typing import Optional
+
+import attr
+import snaphelpers
+
+logger = logging.getLogger(__name__)
+
+
+@attr.s(auto_attribs=True)
+class CharmcraftSnapConfiguration:
+    """Charmcraft's snap configuration options."""
+
+    provider: Optional[str] = None
+
+
+def _get_config_key(*, snap_config: snaphelpers.SnapConfig, key: str, default=None):
+    """Get snap configuration for specified key.
+
+    :returns: Returns key's value or default if undefined.
+    """
+    try:
+        return snap_config.get(key)
+    except snaphelpers._conf.UnknownConfigKey:
+        return default
+
+
+def get_snap_configuration() -> CharmcraftSnapConfiguration:
+    """Get unvalidated snap configuration.
+
+    :returns: Current snap configuration.
+    """
+    snap_config = snaphelpers.SnapConfig()
+    provider = _get_config_key(snap_config=snap_config, key="provider")
+
+    return CharmcraftSnapConfiguration(provider=provider)
+
+
+def validate_snap_configuration(cfg: CharmcraftSnapConfiguration):
+    """Validate given snap configuration.
+
+    :raises ValueError: on error.
+    """
+    if cfg.provider is not None and cfg.provider not in ["lxd", "multipass"]:
+        raise ValueError(f"provider {cfg.provider!r} is not supported")

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -48,6 +48,7 @@ requests-unixsocket==0.2.0
 responses==0.13.3
 semver==2.13.0
 six==1.16.0
+snap-helpers==0.2.0
 snowballstemmer==2.1.0
 tabulate==0.8.9
 toml==0.10.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ Jinja2==3.0.1
 jsonschema==3.2.0
 macaroonbakery==1.3.1
 MarkupSafe==2.0.1
+packaging==21.0
 progressbar==2.5
 protobuf==3.17.3
 pycparser==2.20
@@ -18,6 +19,7 @@ pydantic==1.8.2
 pydantic-yaml==0.4.2
 pymacaroons==0.13.0
 PyNaCl==1.4.0
+pyparsing==2.4.7
 pyRFC3339==1.1
 pyrsistent==0.18.0
 python-dateutil==2.8.2
@@ -29,6 +31,7 @@ requests-toolbelt==0.9.1
 requests-unixsocket==0.2.0
 semver==2.13.0
 six==1.16.0
+snap-helpers==0.2.0
 tabulate==0.8.9
 typing-extensions==3.10.0.0
 urllib3==1.26.6

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ install_requires = [
     "requests",
     "requests-toolbelt",
     "requests-unixsocket",
+    "snap-helpers",
     "tabulate",
 ]
 
@@ -93,7 +94,9 @@ try:
             "Programming Language :: Python :: 3",
         ],
         entry_points={
-            "console_scripts": ["charmcraft = charmcraft.main:main"],
+            "console_scripts": [
+                "charmcraft = charmcraft.main:main",
+            ],
         },
         python_requires=">=3",
         install_requires=install_requires,

--- a/setup.py
+++ b/setup.py
@@ -94,9 +94,7 @@ try:
             "Programming Language :: Python :: 3",
         ],
         entry_points={
-            "console_scripts": [
-                "charmcraft = charmcraft.main:main",
-            ],
+            "console_scripts": ["charmcraft = charmcraft.main:main"],
         },
         python_requires=">=3",
         install_requires=install_requires,

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+
+import sys
+
+from charmcraft import snap
+
+
+def configure_hook_main():
+    cfg = snap.get_snap_configuration()
+    try:
+        snap.validate_snap_configuration(cfg)
+    except ValueError as error:
+        reason = str(error)
+        print(f"Unsupported snap configuration: {reason}.", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    configure_hook_main()

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -126,3 +126,9 @@ parts:
       usr/share/git-core/templates: git/templates
       usr/bin/git: bin/git
       lib/python3.8/site-packages: lib/
+
+hooks:
+  configure:
+    passthrough:
+      environment:
+        PATH: "$SNAP/bin"

--- a/tests/test_snap.py
+++ b/tests/test_snap.py
@@ -1,0 +1,76 @@
+# Copyright 2021 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For further info, check https://github.com/canonical/charmcraft
+
+import re
+from unittest import mock
+
+import pytest
+import snaphelpers
+
+from charmcraft.snap import (
+    CharmcraftSnapConfiguration,
+    get_snap_configuration,
+    validate_snap_configuration,
+)
+
+
+@pytest.fixture
+def mock_snap_config():
+    with mock.patch("charmcraft.snap.snaphelpers.SnapConfig", autospec=True) as mock_snap_config:
+        yield mock_snap_config
+
+
+def test_get_snap_configuration_empty(mock_snap_config):
+    def fake_get(key: str):
+        raise snaphelpers._conf.UnknownConfigKey(key=key)
+
+    mock_snap_config.return_value.get.side_effect = fake_get
+
+    snap_config = get_snap_configuration()
+
+    assert snap_config == CharmcraftSnapConfiguration()
+
+
+@pytest.mark.parametrize("provider", ["lxd", "multipass"])
+def test_get_snap_configuration_valid_providers(mock_snap_config, provider):
+    def fake_get(key: str):
+        if key == "provider":
+            return provider
+        raise snaphelpers._conf.UnknownConfigKey(key=key)
+
+    mock_snap_config.return_value.get.side_effect = fake_get
+
+    snap_config = get_snap_configuration()
+
+    assert snap_config == CharmcraftSnapConfiguration(provider=provider)
+
+
+@pytest.mark.parametrize("provider", ["", "invalid"])
+def test_get_snap_configuration_invalid_providers(mock_snap_config, provider):
+    def fake_get(key: str):
+        if key == "provider":
+            return provider
+        raise snaphelpers._conf.UnknownConfigKey(key=key)
+
+    mock_snap_config.return_value.get.side_effect = fake_get
+
+    snap_config = get_snap_configuration()
+
+    assert snap_config == CharmcraftSnapConfiguration(provider=provider)
+    assert snap_config.provider == provider
+
+    with pytest.raises(ValueError, match=re.escape(f"provider {provider!r} is not supported")):
+        validate_snap_configuration(snap_config)


### PR DESCRIPTION
Enable (unused) configuration for 'provider', erroring if set to
anything other than multipass or lxd.  Update requirements
to include snap-helpers.

Example error:
```
$ snap set charmcraft provider=invalid
error: cannot perform the following tasks:
- Run configure hook of "charmcraft" snap (run hook "configure":
  Invalid snap configuration: provider 'invalid' is not supported.)
```

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>