### PR TITLE
utils: add arch translation for Windows' AMD64 (CRAFT-499)

### DIFF
--- a/charmcraft/utils.py
+++ b/charmcraft/utils.py
@@ -48,6 +48,7 @@ ARCH_TRANSLATIONS = {
     "ppc": "powerpc",
     "ppc64le": "ppc64el",
     "x86_64": "amd64",
+    "AMD64": "amd64",  # Windows support
 }
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -347,6 +347,7 @@ def test_get_os_platform_windows():
 @pytest.mark.parametrize(
     "platform_arch,deb_arch",
     [
+        ("AMD64", "amd64"),
         ("aarch64", "arm64"),
         ("armv7l", "armhf"),
         ("ppc", "powerpc"),


### PR DESCRIPTION
Signed-off-by: Chris Patterson <chris.patterson@canonical.com>