### PR TITLE
build: fix parts workdir in managed mode (CRAFT-459)

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -114,6 +114,7 @@ jobs:
           charmcraft -v init --author testuser
           sg lxd -c "charmcraft -v pack"
           test -f *.charm
+          test ! -d build
           sg lxd -c "charmcraft -v clean"
           popd
 
@@ -121,6 +122,8 @@ jobs:
           pushd another-test
           sg lxd -c "charmcraft -v pack --project-dir ../charm-smoke-test"
           test -f *.charm
+          test ! -d build
+          test ! -d ../charm-smoke-test/build
           sg lxd -c "charmcraft -v clean --project-dir ../charm-smoke-test"
           popd
 

--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -28,7 +28,6 @@ from charmcraft.bases import check_if_base_matches_host
 from charmcraft.cmdbase import BaseCommand, CommandError
 from charmcraft.config import Base, BasesConfiguration, Config
 from charmcraft.deprecations import notify_deprecation
-from charmcraft.env import is_charmcraft_running_in_managed_mode
 from charmcraft.logsetup import message_handler
 from charmcraft.manifest import create_manifest
 from charmcraft.metadata import parse_metadata_yaml
@@ -202,7 +201,7 @@ class Builder:
 
         self._handle_deprecated_cli_arguments()
 
-        if is_charmcraft_running_in_managed_mode():
+        if env.is_charmcraft_running_in_managed_mode():
             work_dir = env.get_managed_environment_home_path()
         else:
             work_dir = self.buildpath
@@ -315,7 +314,7 @@ class Builder:
         """
         charms: List[str] = []
 
-        managed_mode = is_charmcraft_running_in_managed_mode()
+        managed_mode = env.is_charmcraft_running_in_managed_mode()
         if not managed_mode and not destructive_mode:
             self.provider.ensure_provider_is_available()
 

--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -23,16 +23,12 @@ import subprocess
 import zipfile
 from typing import List, Optional
 
-from charmcraft import linters, parts
+from charmcraft import env, linters, parts
 from charmcraft.bases import check_if_base_matches_host
 from charmcraft.cmdbase import BaseCommand, CommandError
 from charmcraft.config import Base, BasesConfiguration, Config
 from charmcraft.deprecations import notify_deprecation
-from charmcraft.env import (
-    get_managed_environment_home_path,
-    get_managed_environment_project_path,
-    is_charmcraft_running_in_managed_mode,
-)
+from charmcraft.env import is_charmcraft_running_in_managed_mode
 from charmcraft.logsetup import message_handler
 from charmcraft.manifest import create_manifest
 from charmcraft.metadata import parse_metadata_yaml
@@ -207,7 +203,7 @@ class Builder:
         self._handle_deprecated_cli_arguments()
 
         if is_charmcraft_running_in_managed_mode():
-            work_dir = get_managed_environment_home_path()
+            work_dir = env.get_managed_environment_home_path()
         else:
             work_dir = self.buildpath
 
@@ -396,10 +392,10 @@ class Builder:
         # project directory and can retrieve it when complete.
         cwd = pathlib.Path.cwd()
         if cwd == self.charmdir:
-            instance_output_dir = get_managed_environment_project_path()
+            instance_output_dir = env.get_managed_environment_project_path()
             pull_charm = False
         else:
-            instance_output_dir = get_managed_environment_home_path()
+            instance_output_dir = env.get_managed_environment_home_path()
             pull_charm = True
 
         cmd = ["charmcraft", "pack", "--bases-index", str(bases_index)]

--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -206,6 +206,11 @@ class Builder:
 
         self._handle_deprecated_cli_arguments()
 
+        if is_charmcraft_running_in_managed_mode():
+            work_dir = get_managed_environment_home_path()
+        else:
+            work_dir = self.buildpath
+
         # add charm files to the prime filter
         self._set_prime_filter()
 
@@ -216,7 +221,7 @@ class Builder:
         logger.debug("Parts definition: %s", self._parts)
         lifecycle = parts.PartsLifecycle(
             self._parts,
-            work_dir=self.buildpath,
+            work_dir=work_dir,
             ignore_local_sources=["*.charm"],
         )
         lifecycle.run(Step.PRIME)

--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -197,14 +197,14 @@ class Builder:
 
         :returns: File name of charm.
         """
-        logger.debug("Building charm in %r", str(self.buildpath))
-
         self._handle_deprecated_cli_arguments()
 
         if env.is_charmcraft_running_in_managed_mode():
             work_dir = env.get_managed_environment_home_path()
         else:
             work_dir = self.buildpath
+
+        logger.debug("Building charm in %r", str(work_dir))
 
         # add charm files to the prime filter
         self._set_prime_filter()


### PR DESCRIPTION
When building in managed mode use workdir outside of project dir to
prevent leaks to the external environment.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>