### PR TITLE
Support --project-dir pointing to a missing directory (CRAFT-474).

### DIFF
--- a/charmcraft/config.py
+++ b/charmcraft/config.py
@@ -276,7 +276,10 @@ class BasesConfiguration(
 class Project(ModelConfigDefaults):
     """Internal-only project configuration."""
 
-    dirpath: pydantic.DirectoryPath
+    # do not verify that `dirpath` is a valid existing directory; it's used externally as a dir
+    # to load the config itself (so we're really do the validation there), and we want to support
+    # the case of a missing directory (and still load a default config structure)
+    dirpath: pathlib.Path
     config_provided: bool = False
 
     # this timestamp will be used in several places, even sent to Charmhub: needs to be UTC
@@ -422,7 +425,7 @@ class Config(ModelConfigDefaults, validate_all=False):
         return schema
 
 
-def load(dirpath):
+def load(dirpath: Optional[str]) -> Config:
     """Load the config from charmcraft.yaml in the indicated directory."""
     if dirpath is None:
         if is_charmcraft_running_in_managed_mode():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -96,6 +96,15 @@ def test_load_optional_charmcraft_missing(tmp_path):
     assert not config.project.config_provided
 
 
+def test_load_optional_charmcraft_bad_directory(tmp_path):
+    """Specify a missing directory."""
+    missing_directory = tmp_path / "missing"
+    config = load(missing_directory)
+    assert config.type is None
+    assert config.project.dirpath == missing_directory
+    assert not config.project.config_provided
+
+
 def test_load_specific_directory_resolved(create_config, monkeypatch):
     """Ensure that the given directory is resolved to always show the whole path."""
     tmp_path = create_config(


### PR DESCRIPTION
I just fixed this when loading the config, so at least `charmcraft` does not crash.

I considered doing this verification in `main.py`, when loading the argument. The verification there would make more sense, as it's a "command line argument" verification, and we could raise a proper ArgumentParsingError indicating that the directory does not exist.

However, we *may want* for `--project-dir` to point to a directory that is not there, for the `init` command. See issue #198, where it claims that if the directory indicated to `init` is not there, we should create it.

So, in the end, I decided that the best behaviour is to just "accept" the parameter pointing to nowhere, and load a default config with that info. Note that the flag `config_provided` is `False` in this case, so if the executed command does need a real config, it will finish in error anyway.

One way to test this behaviour change is by issuing:

    charmcraft version --project-dir /whatever
