### PR TITLE
logsetup: close log descriptor before unlinking (CRAFT-503)

### DIFF
--- a/charmcraft/logsetup.py
+++ b/charmcraft/logsetup.py
@@ -86,7 +86,9 @@ class _MessageHandler:
         if managed_mode:
             self._log_filepath = str(get_managed_environment_log_path())
         else:
-            _, self._log_filepath = tempfile.mkstemp(prefix="charmcraft-log-")
+            fd, self._log_filepath = tempfile.mkstemp(prefix="charmcraft-log-")
+            # Logger will re-open as needed.
+            os.close(fd)
 
         file_handler = logging.FileHandler(self._log_filepath, mode="w")
 

--- a/charmcraft/logsetup.py
+++ b/charmcraft/logsetup.py
@@ -107,6 +107,7 @@ class _MessageHandler:
 
     def ended_ok(self):
         """Cleanup after successful execution."""
+        logging.shutdown()
         os.unlink(self._log_filepath)
 
     def ended_interrupt(self):
@@ -115,6 +116,7 @@ class _MessageHandler:
             logger.exception("Interrupted.")
         else:
             logger.error("Interrupted.")
+        logging.shutdown()
         os.unlink(self._log_filepath)
 
     def ended_cmderror(self, err):

--- a/tests/test_logsetup.py
+++ b/tests/test_logsetup.py
@@ -25,7 +25,13 @@ from charmcraft.logsetup import _MessageHandler
 
 
 @pytest.fixture
-def create_message_handler(tmp_path):
+def mock_os_close():
+    with patch("charmcraft.logsetup.os.close") as mock_close:
+        yield mock_close
+
+
+@pytest.fixture
+def create_message_handler(mock_os_close, tmp_path):
     """Helper to create a message handler.
 
     Always in a temp directory, maybe with patched modes.
@@ -34,7 +40,7 @@ def create_message_handler(tmp_path):
     patchers = []
 
     def factory(modes=None):
-        p = patch("tempfile.mkstemp", lambda prefix: ("fd", str(temp_log_file)))
+        p = patch("tempfile.mkstemp", lambda prefix: (54321, str(temp_log_file)))
         p.start()
         patchers.append(p)
 

--- a/tests/test_logsetup.py
+++ b/tests/test_logsetup.py
@@ -16,7 +16,6 @@
 
 import logging
 import os
-from unittest.mock import patch
 
 import pytest
 

--- a/tests/test_logsetup.py
+++ b/tests/test_logsetup.py
@@ -25,32 +25,16 @@ from charmcraft.logsetup import _MessageHandler
 
 
 @pytest.fixture
-def mock_os_close():
-    with patch("charmcraft.logsetup.os.close") as mock_close:
-        yield mock_close
-
-
-@pytest.fixture
-def create_message_handler(mock_os_close, tmp_path):
+def create_message_handler():
     """Helper to create a message handler.
 
     Always in a temp directory, maybe with patched modes.
     """
-    temp_log_file = tmp_path / "test.log"
-    patchers = []
 
     def factory(modes=None):
-        p = patch("tempfile.mkstemp", lambda prefix: (54321, str(temp_log_file)))
-        p.start()
-        patchers.append(p)
-
         return _MessageHandler()
 
     yield factory
-
-    # cleanup
-    for p in patchers:
-        p.stop()
 
 
 # --- Tests for the MessageHandler


### PR DESCRIPTION
Attempting to unlink the open file on Windows results in:

PermissionError: [WinError 32] The process cannot access the file because it is
being used by another process.

Save off the file handle and close it before unlinking.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>