### PR TITLE
make required files executable (CRAFT-501)

### DIFF
--- a/charmcraft/charm_builder.py
+++ b/charmcraft/charm_builder.py
@@ -188,8 +188,7 @@ class CharmBuilder:
             )
             with dispatch_path.open("wt", encoding="utf8") as fh:
                 fh.write(dispatch_content)
-                if os.name == "posix":
-                    make_executable(fh)
+                make_executable(fh)
 
         # bunch of symlinks, to support old juju: verify that any of the already included hooks
         # in the directory is not linking directly to the entrypoint, and also check all the

--- a/charmcraft/charm_builder.py
+++ b/charmcraft/charm_builder.py
@@ -188,7 +188,8 @@ class CharmBuilder:
             )
             with dispatch_path.open("wt", encoding="utf8") as fh:
                 fh.write(dispatch_content)
-                make_executable(fh)
+                if os.name == "posix":
+                    make_executable(fh)
 
         # bunch of symlinks, to support old juju: verify that any of the already included hooks
         # in the directory is not linking directly to the entrypoint, and also check all the

--- a/charmcraft/commands/init.py
+++ b/charmcraft/commands/init.py
@@ -133,7 +133,7 @@ class InitCommand(BaseCommand):
                 fh.write(out)
                 for todo in _todo_rx.findall(out):
                     todos.append((template_name, todo))
-                if template_name in executables:
+                if template_name in executables and os.name == "posix":
                     make_executable(fh)
                     logger.debug("  made executable")
         logger.info("Charm operator package file and directory tree initialized.")


### PR DESCRIPTION
Windows does not support executable bits or fchmod().  Check if
system is posix before setting exe bit.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>