### PR TITLE
providers: add support to install Charmcraft snap from store (CRAFT-502)

### DIFF
--- a/charmcraft/env.py
+++ b/charmcraft/env.py
@@ -21,6 +21,7 @@ import distutils.util
 import os
 import pathlib
 import sys
+from typing import Optional
 
 from charmcraft.cmdbase import CommandError
 
@@ -38,6 +39,25 @@ def get_managed_environment_log_path():
 def get_managed_environment_project_path():
     """Path for project when running in managed environment."""
     return get_managed_environment_home_path() / "project"
+
+
+def get_managed_environment_snap_channel_default() -> str:
+    """Default channel to use when installing Charmcraft snap from Snap Store.
+
+    May someday be updated to use a track known to be compatible with the running
+    version.  For now, we default to default track's stable.
+
+    :returns: Channel string.
+    """
+    return "stable"
+
+
+def get_managed_environment_snap_channel() -> Optional[str]:
+    """User-specified channel to use when installing Charmcraft snap from Snap Store.
+
+    :returns: Channel string if specified, else None.
+    """
+    return os.getenv("CHARMCRAFT_INSTALL_SNAP_CHANNEL")
 
 
 def is_charmcraft_running_from_snap():

--- a/charmcraft/env.py
+++ b/charmcraft/env.py
@@ -41,17 +41,6 @@ def get_managed_environment_project_path():
     return get_managed_environment_home_path() / "project"
 
 
-def get_managed_environment_snap_channel_default() -> str:
-    """Channel to use when installing Charmcraft snap from Snap Store.
-
-    May someday be updated to use a track known to be compatible with the running
-    version.  For now, we default to default track's stable.
-
-    :returns: Channel string.
-    """
-    return "stable"
-
-
 def get_managed_environment_snap_channel() -> Optional[str]:
     """User-specified channel to use when installing Charmcraft snap from Snap Store.
 

--- a/charmcraft/providers/_buildd.py
+++ b/charmcraft/providers/_buildd.py
@@ -54,7 +54,8 @@ class CharmcraftBuilddBaseConfiguration(bases.BuilddBase):
 
         When installing the snap from the Store, we check if the user specifies a
         channel, using CHARMCRAFT_INSTALL_SNAP_CHANNEL=<channel>.  If unspecified,
-        we use the default determined by get_managed_environment_snap_channel_default().
+        we use the "stable" channel on the default track.
+
         On Linux, the user may specify this environment variable to force Charmcraft
         to install the snap from the Store rather than inject the host snap.
 

--- a/charmcraft/providers/_buildd.py
+++ b/charmcraft/providers/_buildd.py
@@ -22,10 +22,7 @@ from typing import Optional
 from craft_providers import Executor, bases
 from craft_providers.actions import snap_installer
 
-from charmcraft.env import (
-    get_managed_environment_snap_channel,
-    get_managed_environment_snap_channel_default,
-)
+from charmcraft.env import get_managed_environment_snap_channel
 
 
 BASE_CHANNEL_TO_BUILDD_IMAGE_ALIAS = {
@@ -65,7 +62,7 @@ class CharmcraftBuilddBaseConfiguration(bases.BuilddBase):
         """
         snap_channel = get_managed_environment_snap_channel()
         if snap_channel is None and sys.platform != "linux":
-            snap_channel = get_managed_environment_snap_channel_default()
+            snap_channel = "stable"
 
         if snap_channel:
             try:

--- a/charmcraft/providers/_buildd.py
+++ b/charmcraft/providers/_buildd.py
@@ -74,7 +74,8 @@ class CharmcraftBuilddBaseConfiguration(bases.BuilddBase):
                 )
             except snap_installer.SnapInstallationError as error:
                 raise bases.BaseConfigurationError(
-                    brief="Failed to install Charmcraft snap from store into target environment.",
+                    brief="Failed to install Charmcraft snap from store channel "
+                    f"{snap_channel!r} into target environment.",
                 ) from error
         else:
             try:

--- a/tests/providers/test_buildd.py
+++ b/tests/providers/test_buildd.py
@@ -14,6 +14,7 @@
 #
 # For further info, check https://github.com/canonical/charmcraft
 
+import re
 import sys
 from unittest import mock
 from unittest.mock import call
@@ -113,10 +114,14 @@ def test_base_configuration_setup_snap_install_from_store_error(
     alias = bases.BuilddBaseAlias.FOCAL
     config = providers.CharmcraftBuilddBaseConfiguration(alias=alias)
     mock_install_from_store.side_effect = snap_installer.SnapInstallationError(brief="foo error")
+    match = re.escape(
+        "Failed to install Charmcraft snap from store channel "
+        "'test-track/test-channel' into target environment."
+    )
 
     with pytest.raises(
         bases.BaseConfigurationError,
-        match=r"Failed to install Charmcraft snap from store into target environment.",
+        match=match,
     ) as exc_info:
         config.setup(executor=mock_instance)
 

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -41,6 +41,24 @@ def test_get_managed_environment_project_path():
     assert dirpath == pathlib.Path("/root/project")
 
 
+def test_get_managed_environment_snap_channel_default():
+    channel = env.get_managed_environment_snap_channel_default()
+
+    assert channel == "stable"
+
+
+def test_get_managed_environment_snap_channel_none(monkeypatch):
+    monkeypatch.delenv("CHARMCRAFT_INSTALL_SNAP_CHANNEL", raising=False)
+
+    assert env.get_managed_environment_snap_channel() is None
+
+
+def test_get_managed_environment_snap_channel(monkeypatch):
+    monkeypatch.setenv("CHARMCRAFT_INSTALL_SNAP_CHANNEL", "latest/edge")
+
+    assert env.get_managed_environment_snap_channel() == "latest/edge"
+
+
 @pytest.mark.parametrize(
     "snap_name,snap,result",
     [

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -41,12 +41,6 @@ def test_get_managed_environment_project_path():
     assert dirpath == pathlib.Path("/root/project")
 
 
-def test_get_managed_environment_snap_channel_default():
-    channel = env.get_managed_environment_snap_channel_default()
-
-    assert channel == "stable"
-
-
 def test_get_managed_environment_snap_channel_none(monkeypatch):
     monkeypatch.delenv("CHARMCRAFT_INSTALL_SNAP_CHANNEL", raising=False)
 


### PR DESCRIPTION
On Linux, the default behavior is to inject the host snap into the target
environment.

On other platforms, the Charmcraft snap is installed from the Snap Store.

When installing the snap from the Store, we check if the user specifies a
channel, using CHARMCRAFT_INSTALL_SNAP_CHANNEL=<channel>.  If unspecified,
we use the default determined by get_managed_environment_snap_channel_default().

On Linux, the user may specify this environment variable to force Charmcraft
to install the snap from the Store rather than inject the host snap.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>