### PR TITLE
store/client: skip unneeded fchmod (CRAFT-497)

### DIFF
--- a/charmcraft/commands/store/client.py
+++ b/charmcraft/commands/store/client.py
@@ -98,7 +98,6 @@ class _AuthHolder:
             os.makedirs(dirpath, exist_ok=True)
 
             fd = os.open(self._cookiejar_filepath, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-            os.fchmod(fd, 0o600)
             self._cookiejar.save(fd)
 
     def _load_credentials(self):


### PR DESCRIPTION
os.fchmod() is not supported on Windows.  Howver, the permissions
are already set on open(), we do not need to set them again.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>