### PR TITLE
Stopped logging newlines, and moved to a log-each-line situation.

### DIFF
--- a/charmcraft/providers/_logs.py
+++ b/charmcraft/providers/_logs.py
@@ -44,7 +44,8 @@ def capture_logs_from_instance(instance: Executor) -> None:
         logger.debug("No logs found in instance.")
         return
 
-    logs = local_log_path.read_text()
+    logger.debug("Logs captured from managed instance:")
+    with open(local_log_path, "rt", encoding="utf8") as fh:
+        for line in fh:
+            logger.debug(":: %s", line.rstrip())
     local_log_path.unlink()
-
-    logger.debug("Logs captured from managed instance:\n%s", logs)

--- a/tests/providers/test_logs.py
+++ b/tests/providers/test_logs.py
@@ -14,6 +14,7 @@
 #
 # For further info, check https://github.com/canonical/charmcraft
 
+import logging
 import pathlib
 from unittest import mock
 
@@ -22,19 +23,15 @@ import pytest
 from charmcraft import providers
 
 
-@pytest.fixture
-def mock_logger():
-    with mock.patch("charmcraft.providers._logs.logger") as mock_logger:
-        yield mock_logger
-
-
 @pytest.fixture()
 def mock_mkstemp():
     with mock.patch("charmcraft.providers._logs.tempfile.mkstemp") as mock_mkstemp:
         yield mock_mkstemp
 
 
-def test_capture_logs_from_instance(mock_instance, mock_logger, mock_mkstemp, tmp_path):
+def test_capture_logs_from_instance(mock_instance, caplog, mock_mkstemp, tmp_path):
+    caplog.set_level(logging.DEBUG, logger="charmcraft")
+
     fake_log = tmp_path / "x.log"
     mock_mkstemp.return_value = (None, str(fake_log))
 
@@ -46,12 +43,18 @@ def test_capture_logs_from_instance(mock_instance, mock_logger, mock_mkstemp, tm
     assert mock_instance.mock_calls == [
         mock.call.pull_file(source=pathlib.Path("/tmp/charmcraft.log"), destination=fake_log),
     ]
-    assert mock_logger.mock_calls == [
-        mock.call.debug("Logs captured from managed instance:\n%s", fake_log_data)
+    expected = [
+        "Logs captured from managed instance:",
+        ":: some",
+        ":: log data",
+        ":: here",
     ]
+    assert expected == [rec.message for rec in caplog.records]
 
 
-def test_capture_logs_from_instance_not_found(mock_instance, mock_logger, mock_mkstemp, tmp_path):
+def test_capture_logs_from_instance_not_found(mock_instance, caplog, mock_mkstemp, tmp_path):
+    caplog.set_level(logging.DEBUG, logger="charmcraft")
+
     fake_log = tmp_path / "x.log"
     mock_mkstemp.return_value = (None, str(fake_log))
     mock_instance.pull_file.side_effect = FileNotFoundError()
@@ -61,4 +64,4 @@ def test_capture_logs_from_instance_not_found(mock_instance, mock_logger, mock_m
     assert mock_instance.mock_calls == [
         mock.call.pull_file(source=pathlib.Path("/tmp/charmcraft.log"), destination=fake_log),
     ]
-    assert mock_logger.mock_calls == [mock.call.debug("No logs found in instance.")]
+    assert ["No logs found in instance."] == [rec.message for rec in caplog.records]


### PR DESCRIPTION
This is in preparation for the new messages system. Also took the opportunity and started logging with a prefix, so final logs are more clear. And improved tests to use standard log capture fixture.
