### PR TITLE
providers: introduce multipass support (CRAFT-409)

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -117,8 +117,8 @@ jobs:
           sg lxd -c "charmcraft -v clean"
           popd
 
-          mkdir -p another-directory
-          pushd another-directory
+          mkdir -p another-test
+          pushd another-test
           sg lxd -c "charmcraft -v pack --project-dir ../charm-smoke-test"
           test -f *.charm
           sg lxd -c "charmcraft -v clean --project-dir ../charm-smoke-test"

--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -416,7 +416,7 @@ class Builder:
                 instance.execute_run(
                     cmd,
                     check=True,
-                    cwd=instance_output_dir.as_posix(),
+                    cwd=instance_output_dir,
                 )
             except subprocess.CalledProcessError as error:
                 capture_logs_from_instance(instance)

--- a/charmcraft/providers/__init__.py
+++ b/charmcraft/providers/__init__.py
@@ -20,4 +20,5 @@ from ._buildd import CharmcraftBuilddBaseConfiguration  # noqa: F401
 from ._get_provider import get_provider  # noqa: F401
 from ._logs import capture_logs_from_instance  # noqa: F401
 from ._lxd import LXDProvider  # noqa: F401
+from ._multipass import MultipassProvider  # noqa: F401
 from ._provider import Provider  # noqa: F401

--- a/charmcraft/providers/_get_provider.py
+++ b/charmcraft/providers/_get_provider.py
@@ -20,9 +20,9 @@ import logging
 import os
 import sys
 
-from charmcraft.snap import get_snap_configuration
 from charmcraft.cmdbase import CommandError
 from charmcraft.env import is_charmcraft_running_from_snap, is_charmcraft_running_in_developer_mode
+from charmcraft.snap import get_snap_configuration
 
 from ._lxd import LXDProvider
 from ._multipass import MultipassProvider

