### PR TITLE
commands/init: fix handling for platforms without pwd (CRAFT-496)

### DIFF
--- a/charmcraft/commands/init.py
+++ b/charmcraft/commands/init.py
@@ -79,6 +79,8 @@ def _get_author_from_user() -> str:
     """
     if pwd is not None:
         author = _get_users_full_name_gecos()
+    else:
+        author = None
 
     if not author:
         raise CommandError(

--- a/charmcraft/commands/init.py
+++ b/charmcraft/commands/init.py
@@ -93,7 +93,7 @@ def _get_author_from_user() -> str:
     """
     if sys.platform == "win32":
         author = _get_users_full_name_windows()
-    else:
+    elif pwd is not None:
         author = _get_users_full_name_gecos()
 
     if not author:

--- a/charmcraft/commands/init.py
+++ b/charmcraft/commands/init.py
@@ -16,11 +16,9 @@
 
 """Infrastructure for the 'init' command."""
 
-import ctypes
 import logging
 import os
 import re
-import sys
 from datetime import date
 from typing import Optional
 
@@ -74,31 +72,17 @@ def _get_users_full_name_gecos() -> Optional[str]:
         return None
 
 
-def _get_users_full_name_windows() -> str:
-    """Get user's full name on Windows."""
-    name_display = 3
-
-    size = ctypes.pointer(ctypes.c_ulong(0))
-    ctypes.windll.secur32.GetUserNameExW(name_display, None, size)
-
-    name_buffer = ctypes.create_unicode_buffer(size.contents.value)
-    ctypes.windll.secur32.GetUserNameExW(name_display, name_buffer, size)
-    return name_buffer.value
-
-
 def _get_author_from_user() -> str:
     """Get the author's name by querying system's user information.
 
     :raises CommandError: If unable to determine author.
     """
-    if sys.platform == "win32":
-        author = _get_users_full_name_windows()
-    elif pwd is not None:
+    if pwd is not None:
         author = _get_users_full_name_gecos()
 
     if not author:
         raise CommandError(
-            "Unable to automatically determine author's name, " "specify it with --author"
+            "Unable to automatically determine author's name, specify it with --author"
         )
 
     return author

--- a/charmcraft/commands/init.py
+++ b/charmcraft/commands/init.py
@@ -19,7 +19,9 @@
 import logging
 import os
 import re
+import sys
 from datetime import date
+from typing import Optional
 
 from charmcraft.cmdbase import BaseCommand, CommandError
 from charmcraft.utils import make_executable, get_templates_environment
@@ -58,6 +60,48 @@ example tests with a harness to run them.
 """
 
 
+def _get_users_full_name_gecos() -> Optional[str]:
+    """Get user's full name from Gecos (/etc/passwd)."""
+    import pwd
+
+    try:
+        return pwd.getpwuid(os.getuid()).pw_gecos.split(",", 1)[0]
+    except KeyError:
+        return None
+
+
+def _get_users_full_name_windows() -> str:
+    """Get user's full name on Windows."""
+    import ctypes
+
+    name_display = 3
+
+    size = ctypes.pointer(ctypes.c_ulong(0))
+    ctypes.windll.secur32.GetUserNameExW(name_display, None, size)
+
+    name_buffer = ctypes.create_unicode_buffer(size.contents.value)
+    ctypes.windll.secur32.GetUserNameExW(name_display, name_buffer, size)
+    return name_buffer.value
+
+
+def _get_author_from_user() -> str:
+    """Get the author's name by querying system's user information.
+
+    :raises CommandError: If unable to determine author.
+    """
+    if sys.platform == "win32":
+        author = _get_users_full_name_windows()
+    else:
+        author = _get_users_full_name_gecos()
+
+    if not author:
+        raise CommandError(
+            "Unable to automatically determine author's name, " "specify it with --author"
+        )
+
+    return author
+
+
 class InitCommand(BaseCommand):
     """Initialize a directory to be a charm project."""
 
@@ -88,19 +132,7 @@ class InitCommand(BaseCommand):
         logger.debug("Using project directory %r", str(self.config.project.dirpath))
 
         if args.author is None:
-            try:
-                # Not all platforms support pwd, so we do a late import here and handle
-                # the potential import error.
-                import pwd
-
-                gecos = pwd.getpwuid(os.getuid()).pw_gecos.split(",", 1)[0]
-            except (KeyError, ImportError):
-                # no info for the user
-                gecos = None
-            if not gecos:
-                raise CommandError("Author not given, and nothing in GECOS field")
-            logger.debug("Setting author to %r from GECOS field", gecos)
-            args.author = gecos
+            args.author = _get_author_from_user()
 
         if not args.name:
             args.name = self.config.project.dirpath.name

--- a/charmcraft/commands/init.py
+++ b/charmcraft/commands/init.py
@@ -26,6 +26,16 @@ from typing import Optional
 from charmcraft.cmdbase import BaseCommand, CommandError
 from charmcraft.utils import make_executable, get_templates_environment
 
+try:
+    import ctypes
+except ImportError:
+    ctypes = None
+
+try:
+    import pwd
+except ImportError:
+    pwd = None
+
 logger = logging.getLogger(__name__)
 
 _overview = """
@@ -62,8 +72,6 @@ example tests with a harness to run them.
 
 def _get_users_full_name_gecos() -> Optional[str]:
     """Get user's full name from Gecos (/etc/passwd)."""
-    import pwd
-
     try:
         return pwd.getpwuid(os.getuid()).pw_gecos.split(",", 1)[0]
     except KeyError:
