### PR TITLE
utils: use dataclass for ResourceOption

### DIFF
--- a/charmcraft/utils.py
+++ b/charmcraft/utils.py
@@ -16,6 +16,7 @@
 
 """Collection of utilities for charmcraft."""
 
+from dataclasses import dataclass
 import logging
 import os
 import pathlib
@@ -24,7 +25,6 @@ import sys
 from collections import namedtuple
 from stat import S_IRGRP, S_IROTH, S_IRUSR, S_IXGRP, S_IXOTH, S_IXUSR
 
-import attr
 import yaml
 from jinja2 import Environment, PackageLoader, StrictUndefined
 
@@ -111,7 +111,7 @@ class SingleOptionEnsurer:
         return self.converter(value)
 
 
-@attr.s(frozen=True)
+@dataclass(frozen=True)
 class ResourceOption:
     """Argparse helper to validate and convert a 'resource' option.
 
@@ -122,8 +122,8 @@ class ResourceOption:
         parser.add_argument('--resource',  type=ResourceOption())
     """
 
-    name = attr.ib(default=None)
-    revision = attr.ib(default=None)
+    name: str = None
+    revision: int = None
 
     def __call__(self, value):
         """Run by argparse to validate and convert the given argument."""

--- a/charmcraft/utils.py
+++ b/charmcraft/utils.py
@@ -16,13 +16,13 @@
 
 """Collection of utilities for charmcraft."""
 
-from dataclasses import dataclass
 import logging
 import os
 import pathlib
 import platform
 import sys
 from collections import namedtuple
+from dataclasses import dataclass
 from stat import S_IRGRP, S_IROTH, S_IRUSR, S_IXGRP, S_IXOTH, S_IXUSR
 
 import yaml

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ with open("README.md", "rt", encoding="utf8") as fh:
 
 install_requires = [
     "appdirs",
-    "attrs",
     "craft-parts @ https://github.com/canonical/craft-parts/archive/refs/tags/v1.0-alpha.3.tar.gz",
     "craft-providers",
     "humanize>=2.6.0",


### PR DESCRIPTION
This removes attr usage in Charmcraft, so remove attrs
from install_requires as well.  Does not affect the generated
requirements as other dependencies require attrs anyhow.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>