--- a/charmcraft/providers/_multipass.py
+++ b/charmcraft/providers/_multipass.py
@@ -1,0 +1,175 @@
+# Copyright 2021 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For further info, check https://github.com/canonical/charmcraft
+
+"""Build environment provider support for charmcraft."""
+
+import contextlib
+import logging
+import pathlib
+import re
+from typing import List
+
+from craft_providers import multipass
+
+from charmcraft.cmdbase import CommandError
+from charmcraft.config import Base
+from charmcraft.env import get_managed_environment_project_path
+from charmcraft.utils import confirm_with_user, get_host_architecture
+
+from ._buildd import BASE_CHANNEL_TO_BUILDD_IMAGE_ALIAS, CharmcraftBuilddBaseConfiguration
+from ._provider import Provider
+
+logger = logging.getLogger(__name__)
+
+
+class MultipassProvider(Provider):
+    """Charmcraft's build environment provider.
+
+    :param multipass: Optional Multipass client to use.
+    """
+
+    def __init__(
+        self,
+        *,
+        multipass: multipass.Multipass = multipass.Multipass(),
+    ) -> None:
+        self.multipass = multipass
+
+    def clean_project_environments(
+        self,
+        *,
+        charm_name: str,
+        project_path: pathlib.Path,
+    ) -> List[str]:
+        """Clean up any environments created for project.
+
+        :param charm_name: Name of project.
+        :param project_path: Directory of charm project.
+
+        :returns: List of containers deleted.
+        """
+        deleted: List[str] = []
+
+        # Nothing to do if provider is not installed.
+        if not self.is_provider_available():
+            return deleted
+
+        inode = str(project_path.stat().st_ino)
+
+        for name in self.multipass.list():
+            match_regex = f"^charmcraft-{charm_name}-{inode}-.+-.+-.+$"
+            if re.match(match_regex, name):
+                logger.debug("Deleting Multipass VM %r.", name)
+                self.multipass.delete(
+                    instance_name=name,
+                    purge=True,
+                )
+                deleted.append(name)
+            else:
+                logger.debug("Not deleting Multipass VM %r.", name)
+
+        return deleted
+
+    @classmethod
+    def ensure_provider_is_available(cls) -> None:
+        """Ensure provider is available, prompting the user to install it if required.
+
+        :raises CommandError: if provider is not available.
+        """
+        if not multipass.is_installed():
+            if confirm_with_user(
+                "Multipass is required, but not installed. Do you wish to install Multipass "
+                "and configure it with the defaults?",
+                default=False,
+            ):
+                try:
+                    multipass.install()
+                except multipass.MultipassInstallationError as error:
+                    raise CommandError(
+                        "Failed to install Multipass. Visit https://multipass.run/ for "
+                        "instructions on installing Multipass for your operating system."
+                    ) from error
+            else:
+                raise CommandError(
+                    "Multipass is required, but not installed. Visit https://multipass.run/ for "
+                    "instructions on installing Multipass for your operating system."
+                )
+
+        try:
+            multipass.ensure_multipass_is_ready()
+        except multipass.MultipassError as error:
+            raise CommandError(str(error))
+
+    @classmethod
+    def is_provider_available(cls) -> bool:
+        """Check if provider is installed and available for use.
+
+        :returns: True if installed.
+        """
+        return multipass.is_installed()
+
+    @contextlib.contextmanager
+    def launched_environment(
+        self,
+        *,
+        charm_name: str,
+        project_path: pathlib.Path,
+        base: Base,
+        bases_index: int,
+        build_on_index: int,
+    ):
+        """Launch environment for specified base.
+
+        :param charm_name: Name of project.
+        :param project_path: Path to project.
+        :param base: Base to create.
+        :param bases_index: Index of `bases:` entry.
+        :param build_on_index: Index of `build-on` within bases entry.
+        """
+        alias = BASE_CHANNEL_TO_BUILDD_IMAGE_ALIAS[base.channel]
+        target_arch = get_host_architecture()
+
+        instance_name = self.get_instance_name(
+            bases_index=bases_index,
+            build_on_index=build_on_index,
+            project_name=charm_name,
+            project_path=project_path,
+            target_arch=target_arch,
+        )
+
+        environment = self.get_command_environment()
+        base_configuration = CharmcraftBuilddBaseConfiguration(
+            alias=alias, environment=environment, hostname=instance_name
+        )
+        instance = multipass.launch(
+            name=instance_name,
+            base_configuration=base_configuration,
+            image_name=base.channel,
+            cpus=2,
+            disk_gb=64,
+            mem_gb=2,
+            auto_clean=True,
+        )
+
+        # Mount project.
+        instance.mount(host_source=project_path, target=get_managed_environment_project_path())
+
+        try:
+            yield instance
+        finally:
+            # Ensure to unmount everything and stop instance upon completion.
+            instance.unmount_all()
+            instance.stop()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,7 @@ charset-normalizer==2.0.4
 click==8.0.1
 coverage==5.5
 craft-parts==1.0.0
-craft-providers==1.0.2
+craft-providers==1.0.3
 flake8==3.9.2
 humanize==3.11.0
 idna==3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ certifi==2021.5.30
 cffi==1.14.6
 charset-normalizer==2.0.4
 craft-parts==1.0.0
-craft-providers==1.0.2
+craft-providers==1.0.3
 humanize==3.11.0
 idna==3.2
 Jinja2==3.0.1

--- a/tests/commands/test_build.py
+++ b/tests/commands/test_build.py
@@ -775,7 +775,7 @@ def test_build_project_is_cwd(
         call.execute_run(
             ["charmcraft", "pack", "--bases-index", "0"],
             check=True,
-            cwd="/root/project",
+            cwd=pathlib.Path("/root/project"),
         ),
     ]
 