@@ -72,8 +80,6 @@ def _get_users_full_name_gecos() -> Optional[str]:
 
 def _get_users_full_name_windows() -> str:
     """Get user's full name on Windows."""
-    import ctypes
-
     name_display = 3
 
     size = ctypes.pointer(ctypes.c_ulong(0))

--- a/charmcraft/commands/init.py
+++ b/charmcraft/commands/init.py
@@ -72,24 +72,6 @@ def _get_users_full_name_gecos() -> Optional[str]:
         return None
 
 
-def _get_author_from_user() -> str:
-    """Get the author's name by querying system's user information.
-
-    :raises CommandError: If unable to determine author.
-    """
-    if pwd is not None:
-        author = _get_users_full_name_gecos()
-    else:
-        author = None
-
-    if not author:
-        raise CommandError(
-            "Unable to automatically determine author's name, specify it with --author"
-        )
-
-    return author
-
-
 class InitCommand(BaseCommand):
     """Initialize a directory to be a charm project."""
 
@@ -119,8 +101,13 @@ class InitCommand(BaseCommand):
             raise CommandError(tpl.format(str(self.config.project.dirpath)))
         logger.debug("Using project directory %r", str(self.config.project.dirpath))
 
-        if args.author is None:
-            args.author = _get_author_from_user()
+        if args.author is None and pwd is not None:
+            args.author = _get_users_full_name_gecos()
+
+        if not args.author:
+            raise CommandError(
+                "Unable to automatically determine author's name, specify it with --author"
+            )
 
         if not args.name:
             args.name = self.config.project.dirpath.name

--- a/charmcraft/commands/init.py
+++ b/charmcraft/commands/init.py
@@ -16,6 +16,7 @@
 
 """Infrastructure for the 'init' command."""
 
+import ctypes
 import logging
 import os
 import re
@@ -25,11 +26,6 @@ from typing import Optional
 
 from charmcraft.cmdbase import BaseCommand, CommandError
 from charmcraft.utils import make_executable, get_templates_environment
-
-try:
-    import ctypes
-except ImportError:
-    ctypes = None
 
 try:
     import pwd

--- a/charmcraft/commands/init.py
+++ b/charmcraft/commands/init.py
@@ -18,7 +18,6 @@
 
 import logging
 import os
-import pwd
 import re
 from datetime import date
 
@@ -90,8 +89,12 @@ class InitCommand(BaseCommand):
 
         if args.author is None:
             try:
+                # Not all platforms support pwd, so we do a late import here and handle
+                # the potential import error.
+                import pwd
+
                 gecos = pwd.getpwuid(os.getuid()).pw_gecos.split(",", 1)[0]
-            except KeyError:
+            except (KeyError, ImportError):
                 # no info for the user
                 gecos = None
             if not gecos:

--- a/tests/commands/test_init.py
+++ b/tests/commands/test_init.py
@@ -29,13 +29,6 @@ from tests.test_infra import pep8_test, get_python_filepaths, pep257_test
 
 
 @pytest.fixture
-def mock_ctypes():
-    with patch("charmcraft.commands.init.ctypes") as mock_ctypes:
-        mock_ctypes.create_unicode_buffer.return_value.value = "Test Windows Author Name"
-        yield mock_ctypes
-
-
-@pytest.fixture
 def mock_pwd():
     with patch("charmcraft.commands.init.pwd", autospec=True) as mock_pwd:
         mock_pwd.getpwuid.return_value.pw_gecos = "Test Gecos Author Name,,,"
@@ -115,15 +108,6 @@ def test_no_author_gecos(tmp_path, config, mock_pwd):
 
     text = (tmp_path / "src" / "charm.py").read_text()
     assert "Test Gecos Author Name" in text
-
-
-@pytest.mark.skipif(sys.platform != "win32", reason="mocking for windows only")
-def test_no_author_windows(tmp_path, config, mock_ctypes):
-    cmd = InitCommand("group", config)
-    cmd.run(Namespace(name="my-charm", author=None, series="k8s", force=False))
-
-    text = (tmp_path / "src" / "charm.py").read_text()
-    assert "Test Windows Author Name" in text
 
 
 def test_executables(tmp_path, config):

--- a/tests/commands/test_init.py
+++ b/tests/commands/test_init.py
@@ -130,7 +130,7 @@ def test_gecos_missing_in_getpwuid_response(config):
     with patch("pwd.getpwuid") as mock_pwd:
         # return a fack passwd struct with an empty gecos (5th parameter)
         mock_pwd.return_value = pwd.struct_passwd(("user", "pass", 1, 1, "", "dir", "shell"))
-        msg = "Author not given, and nothing in GECOS field"
+        msg = "Unable to automatically determine author's name, specify it with --author"
         with pytest.raises(CommandError, match=msg):
             cmd.run(Namespace(name="my-charm", author=None, series="k8s", force=False))
 
@@ -141,6 +141,6 @@ def test_gecos_missing_user_information(config):
 
     with patch("pwd.getpwuid") as mock_pwd:
         mock_pwd.side_effect = KeyError("no user")
-        msg = "Author not given, and nothing in GECOS field"
+        msg = "Unable to automatically determine author's name, specify it with --author"
         with pytest.raises(CommandError, match=msg):
             cmd.run(Namespace(name="my-charm", author=None, series="k8s", force=False))


### PR DESCRIPTION
Future work can add similar support for other platforms. Example
code for Windows:

https://sjohannes.wordpress.com/2010/06/19/win32-python-getting-users-display-name-using-ctypes/

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>