### PR TITLE
env: add win32 to supported platform environments (CRAFT-498)

### DIFF
--- a/charmcraft/env.py
+++ b/charmcraft/env.py
@@ -59,7 +59,12 @@ def is_charmcraft_running_in_managed_mode():
 
 def is_charmcraft_running_in_supported_environment():
     """Check if Charmcraft is running in a supported environment."""
-    return sys.platform == "linux" and is_charmcraft_running_from_snap()
+    if sys.platform == "linux":
+        return is_charmcraft_running_from_snap()
+    elif sys.platform in ["win32"]:
+        return True
+
+    return False
 
 
 def ensure_charmcraft_environment_is_supported():

--- a/charmcraft/env.py
+++ b/charmcraft/env.py
@@ -61,7 +61,7 @@ def is_charmcraft_running_in_supported_environment():
     """Check if Charmcraft is running in a supported environment."""
     if sys.platform == "linux":
         return is_charmcraft_running_from_snap()
-    elif sys.platform in ["win32"]:
+    elif sys.platform == "win32":
         return True
 
     return False

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -123,14 +123,16 @@ def test_is_charmcraft_running_in_supported_environment_linux(monkeypatch, as_sn
     assert env.is_charmcraft_running_in_supported_environment() == as_snap
 
 
-@pytest.mark.parametrize(
-    "platform",
-    ["windows", "darwin"],
-)
-def test_is_charmcraft_running_in_supported_environment_non_linux(monkeypatch, platform):
-    monkeypatch.setattr(sys, "platform", platform)
+def test_is_charmcraft_running_in_supported_environment_osx(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "darwin")
 
     assert env.is_charmcraft_running_in_supported_environment() is False
+
+
+def test_is_charmcraft_running_in_supported_environment_windows(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "win32")
+
+    assert env.is_charmcraft_running_in_supported_environment() is True
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Add a platform check for Linux before vetting that Charmcraft is
running from the snap (or running in developer mode).

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>