@@ -830,7 +830,7 @@ def test_build_project_is_not_cwd(
         call.execute_run(
             ["charmcraft", "pack", "--bases-index", "0"],
             check=True,
-            cwd="/root",
+            cwd=pathlib.Path("/root"),
         ),
         call.pull_file(
             source=pathlib.Path("/root") / zipnames[0],
@@ -905,7 +905,7 @@ def test_build_bases_index_scenarios_provider(
         call.execute_run(
             ["charmcraft", "pack", "--bases-index", "0"] + cmd_flags,
             check=True,
-            cwd="/root/project",
+            cwd=pathlib.Path("/root/project"),
         ),
     ]
     assert f"Packing charm 'name-from-metadata_ubuntu-18.04-{host_arch}.charm'..." in [
@@ -935,7 +935,7 @@ def test_build_bases_index_scenarios_provider(
         call.execute_run(
             ["charmcraft", "pack", "--bases-index", "1"] + cmd_flags,
             check=True,
-            cwd="/root/project",
+            cwd=pathlib.Path("/root/project"),
         ),
     ]
     mock_provider.reset_mock()
@@ -973,12 +973,12 @@ def test_build_bases_index_scenarios_provider(
         call.execute_run(
             ["charmcraft", "pack", "--bases-index", "0"] + cmd_flags,
             check=True,
-            cwd="/root/project",
+            cwd=pathlib.Path("/root/project"),
         ),
         call.execute_run(
             ["charmcraft", "pack", "--bases-index", "1"] + cmd_flags,
             check=True,
-            cwd="/root/project",
+            cwd=pathlib.Path("/root/project"),
         ),
     ]
     mock_provider.reset_mock()
@@ -1010,7 +1010,7 @@ def test_build_bases_index_scenarios_provider(
         call.execute_run(
             ["charmcraft", "pack", "--bases-index", "0"] + cmd_flags,
             check=True,
-            cwd="/root/project",
+            cwd=pathlib.Path("/root/project"),
         ),
     ]
     assert mock_capture_logs_from_instance.mock_calls == [call(mock_instance)]

--- a/tests/providers/test_get_provider.py
+++ b/tests/providers/test_get_provider.py
@@ -14,9 +14,61 @@
 #
 # For further info, check https://github.com/canonical/charmcraft
 
+import sys
+from unittest import mock
 
-from charmcraft.providers import LXDProvider, get_provider
+import pytest
+
+from charmcraft.providers import LXDProvider, MultipassProvider, get_provider
+from charmcraft.snap import CharmcraftSnapConfiguration
 
 
-def test_get_provider():
+@pytest.fixture(autouse=True)
+def mock_snap_config():
+    with mock.patch(
+        "charmcraft.providers._get_provider.get_snap_configuration", return_value=None
+    ) as mock_snap:
+        yield mock_snap
+
+
+@pytest.fixture(autouse=True)
+def mock_is_developer_mode():
+    with mock.patch(
+        "charmcraft.providers._get_provider.is_charmcraft_running_in_developer_mode",
+        return_value=False,
+    ) as mock_is_dev_mode:
+        yield mock_is_dev_mode
+
+
+@pytest.fixture(autouse=True)
+def mock_is_snap():
+    with mock.patch(
+        "charmcraft.providers._get_provider.is_charmcraft_running_from_snap", return_value=False
+    ) as mock_is_snap:
+        yield mock_is_snap
+
+
+def test_get_provider_default():
+    if sys.platform == "linux":
+        assert isinstance(get_provider(), LXDProvider)
+    else:
+        assert isinstance(get_provider(), MultipassProvider)
+
+
+def test_get_provider_developer_mode_env(monkeypatch, mock_is_developer_mode):
+    mock_is_developer_mode.return_value = True
+    monkeypatch.setenv("CHARMCRAFT_PROVIDER", "lxd")
     assert isinstance(get_provider(), LXDProvider)
+
+    monkeypatch.setenv("CHARMCRAFT_PROVIDER", "multipass")
+    assert isinstance(get_provider(), MultipassProvider)
+
+
+def test_get_provider_snap_config(mock_is_snap, mock_snap_config):
+    mock_is_snap.return_value = True
+
+    mock_snap_config.return_value = CharmcraftSnapConfiguration(provider="lxd")
+    assert isinstance(get_provider(), LXDProvider)
+
+    mock_snap_config.return_value = CharmcraftSnapConfiguration(provider="multipass")
+    assert isinstance(get_provider(), MultipassProvider)

--- a/tests/providers/test_multipass.py
+++ b/tests/providers/test_multipass.py
@@ -174,6 +174,29 @@ def test_clean_project_environments(mock_multipass, mock_path):
     ]
 
 
+def test_clean_project_environments_list_failure(mock_multipass, mock_path):
+    mock_multipass.list.side_effect = MultipassError(brief="fail")
+    provider = providers.MultipassProvider(multipass=mock_multipass)
+
+    with pytest.raises(CommandError, match="fail"):
+        provider.clean_project_environments(
+            charm_name="charm",
+            project_path=mock_path,
+        )
+
+
+def test_clean_project_environments_delete_failure(mock_multipass, mock_path):
+    mock_multipass.list.return_value = ["charmcraft-testcharm-445566-b-c-d"]
+    mock_multipass.delete.side_effect = MultipassError("fail")
+    provider = providers.MultipassProvider(multipass=mock_multipass)
+
+    with pytest.raises(CommandError, match="fail"):
+        provider.clean_project_environments(
+            charm_name="testcharm",
+            project_path=mock_path,
+        )
+
+
 def test_ensure_provider_is_available_ok_when_installed(mock_multipass_is_installed):
     mock_multipass_is_installed.return_value = True
     provider = providers.MultipassProvider()

--- a/tests/providers/test_multipass.py
+++ b/tests/providers/test_multipass.py
@@ -1,0 +1,441 @@
+# Copyright 2021 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For further info, check https://github.com/canonical/charmcraft
+
+import pathlib
+import re
+from unittest import mock
+from unittest.mock import call
+
+import pytest
+from craft_providers import bases
+from craft_providers.multipass import MultipassError, MultipassInstallationError
+
+from charmcraft import providers
+from charmcraft.cmdbase import CommandError
+from charmcraft.config import Base
+
+
+@pytest.fixture(autouse=True)
+def mock_base_provider_get_host_architecture():
+    with mock.patch(
+        "charmcraft.providers._provider.get_host_architecture", return_value="host-arch"
+    ) as mock_arch:
+        yield mock_arch
+
+
+@pytest.fixture()
+def mock_buildd_base_configuration():
+    with mock.patch(
+        "charmcraft.providers._multipass.CharmcraftBuilddBaseConfiguration", autospec=True
+    ) as mock_base_config:
+        yield mock_base_config
+
+
+@pytest.fixture
+def mock_confirm_with_user():
+    with mock.patch(
+        "charmcraft.providers._multipass.confirm_with_user",
+        return_value=False,
+    ) as mock_confirm:
+        yield mock_confirm
+
+
+@pytest.fixture
+def mock_multipass(monkeypatch):
+    with mock.patch("craft_providers.multipass.Multipass", autospec=True) as mock_client:
+        yield mock_client.return_value
+
+
+@pytest.fixture(autouse=True)
+def mock_get_host_architecture():
+    with mock.patch(
+        "charmcraft.providers._multipass.get_host_architecture", return_value="host-arch"
+    ) as mock_arch:
+        yield mock_arch
+
+
+@pytest.fixture(autouse=True)
+def mock_multipass_ensure_multipass_is_ready():
+    with mock.patch(
+        "craft_providers.multipass.ensure_multipass_is_ready", return_value=None
+    ) as mock_is_ready:
+        yield mock_is_ready
+
+
+@pytest.fixture()
+def mock_multipass_install():
+    with mock.patch("craft_providers.multipass.install") as mock_install:
+        yield mock_install
+
+
+@pytest.fixture(autouse=True)
+def mock_multipass_is_installed():
+    with mock.patch(
+        "craft_providers.multipass.is_installed", return_value=True
+    ) as mock_is_installed:
+        yield mock_is_installed
+
+
+@pytest.fixture
+def mock_multipass_launch():
+    with mock.patch("craft_providers.multipass.launch", autospec=True) as mock_multipass_launch:
+        yield mock_multipass_launch
+
+
+def test_clean_project_environments_without_multipass(
+    mock_multipass, mock_multipass_is_installed, mock_path
+):
+    mock_multipass_is_installed.return_value = False
+    provider = providers.MultipassProvider(multipass=mock_multipass)
+
+    assert (
+        provider.clean_project_environments(
+            charm_name="my-charm",
+            project_path=mock_path,
+        )
+        == []
+    )
+
+    assert mock_multipass_is_installed.mock_calls == [mock.call()]
+    assert mock_multipass.mock_calls == []
+
+
+def test_clean_project_environments(mock_multipass, mock_path):
+    mock_multipass.list.return_value = [
+        "do-not-delete-me-please",
+        "charmcraft-testcharm-445566-b-c-d",
+        "charmcraft-my-charm---",
+        "charmcraft-my-charm-445566---",
+        "charmcraft-my-charm-project-445566-0-0-amd99",
+        "charmcraft-my-charm-project-445566-999-444-arm64",
+        "charmcraft_445566_a_b_c_d",
+    ]
+    provider = providers.MultipassProvider(multipass=mock_multipass)
+
+    assert provider.clean_project_environments(
+        charm_name="my-charm-project",
+        project_path=mock_path,
+    ) == [
+        "charmcraft-my-charm-project-445566-0-0-amd99",
+        "charmcraft-my-charm-project-445566-999-444-arm64",
+    ]
+    assert mock_multipass.mock_calls == [
+        mock.call.list(),
+        mock.call.delete(
+            instance_name="charmcraft-my-charm-project-445566-0-0-amd99",
+            purge=True,
+        ),
+        mock.call.delete(
+            instance_name="charmcraft-my-charm-project-445566-999-444-arm64",
+            purge=True,
+        ),
+    ]
+
+    mock_multipass.reset_mock()
+
+    assert provider.clean_project_environments(
+        charm_name="testcharm",
+        project_path=mock_path,
+    ) == [
+        "charmcraft-testcharm-445566-b-c-d",
+    ]
+    assert mock_multipass.mock_calls == [
+        mock.call.list(),
+        mock.call.delete(
+            instance_name="charmcraft-testcharm-445566-b-c-d",
+            purge=True,
+        ),
+    ]
+
+    mock_multipass.reset_mock()
+
+    assert (
+        provider.clean_project_environments(
+            charm_name="unknown-charm",
+            project_path=mock_path,
+        )
+        == []
+    )
+    assert mock_multipass.mock_calls == [
+        mock.call.list(),
+    ]
+
+
+def test_ensure_provider_is_available_ok_when_installed(mock_multipass_is_installed):
+    mock_multipass_is_installed.return_value = True
+    provider = providers.MultipassProvider()
+
+    provider.ensure_provider_is_available()
+
+
+def test_ensure_provider_is_available_errors_when_user_declines(
+    mock_confirm_with_user, mock_multipass_is_installed
+):
+    mock_confirm_with_user.return_value = False
+    mock_multipass_is_installed.return_value = False
+    provider = providers.MultipassProvider()
+
+    match = re.escape(
+        "Multipass is required, but not installed. Visit https://multipass.run/ for "
+        "instructions on installing Multipass for your operating system."
+    )
+    with pytest.raises(CommandError, match=match):
+        provider.ensure_provider_is_available()
+
+    assert mock_confirm_with_user.mock_calls == [
+        mock.call(
+            "Multipass is required, but not installed. "
+            "Do you wish to install Multipass and configure it with the defaults?",
+            default=False,
+        )
+    ]
+
+
+def test_ensure_provider_is_available_errors_when_multipass_install_fails(
+    mock_confirm_with_user, mock_multipass_is_installed, mock_multipass_install
+):
+    mock_confirm_with_user.return_value = True
+    mock_multipass_is_installed.return_value = False
+    mock_multipass_install.side_effect = MultipassInstallationError("foo")
+    provider = providers.MultipassProvider()
+
+    match = re.escape(
+        "Failed to install Multipass. Visit https://multipass.run/ for "
+        "instructions on installing Multipass for your operating system."
+    )
+    with pytest.raises(CommandError, match=match) as exc_info:
+        provider.ensure_provider_is_available()
+
+    assert mock_confirm_with_user.mock_calls == [
+        mock.call(
+            "Multipass is required, but not installed. "
+            "Do you wish to install Multipass and configure it with the defaults?",
+            default=False,
+        )
+    ]
+    assert exc_info.value.__cause__ == mock_multipass_install.side_effect
+
+
+def test_ensure_provider_is_available_errors_when_multipass_not_ready(
+    mock_confirm_with_user,
+    mock_multipass_is_installed,
+    mock_multipass_install,
+    mock_multipass_ensure_multipass_is_ready,
+):
+    mock_confirm_with_user.return_value = True
+    mock_multipass_is_installed.return_value = True
+    mock_multipass_ensure_multipass_is_ready.side_effect = MultipassError(
+        brief="some error", details="some details", resolution="some resolution"
+    )
+    provider = providers.MultipassProvider()
+
+    with pytest.raises(
+        CommandError,
+        match=re.escape("some error\nsome details\nsome resolution"),
+    ) as exc_info:
+        provider.ensure_provider_is_available()
+
+    assert exc_info.value.__cause__ == mock_multipass_install.side_effect
+
+
+def test_get_command_environment_minimal(monkeypatch):
+    monkeypatch.setenv("IGNORE_ME", "or-im-failing")
+    monkeypatch.setenv("PATH", "not-using-host-path")
+    provider = providers.MultipassProvider()
+
+    env = provider.get_command_environment()
+
+    assert env == {
+        "CHARMCRAFT_MANAGED_MODE": "1",
+        "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin",
+    }
+
+
+def test_get_command_environment_all_opts(monkeypatch):
+    monkeypatch.setenv("IGNORE_ME", "or-im-failing")
+    monkeypatch.setenv("PATH", "not-using-host-path")
+    monkeypatch.setenv("http_proxy", "test-http-proxy")
+    monkeypatch.setenv("https_proxy", "test-https-proxy")
+    monkeypatch.setenv("no_proxy", "test-no-proxy")
+    provider = providers.MultipassProvider()
+
+    env = provider.get_command_environment()
+
+    assert env == {
+        "CHARMCRAFT_MANAGED_MODE": "1",
+        "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin",
+        "http_proxy": "test-http-proxy",
+        "https_proxy": "test-https-proxy",
+        "no_proxy": "test-no-proxy",
+    }
+
+
+@pytest.mark.parametrize(
+    "bases_index,build_on_index,project_name,target_arch,expected",
+    [
+        (0, 0, "mycharm", "test-arch1", "charmcraft-mycharm-{inode}-0-0-test-arch1"),
+        (
+            1,
+            2,
+            "my-other-charm",
+            "test-arch2",
+            "charmcraft-my-other-charm-{inode}-1-2-test-arch2",
+        ),
+    ],
+)
+def test_get_instance_name(
+    bases_index, build_on_index, project_name, target_arch, expected, mock_path
+):
+    provider = providers.MultipassProvider()
+
+    assert (
+        provider.get_instance_name(
+            bases_index=bases_index,
+            build_on_index=build_on_index,
+            project_name=project_name,
+            project_path=mock_path,
+            target_arch=target_arch,
+        )
+        == expected.format(inode="445566")
+    )
+
+
+@pytest.mark.parametrize(
+    "name,channel,architectures,expected_valid,expected_reason",
+    [
+        ("ubuntu", "18.04", ["host-arch"], True, None),
+        ("ubuntu", "20.04", ["host-arch"], True, None),
+        ("ubuntu", "20.04", ["extra-arch", "host-arch"], True, None),
+        (
+            "not-ubuntu",
+            "20.04",
+            ["host-arch"],
+            False,
+            "name 'not-ubuntu' is not yet supported (must be 'ubuntu')",
+        ),
+        (
+            "ubuntu",
+            "10.04",
+            ["host-arch"],
+            False,
+            "channel '10.04' is not yet supported (must be '18.04' or '20.04')",
+        ),
+        (
+            "ubuntu",
+            "20.04",
+            ["other-arch"],
+            False,
+            "host architecture 'host-arch' not in base architectures ['other-arch']",
+        ),
+    ],
+)
+def test_is_base_available(
+    mock_get_host_architecture, name, channel, architectures, expected_valid, expected_reason
+):
+    base = Base(name=name, channel=channel, architectures=architectures)
+    provider = providers.MultipassProvider()
+
+    valid, reason = provider.is_base_available(base)
+
+    assert (valid, reason) == (expected_valid, expected_reason)
+
+
+@pytest.mark.parametrize("is_installed", [True, False])
+def test_is_provider_available(is_installed, mock_multipass_is_installed):
+    mock_multipass_is_installed.return_value = is_installed
+    provider = providers.MultipassProvider()
+
+    assert provider.is_provider_available() == is_installed
+
+
+@pytest.mark.parametrize(
+    "channel,alias",
+    [("18.04", bases.BuilddBaseAlias.BIONIC), ("20.04", bases.BuilddBaseAlias.FOCAL)],
+)
+def test_launched_environment(
+    channel,
+    alias,
+    mock_buildd_base_configuration,
+    mock_multipass_launch,
+    monkeypatch,
+    tmp_path,
+    mock_path,
+):
+    expected_environment = {
+        "CHARMCRAFT_MANAGED_MODE": "1",
+        "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin",
+    }
+
+    base = Base(name="ubuntu", channel=channel, architectures=["host-arch"])
+    provider = providers.MultipassProvider()
+
+    with provider.launched_environment(
+        charm_name="test-charm",
+        project_path=mock_path,
+        base=base,
+        bases_index=1,
+        build_on_index=2,
+    ) as instance:
+        assert instance is not None
+        assert mock_multipass_launch.mock_calls == [
+            mock.call(
+                name="charmcraft-test-charm-445566-1-2-host-arch",
+                base_configuration=mock_buildd_base_configuration.return_value,
+                image_name=channel,
+                cpus=2,
+                disk_gb=64,
+                mem_gb=2,
+                auto_clean=True,
+            ),
+            mock.call().mount(host_source=mock_path, target=pathlib.Path("/root/project")),
+        ]
+        assert mock_buildd_base_configuration.mock_calls == [
+            call(
+                alias=alias,
+                environment=expected_environment,
+                hostname="charmcraft-test-charm-445566-1-2-host-arch",
+            )
+        ]
+
+        mock_multipass_launch.reset_mock()
+
+    assert mock_multipass_launch.mock_calls == [
+        mock.call().unmount_all(),
+        mock.call().stop(),
+    ]
+
+
+def test_launched_environment_unmounts_and_stops_after_error(
+    mock_buildd_base_configuration, mock_multipass_launch, tmp_path
+):
+    base = Base(name="ubuntu", channel="20.04", architectures=["host-arch"])
+    provider = providers.MultipassProvider()
+
+    with pytest.raises(RuntimeError):
+        with provider.launched_environment(
+            charm_name="test-charm",
+            project_path=tmp_path,
+            base=base,
+            bases_index=1,
+            build_on_index=2,
+        ):
+            mock_multipass_launch.reset_mock()
+            raise RuntimeError("this is a test")
+
+    assert mock_multipass_launch.mock_calls == [
+        mock.call().unmount_all(),
+        mock.call().stop(),
+    ]

--- a/tests/providers/test_multipass.py
+++ b/tests/providers/test_multipass.py
@@ -462,3 +462,57 @@ def test_launched_environment_unmounts_and_stops_after_error(
         mock.call().unmount_all(),
         mock.call().stop(),
     ]
+
+
+def test_launched_environment_launch_error(
+    mock_buildd_base_configuration, mock_multipass_launch, tmp_path
+):
+    mock_multipass_launch.side_effect = MultipassError(brief="fail")
+    base = Base(name="ubuntu", channel="20.04", architectures=["host-arch"])
+    provider = providers.MultipassProvider()
+
+    with pytest.raises(CommandError, match="fail"):
+        with provider.launched_environment(
+            charm_name="test-charm",
+            project_path=tmp_path,
+            base=base,
+            bases_index=1,
+            build_on_index=2,
+        ):
+            pass
+
+
+def test_launched_environment_unmount_all_error(
+    mock_buildd_base_configuration, mock_multipass_launch, tmp_path
+):
+    mock_multipass_launch.return_value.unmount_all.side_effect = MultipassError(brief="fail")
+    base = Base(name="ubuntu", channel="20.04", architectures=["host-arch"])
+    provider = providers.MultipassProvider()
+
+    with pytest.raises(CommandError, match="fail"):
+        with provider.launched_environment(
+            charm_name="test-charm",
+            project_path=tmp_path,
+            base=base,
+            bases_index=1,
+            build_on_index=2,
+        ):
+            pass
+
+
+def test_launched_environment_stop_error(
+    mock_buildd_base_configuration, mock_multipass_launch, tmp_path
+):
+    mock_multipass_launch.return_value.stop.side_effect = MultipassError(brief="fail")
+    base = Base(name="ubuntu", channel="20.04", architectures=["host-arch"])
+    provider = providers.MultipassProvider()
+
+    with pytest.raises(CommandError, match="fail"):
+        with provider.launched_environment(
+            charm_name="test-charm",
+            project_path=tmp_path,
+            base=base,
+            bases_index=1,
+            build_on_index=2,
+        ):
+            pass


### PR DESCRIPTION
Add support for Multipass similar to LXD.

To determine provider on linux:

- check CHARMCRAFT_PROVIDER environment variable if in
  developer mode.

- check snap configuration if running as snap.

- fall back to platform default.

Update execute_run() to use cwd=pathlib.Path(x) interface.

Add unit tests and a smoke test for Linux & Multipass.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>