### PR TITLE
build: add README.md by default

### DIFF
--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -77,6 +77,7 @@ CHARM_OPTIONAL = [
     "mod",
     "LICENSE",
     "icon.svg",
+    "README.md",
 ]
 
 

--- a/tests/commands/test_build.py
+++ b/tests/commands/test_build.py
@@ -85,6 +85,10 @@ def basic_project(tmp_path):
     icon = tmp_path / "icon.svg"
     icon.write_text("icon content")
 
+    # README
+    readme = tmp_path / "README.md"
+    readme.write_text("README content")
+
     yield tmp_path
 
 
@@ -539,6 +543,7 @@ def test_build_basic_complete_structure(basic_project, caplog, monkeypatch, conf
     assert zf.read("lib/ops/stuff.txt") == b"ops stuff"
     assert zf.read("LICENSE") == b"license content"
     assert zf.read("icon.svg") == b"icon content"
+    assert zf.read("README.md") == b"README content"
 
     # check the manifest is present and with particular values that depend on given info
     manifest = yaml.safe_load(zf.read("manifest.yaml"))
@@ -1361,6 +1366,7 @@ def test_build_entrypoint_from_parts(basic_project, monkeypatch, caplog):
                             "lib",
                             "LICENSE",
                             "icon.svg",
+                            "README.md",
                         ],
                         "charm-entrypoint": "my_entrypoint.py",
                         "charm-requirements": ["reqs.txt"],
@@ -1431,6 +1437,7 @@ def test_build_entrypoint_from_commandline(basic_project, monkeypatch, caplog):
                             "lib",
                             "LICENSE",
                             "icon.svg",
+                            "README.md",
                         ],
                         "charm-entrypoint": "my_entrypoint.py",
                         "charm-requirements": ["reqs.txt"],
@@ -1497,6 +1504,7 @@ def test_build_entrypoint_default(basic_project, monkeypatch, caplog):
                             "lib",
                             "LICENSE",
                             "icon.svg",
+                            "README.md",
                         ],
                         "charm-entrypoint": "src/charm.py",
                         "charm-requirements": ["reqs.txt"],
@@ -1636,6 +1644,7 @@ def test_build_requirements_from_parts(basic_project, monkeypatch, caplog):
                             "lib",
                             "LICENSE",
                             "icon.svg",
+                            "README.md",
                         ],
                         "charm-entrypoint": "src/charm.py",
                         "charm-requirements": ["reqs.txt"],
@@ -1706,6 +1715,7 @@ def test_build_requirements_from_commandline(basic_project, monkeypatch, caplog)
                             "lib",
                             "LICENSE",
                             "icon.svg",
+                            "README.md",
                         ],
                         "charm-entrypoint": "src/charm.py",
                         "charm-requirements": ["reqs.txt"],
@@ -1776,6 +1786,7 @@ def test_build_requirements_default(basic_project, monkeypatch, caplog):
                             "lib",
                             "LICENSE",
                             "icon.svg",
+                            "README.md",
                         ],
                         "charm-entrypoint": "src/charm.py",
                         "charm-requirements": ["requirements.txt"],
@@ -1842,6 +1853,7 @@ def test_build_requirements_no_requirements_txt(basic_project, monkeypatch, capl
                             "lib",
                             "LICENSE",
                             "icon.svg",
+                            "README.md",
                         ],
                         "charm-entrypoint": "src/charm.py",
                         "charm-requirements": [],


### PR DESCRIPTION
The README.md file is used by CharmHub to display the contents of the
charm's page. This file should then be included by default.