### PR TITLE
commands/build: separate planning from execution (CRAFT-331)

### DIFF
--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -389,11 +389,7 @@ class Builder:
 
         charms = []
         for bases_config, build_on, bases_index, build_on_index in build_plan:
-            logger.debug(
-                "Building for 'bases[%d][%d]'.",
-                bases_index,
-                build_on_index,
-            )
+            logger.debug("Building for 'bases[%d][%d]'.", bases_index, build_on_index)
             if managed_mode or destructive_mode:
                 charm_name = self.build_charm(bases_config)
             else:

--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -303,14 +303,13 @@ class Builder:
     def plan(
         self, *, bases_indices: Optional[List[int]], destructive_mode: bool, managed_mode: bool
     ) -> List[Tuple[BasesConfiguration, Base, int, int]]:
-        """Plan build porocess.
+        """Determine the build plan based on user inputs and host environment.
 
-        In managed-mode or destructive-mode, build for each bases configuration
-        which has a matching build-on to the host we are executing on.  Warn for
-        each base configuration that is incompatible.  Error if unable to
-        produce any builds for any bases configuration.
+        Provide a list of bases that are buildable and scoped according to user
+        configuration. Provide all relevant details including the applicable
+        bases configuration and the indices of the entries to build for.
 
-        :returns: List of charm files created.
+        :returns: List of Tuples (bases_config, build_on, bases_index, build_on_index).
         """
         build_plan: List[Tuple[BasesConfiguration, Base, int, int]] = []
 

--- a/tests/commands/test_build.py
+++ b/tests/commands/test_build.py
@@ -955,15 +955,15 @@ def test_build_bases_index_scenarios_provider(
         call.is_base_available(
             Base(name="ubuntu", channel="18.04", architectures=[host_arch]),
         ),
+        call.is_base_available(
+            Base(name="ubuntu", channel="20.04", architectures=[host_arch]),
+        ),
         call.launched_environment(
             charm_name="name-from-metadata",
             project_path=basic_project,
             base=Base(name="ubuntu", channel="18.04", architectures=[host_arch]),
             bases_index=0,
             build_on_index=0,
-        ),
-        call.is_base_available(
-            Base(name="ubuntu", channel="20.04", architectures=[host_arch]),
         ),
         call.launched_environment(
             charm_name="name-from-metadata",


### PR DESCRIPTION
Determine bases that can be built first (in new `plan()` method)
then run through the process of building.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>