### PR TITLE
setup: unlink target file before rename (CRAFT-495)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,8 @@ extras_require = {
 
 version_path = Path("charmcraft/version.py")
 version_backup = Path("charmcraft/version.py~")
+if version_backup.exists():
+    version_backup.unlink()
 version_path.rename(version_backup)
 try:
     with version_path.open("wt", encoding="utf8") as fh:
@@ -102,4 +104,6 @@ try:
     )
 
 finally:
+    if version_path.exists():
+        version_path.unlink()
     version_backup.rename(version_path)

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ extras_require = {
 version_path = Path("charmcraft/version.py")
 version_backup = Path("charmcraft/version.py~")
 if version_backup.exists():
+    # Windows requires the dest file to be unlinked before renaming.
     version_backup.unlink()
 version_path.rename(version_backup)
 try:
@@ -105,5 +106,6 @@ try:
 
 finally:
     if version_path.exists():
+        # Windows requires the dest file to be unlinked before renaming.
         version_path.unlink()
     version_backup.rename(version_path)


### PR DESCRIPTION
On Windows we get an error when using rename to overwrite an existing
file:

FileExistsError: [WinError 183] Cannot create a file when that file
 already exists: 'charmcraft\\version.py~' -> 'charmcraft\\version.py'

Unlink the target first if it exists.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>