### PR TITLE
charmcraft: perform LXD checks before use (CRAFT-420)

### DIFF
--- a/charmcraft/providers.py
+++ b/charmcraft/providers.py
@@ -116,12 +116,12 @@ def ensure_provider_is_available() -> None:
                 lxd.install()
             except lxd.LXDInstallationError as error:
                 raise CommandError(
-                    "Failed to install LXD. Please visit https://snapcraft.io/lxd for "
+                    "Failed to install LXD. Visit https://snapcraft.io/lxd for "
                     "instructions on how to install the LXD snap for your distribution"
                 ) from error
         else:
             raise CommandError(
-                "LXD is required, but not installed. Please visit https://snapcraft.io/lxd for "
+                "LXD is required, but not installed. Visit https://snapcraft.io/lxd for "
                 "instructions on how to install the LXD snap for your distribution"
             )
 

--- a/charmcraft/providers.py
+++ b/charmcraft/providers.py
@@ -27,16 +27,10 @@ from typing import Dict, List, Optional, Tuple, Union
 
 from craft_providers import Executor, bases, lxd
 from craft_providers.actions import snap_installer
-from craft_providers.lxd import LXDInstallationError
-from craft_providers.lxd import installer as lxd_installer
-from craft_providers.lxd.remotes import configure_buildd_image_remote
 
 from charmcraft.cmdbase import CommandError
 from charmcraft.config import Base
-from charmcraft.env import (
-    get_managed_environment_log_path,
-    get_managed_environment_project_path,
-)
+from charmcraft.env import get_managed_environment_log_path, get_managed_environment_project_path
 from charmcraft.utils import confirm_with_user, get_host_architecture
 
 logger = logging.getLogger(__name__)
@@ -112,26 +106,29 @@ def ensure_provider_is_available() -> None:
 
     :raises CommandError: if provider is not available.
     """
-    if is_provider_available():
-        return
-
-    if confirm_with_user(
-        "LXD is required, but not installed. Do you wish to install LXD "
-        "and configure it with the defaults?",
-        default=False,
-    ):
-        try:
-            lxd_installer.install()
-        except LXDInstallationError as error:
+    if not is_provider_available():
+        if confirm_with_user(
+            "LXD is required, but not installed. Do you wish to install LXD "
+            "and configure it with the defaults?",
+            default=False,
+        ):
+            try:
+                lxd.install()
+            except lxd.LXDInstallationError as error:
+                raise CommandError(
+                    "Failed to install LXD. Please visit https://snapcraft.io/lxd for "
+                    "instructions on how to install the LXD snap for your distribution"
+                ) from error
+        else:
             raise CommandError(
-                "Failed to install LXD. Please visit https://snapcraft.io/lxd for "
+                "LXD is required, but not installed. Please visit https://snapcraft.io/lxd for "
                 "instructions on how to install the LXD snap for your distribution"
-            ) from error
-    else:
-        raise CommandError(
-            "LXD is required, but not installed. Please visit https://snapcraft.io/lxd for "
-            "instructions on how to install the LXD snap for your distribution"
-        )
+            )
+
+    try:
+        lxd.ensure_lxd_is_ready()
+    except lxd.LXDError as error:
+        raise CommandError(str(error))
 
 
 def is_base_providable(base: Base) -> Tuple[bool, Union[str, None]]:
@@ -216,7 +213,7 @@ def is_provider_available() -> bool:
 
     :returns: True if installed.
     """
-    return lxd_installer.is_installed()
+    return lxd.is_installed()
 
 
 @contextlib.contextmanager
@@ -250,7 +247,7 @@ def launched_environment(
     )
 
     environment = get_command_environment()
-    image_remote = configure_buildd_image_remote()
+    image_remote = lxd.configure_buildd_image_remote()
     base_configuration = CharmcraftBuilddBaseConfiguration(
         alias=alias, environment=environment, hostname=instance_name
     )

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,13 +3,13 @@ attrs==21.2.0
 black==21.7b0
 certifi==2021.5.30
 cffi==1.14.6
-charset-normalizer==2.0.3
+charset-normalizer==2.0.4
 click==8.0.1
 coverage==5.5
 craft-parts @ https://github.com/canonical/craft-parts/archive/refs/tags/v1.0-alpha.3.tar.gz
-craft-providers==1.0.1
+craft-providers==1.0.2
 flake8==3.9.2
-humanize==3.10.0
+humanize==3.11.0
 idna==3.2
 iniconfig==1.1.1
 Jinja2==3.0.1
@@ -51,6 +51,6 @@ six==1.16.0
 snowballstemmer==2.1.0
 tabulate==0.8.9
 toml==0.10.2
-tomli==1.1.0
+tomli==1.2.0
 typing-extensions==3.10.0.0
 urllib3==1.26.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,10 @@ appdirs==1.4.4
 attrs==21.2.0
 certifi==2021.5.30
 cffi==1.14.6
-charset-normalizer==2.0.3
+charset-normalizer==2.0.4
 craft-parts @ https://github.com/canonical/craft-parts/archive/refs/tags/v1.0-alpha.3.tar.gz
-craft-providers==1.0.1
-humanize==3.10.0
+craft-providers==1.0.2
+humanize==3.11.0
 idna==3.2
 Jinja2==3.0.1
 jsonschema==3.2.0

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -321,7 +321,7 @@ def test_ensure_provider_is_available_errors_when_user_declines(
     with pytest.raises(
         CommandError,
         match=re.escape(
-            "LXD is required, but not installed. Please visit https://snapcraft.io/lxd for "
+            "LXD is required, but not installed. Visit https://snapcraft.io/lxd for "
             "instructions on how to install the LXD snap for your distribution"
         ),
     ):
@@ -346,7 +346,7 @@ def test_ensure_provider_is_available_errors_when_lxd_install_fails(
     with pytest.raises(
         CommandError,
         match=re.escape(
-            "Failed to install LXD. Please visit https://snapcraft.io/lxd for "
+            "Failed to install LXD. Visit https://snapcraft.io/lxd for "
             "instructions on how to install the LXD snap for your distribution"
         ),
     ) as exc_info:


### PR DESCRIPTION
Invoke ensure_lxd_is_ready() interface before using LXD
provider. This consolidates a couple of existing checks
done elsewhere as well as a new one for ensuring the user
has the necessary permissions to use LXD.

Minor simplification of imports used in providers module
to improve and update mocks accordingly.

Example error:
```
$ /snap/bin/charmcraft pack
LXD requires additional permissions.
Please ensure that the user is in the 'lxd' group.
(full execution logs in '/home/test1/snap/charmcraft/common/charmcraft-log-0xgcist7')
```

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>