### PR TITLE
build: include optional license and icon files (CRAFT-436)

### DIFF
--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -80,6 +80,8 @@ CHARM_OPTIONAL = [
     "version",
     "lib",
     "mod",
+    "LICENSE",
+    "icon.svg",
 ]
 
 

--- a/tests/commands/test_build.py
+++ b/tests/commands/test_build.py
@@ -76,6 +76,14 @@ def basic_project(tmp_path):
     charm_script = src_dir / "charm.py"
     charm_script.write_bytes(b"all the magic")
 
+    # the license file
+    license = tmp_path / "LICENSE"
+    license.write_text("license content")
+
+    # other optional assets
+    icon = tmp_path / "icon.svg"
+    icon.write_text("icon content")
+
     yield tmp_path
 
 
@@ -527,6 +535,8 @@ def test_build_basic_complete_structure(basic_project, caplog, monkeypatch, conf
     assert zf.read("hooks/start") == dispatch
     assert zf.read("hooks/upgrade-charm") == dispatch
     assert zf.read("lib/ops/stuff.txt") == b"ops stuff"
+    assert zf.read("LICENSE") == b"license content"
+    assert zf.read("icon.svg") == b"icon content"
 
     # check the manifest is present and with particular values that depend on given info
     manifest = yaml.safe_load(zf.read("manifest.yaml"))
@@ -1342,6 +1352,8 @@ def test_build_entrypoint_from_parts(basic_project, monkeypatch, caplog):
                             "dispatch",
                             "hooks",
                             "lib",
+                            "LICENSE",
+                            "icon.svg",
                         ],
                         "charm-entrypoint": "my_entrypoint.py",
                         "charm-requirements": ["reqs.txt"],
@@ -1410,6 +1422,8 @@ def test_build_entrypoint_from_commandline(basic_project, monkeypatch, caplog):
                             "dispatch",
                             "hooks",
                             "lib",
+                            "LICENSE",
+                            "icon.svg",
                         ],
                         "charm-entrypoint": "my_entrypoint.py",
                         "charm-requirements": ["reqs.txt"],
@@ -1467,7 +1481,16 @@ def test_build_entrypoint_default(basic_project, monkeypatch, caplog):
                 {
                     "charm": {
                         "plugin": "charm",
-                        "prime": ["src", "venv", "metadata.yaml", "dispatch", "hooks", "lib"],
+                        "prime": [
+                            "src",
+                            "venv",
+                            "metadata.yaml",
+                            "dispatch",
+                            "hooks",
+                            "lib",
+                            "LICENSE",
+                            "icon.svg",
+                        ],
                         "charm-entrypoint": "src/charm.py",
                         "charm-requirements": ["reqs.txt"],
                         "source": str(basic_project),
@@ -1598,7 +1621,16 @@ def test_build_requirements_from_parts(basic_project, monkeypatch, caplog):
                 {
                     "charm": {
                         "plugin": "charm",
-                        "prime": ["src", "venv", "metadata.yaml", "dispatch", "hooks", "lib"],
+                        "prime": [
+                            "src",
+                            "venv",
+                            "metadata.yaml",
+                            "dispatch",
+                            "hooks",
+                            "lib",
+                            "LICENSE",
+                            "icon.svg",
+                        ],
                         "charm-entrypoint": "src/charm.py",
                         "charm-requirements": ["reqs.txt"],
                         "source": str(basic_project),
@@ -1659,7 +1691,16 @@ def test_build_requirements_from_commandline(basic_project, monkeypatch, caplog)
                 {
                     "charm": {
                         "plugin": "charm",
-                        "prime": ["src", "venv", "metadata.yaml", "dispatch", "hooks", "lib"],
+                        "prime": [
+                            "src",
+                            "venv",
+                            "metadata.yaml",
+                            "dispatch",
+                            "hooks",
+                            "lib",
+                            "LICENSE",
+                            "icon.svg",
+                        ],
                         "charm-entrypoint": "src/charm.py",
                         "charm-requirements": ["reqs.txt"],
                         "source": str(basic_project),
@@ -1720,7 +1761,16 @@ def test_build_requirements_default(basic_project, monkeypatch, caplog):
                 {
                     "charm": {
                         "plugin": "charm",
-                        "prime": ["src", "venv", "metadata.yaml", "dispatch", "hooks", "lib"],
+                        "prime": [
+                            "src",
+                            "venv",
+                            "metadata.yaml",
+                            "dispatch",
+                            "hooks",
+                            "lib",
+                            "LICENSE",
+                            "icon.svg",
+                        ],
                         "charm-entrypoint": "src/charm.py",
                         "charm-requirements": ["requirements.txt"],
                         "source": str(basic_project),
@@ -1778,7 +1828,15 @@ def test_build_requirements_no_requirements_txt(basic_project, monkeypatch, capl
                 {
                     "charm": {
                         "plugin": "charm",
-                        "prime": ["src", "metadata.yaml", "dispatch", "hooks", "lib"],
+                        "prime": [
+                            "src",
+                            "metadata.yaml",
+                            "dispatch",
+                            "hooks",
+                            "lib",
+                            "LICENSE",
+                            "icon.svg",
+                        ],
                         "charm-entrypoint": "src/charm.py",
                         "charm-requirements": [],
                         "source": str(basic_project),


### PR DESCRIPTION
Add `LICENSE` and `icon.svg` to the list of files to be included in
the charm, if they exist in the project directory.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>