### PR TITLE
tests: skip broken tests when running on Windows (CRAFT-504)

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,7 +13,7 @@ jobs:
   run-tests:
     strategy:
       matrix:
-        os: [macos-10.15, ubuntu-18.04, ubuntu-20.04]
+        os: [macos-10.15, ubuntu-18.04, ubuntu-20.04, windows-2019]
         python-version: [3.8, 3.9]
 
     runs-on: ${{ matrix.os }}
@@ -26,32 +26,30 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install/update pip, wheel, and setuptools
+        run: |
+          pip install -U pip wheel setuptools
+      - name: Install Ubuntu-specific dependencies
+        if: ${{ matrix.os == 'ubuntu-18.04' || matrix.os == 'ubuntu-20.04' }}
+        run: |
+          sudo apt update
+          sudo apt install -y python3-pip python3-setuptools python3-wheel python3-venv libapt-pkg-dev
+      - name: Install Ubuntu 18.04-specific dependencies
+        if: ${{ matrix.os == 'ubuntu-18.04' }}
+        run: |
+          # pip 20.2 breaks python3-apt, so pin the version before building
+          pip install -U pip==20.1
+          pip install -U -r requirements-bionic.txt
+      - name: Install Ubuntu 20.04-specific dependencies
+        if: ${{ matrix.os == 'ubuntu-20.04' }}
+        run: |
+          pip install -U -r requirements-focal.txt
       - name: Install charmcraft and dependencies
         run: |
-          case "${{ matrix.os }}" in
-            ubuntu-*)
-              sudo apt update
-              sudo apt install -y python3-pip python3-setuptools python3-wheel python3-venv libapt-pkg-dev
-              ;;
-          esac
-          python3 -m venv ${HOME}/.venv
-          source ${HOME}/.venv/bin/activate
-          pip install -U pip wheel setuptools
-          case "${{ matrix.os }}" in
-            ubuntu-18.04)
-              # pip 20.2 breaks python3-apt, so pin the version before building
-              pip install pip==20.1
-              pip install -U -r requirements-bionic.txt
-              ;;
-            ubuntu-20.04)
-              pip install -U -r requirements-focal.txt
-              ;;
-          esac
           pip install -U -r requirements-dev.txt
           pip install -e .
       - name: Run tests
         run: |
-          source ${HOME}/.venv/bin/activate
           pytest -ra tests
 
   snap-build:

--- a/tests/commands/test_analyze.py
+++ b/tests/commands/test_analyze.py
@@ -16,6 +16,7 @@
 
 import json
 import logging
+import sys
 import zipfile
 from argparse import Namespace, ArgumentParser
 from unittest.mock import patch, ANY
@@ -76,6 +77,7 @@ def test_expanded_charm_basic(config, tmp_path, monkeypatch):
     assert fake_analyze_called
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 @pytest.mark.parametrize("modebits", [0o777, 0o750, 0o444])
 def test_expanded_charm_permissions(config, tmp_path, monkeypatch, modebits):
     """Check that the expanded charm keeps original permissions."""
@@ -99,6 +101,7 @@ def test_expanded_charm_permissions(config, tmp_path, monkeypatch, modebits):
     AnalyzeCommand("group", config).run(args)
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_corrupt_charm(tmp_path, config):
     """There was a problem opening the indicated charm."""
     charm_file = tmp_path / "foobar.charm"

--- a/tests/commands/test_build.py
+++ b/tests/commands/test_build.py
@@ -19,6 +19,7 @@ import os
 import pathlib
 import re
 import subprocess
+import sys
 import zipfile
 from collections import namedtuple
 from textwrap import dedent
@@ -264,6 +265,7 @@ def test_validator_from_expanded(config):
     assert resp == pathlib.Path.home()
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_validator_from_exist(config):
     """'from' param: checks that the directory exists."""
     validator = Validator(config)
@@ -272,6 +274,7 @@ def test_validator_from_exist(config):
         validator.validate_from(pathlib.Path("/not_really_there"))
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_validator_from_isdir(tmp_path, config):
     """'from' param: checks that the directory is really that."""
     testfile = tmp_path / "testfile"
@@ -337,6 +340,7 @@ def test_validator_entrypoint_absolutized(tmp_path, monkeypatch, config):
     assert resp == testfile
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_validator_entrypoint_expanded(tmp_path, config):
     """'entrypoint' param: expands the user-home prefix."""
     fake_home = tmp_path / "homedir"
@@ -353,6 +357,7 @@ def test_validator_entrypoint_expanded(tmp_path, config):
     assert resp == testfile
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_validator_entrypoint_exist(config):
     """'entrypoint' param: checks that the file exists."""
     validator = Validator(config)
@@ -361,6 +366,7 @@ def test_validator_entrypoint_exist(config):
         validator.validate_entrypoint(pathlib.Path("/not_really_there.py"))
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_validator_entrypoint_inside_project(tmp_path, config):
     """'entrypoint' param: checks that it's part of the project."""
     project_dir = tmp_path / "test-project"
@@ -375,6 +381,7 @@ def test_validator_entrypoint_inside_project(tmp_path, config):
         validator.validate_entrypoint(testfile)
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_validator_entrypoint_exec(tmp_path, config):
     """'entrypoint' param: checks that the file is executable."""
     testfile = tmp_path / "testfile"
@@ -448,6 +455,7 @@ def test_validator_requirement_absolutized(tmp_path, monkeypatch, config):
     assert resp == [testfile]
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_validator_requirement_expanded(tmp_path, config):
     """'requirement' param: expands the user-home prefix."""
     fake_home = tmp_path / "homedir"
@@ -463,6 +471,7 @@ def test_validator_requirement_expanded(tmp_path, config):
     assert resp == [requirement]
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_validator_requirement_exist(config):
     """'requirement' param: checks that the file exists."""
     validator = Validator(config)
@@ -489,6 +498,7 @@ def test_validator_force(config, inp_value, out_value):
 # --- (real) build tests
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_build_basic_complete_structure(basic_project, caplog, monkeypatch, config, tmp_path):
     """Integration test: a simple structure with custom lib and normal src dir."""
     caplog.set_level(logging.WARNING, logger="charmcraft")
@@ -543,6 +553,7 @@ def test_build_error_without_metadata_yaml(basic_project, monkeypatch):
         get_builder(config)
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_build_with_charmcraft_yaml_destructive_mode(basic_project_builder, caplog, monkeypatch):
     host_base = get_host_as_base()
     builder = basic_project_builder(
@@ -560,6 +571,7 @@ def test_build_with_charmcraft_yaml_destructive_mode(basic_project_builder, capl
     assert "Building for 'bases[0]' as host matches 'build-on[0]'." in records
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_build_with_charmcraft_yaml_managed_mode(
     basic_project_builder, caplog, monkeypatch, tmp_path
 ):
@@ -681,6 +693,7 @@ def test_build_without_charmcraft_yaml_issues_dn02(basic_project, caplog, monkey
     ]
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_build_multiple_with_charmcraft_yaml_destructive_mode(
     basic_project_builder, monkeypatch, caplog
 ):
@@ -720,6 +733,7 @@ def test_build_multiple_with_charmcraft_yaml_destructive_mode(
     assert "Building for 'bases[2]' as host matches 'build-on[0]'." in records
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_build_multiple_with_charmcraft_yaml_managed_mode(
     basic_project_builder, monkeypatch, caplog, tmp_path
 ):
@@ -876,6 +890,7 @@ def test_build_project_is_not_cwd(
     ]
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 @pytest.mark.parametrize(
     "mode,cmd_flags",
     [
@@ -1053,6 +1068,7 @@ def test_build_bases_index_scenarios_provider(
     assert mock_capture_logs_from_instance.mock_calls == [call(mock_instance)]
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_build_bases_index_scenarios_managed_mode(basic_project, monkeypatch, caplog, tmp_path):
     """Test cases for base-index parameter."""
     host_base = get_host_as_base()
@@ -1172,6 +1188,7 @@ def test_build_error_no_match_with_charmcraft_yaml(
     assert "No suitable 'build-on' environment found in 'bases[2]' configuration." in records
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_build_package_tree_structure(tmp_path, monkeypatch, config):
     """The zip file is properly built internally."""
     # the metadata
@@ -1791,6 +1808,7 @@ def test_build_requirements_from_both(basic_project, monkeypatch, caplog):
     )
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_build_using_linters_attributes(basic_project, monkeypatch, config, tmp_path):
     """Generic use of linters, pass them ok to their proceessor and save them in the manifest."""
     builder = get_builder(config)

--- a/tests/commands/test_pack.py
+++ b/tests/commands/test_pack.py
@@ -17,6 +17,7 @@
 import datetime
 import logging
 import pathlib
+import sys
 import zipfile
 from argparse import ArgumentParser, Namespace
 from unittest import mock
@@ -152,6 +153,7 @@ def test_resolve_bundle_with_entrypoint(config):
 # -- tests for main bundle building process
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_bundle_simple_succesful_build(tmp_path, caplog, bundle_yaml, bundle_config):
     """A simple happy story."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
@@ -182,6 +184,7 @@ def test_bundle_simple_succesful_build(tmp_path, caplog, bundle_yaml, bundle_con
     assert not (tmp_path / "manifest.yaml").exists()
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_bundle_missing_bundle_file(tmp_path, bundle_config):
     """Can not build a bundle without bundle.yaml."""
     # build without a bundle.yaml!
@@ -203,6 +206,7 @@ def test_bundle_missing_other_mandatory_file(tmp_path, bundle_config, bundle_yam
     assert str(cm.value) == "Missing mandatory file: {!r}.".format(str(tmp_path / "README.md"))
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_bundle_missing_name_in_bundle(tmp_path, bundle_yaml, bundle_config):
     """Can not build a bundle without name."""
     bundle_config.set(type="bundle")
@@ -267,6 +271,7 @@ def test_bundle_shell_after(tmp_path, bundle_yaml, bundle_config, mock_parts, mo
 # -- tests for get paths helper
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_prime_mandatory_ok(tmp_path, bundle_yaml, bundle_config):
     """Simple succesful case getting all mandatory files."""
     bundle_yaml(name="testbundle")
@@ -285,6 +290,7 @@ def test_prime_mandatory_ok(tmp_path, bundle_yaml, bundle_config):
     assert "bar.bin" in zipped_files
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_prime_extra_ok(tmp_path, bundle_yaml, bundle_config):
     """Extra files were indicated ok."""
     bundle_yaml(name="testbundle")
@@ -303,6 +309,7 @@ def test_prime_extra_ok(tmp_path, bundle_yaml, bundle_config):
     assert "f2.txt" in zipped_files
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_prime_extra_missing(tmp_path, bundle_yaml, bundle_config):
     """Extra files were indicated but not found."""
     bundle_yaml(name="testbundle")
@@ -319,6 +326,7 @@ def test_prime_extra_missing(tmp_path, bundle_yaml, bundle_config):
     )
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_prime_extra_long_path(tmp_path, bundle_yaml, bundle_config):
     """An extra file can be deep in directories."""
     bundle_yaml(name="testbundle")
@@ -335,6 +343,7 @@ def test_prime_extra_long_path(tmp_path, bundle_yaml, bundle_config):
     assert "foo/bar/baz/extra.txt" in zipped_files
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_prime_extra_wildcards_ok(tmp_path, bundle_yaml, bundle_config):
     """Use wildcards to specify several files ok."""
     bundle_yaml(name="testbundle")
@@ -356,6 +365,7 @@ def test_prime_extra_wildcards_ok(tmp_path, bundle_yaml, bundle_config):
     assert "f3.txt" in zipped_files
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_prime_extra_wildcards_not_found(tmp_path, bundle_yaml, bundle_config):
     """Use wildcards to specify several files but nothing found."""
     bundle_yaml(name="testbundle")
@@ -370,6 +380,7 @@ def test_prime_extra_wildcards_not_found(tmp_path, bundle_yaml, bundle_config):
     assert zipped_files == ["manifest.yaml"]
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_prime_extra_globstar(tmp_path, bundle_yaml, bundle_config):
     """Double star means whatever directories are in the path."""
     bundle_yaml(name="testbundle")
@@ -397,6 +408,7 @@ def test_prime_extra_globstar(tmp_path, bundle_yaml, bundle_config):
         assert (srcpath in zipped_files) == expected
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_prime_extra_globstar_specific_files(tmp_path, bundle_yaml, bundle_config):
     """Combination of both mechanisms."""
     bundle_yaml(name="testbundle")
@@ -452,6 +464,7 @@ def test_zipbuild_simple(tmp_path):
     assert zf.read("bar/baz.txt") == b"mo\xc3\xb1o"
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_zipbuild_symlink_simple(tmp_path):
     """Symlinks are supported."""
     build_dir = tmp_path / "somedir"
@@ -471,6 +484,7 @@ def test_zipbuild_symlink_simple(tmp_path):
     assert zf.read("link.txt") == b"123\x00456"
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_zipbuild_symlink_outside(tmp_path):
     """No matter where the symlink points to."""
     # outside the build dir

--- a/tests/commands/test_store_client.py
+++ b/tests/commands/test_store_client.py
@@ -19,6 +19,7 @@
 import json
 import logging
 import os
+import sys
 from http.cookiejar import MozillaCookieJar, Cookie
 from unittest.mock import patch
 
@@ -248,6 +249,7 @@ def test_authholder_credentials_save_reallysave(auth_holder):
     assert mock.call_count == 1
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_authholder_credentials_save_createsdir(auth_holder, tmp_path):
     """Save creates the directory if not there."""
     weird_filepath = tmp_path / "not_created_dir" / "deep" / "credentials"

--- a/tests/commands/test_store_commands.py
+++ b/tests/commands/test_store_commands.py
@@ -20,6 +20,7 @@ import datetime
 import hashlib
 import logging
 import pathlib
+import sys
 import zipfile
 from argparse import Namespace, ArgumentParser
 from unittest.mock import patch, call, MagicMock, ANY
@@ -341,6 +342,7 @@ def _build_zip_with_yaml(zippath, filename, *, content=None, raw_yaml=None):
         zf.writestr(filename, raw_yaml)
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_get_name_bad_zip(tmp_path):
     """Get the name from a bad zip file."""
     bad_zip = tmp_path / "badstuff.zip"
@@ -361,6 +363,7 @@ def test_get_name_charm_ok(tmp_path):
     assert name == test_name
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 @pytest.mark.parametrize(
     "yaml_content",
     [
@@ -391,6 +394,7 @@ def test_get_name_bundle_ok(tmp_path):
     assert name == test_name
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 @pytest.mark.parametrize(
     "yaml_content",
     [
@@ -411,6 +415,7 @@ def test_get_name_bundle_bad_data(tmp_path, yaml_content):
     )
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_get_name_nor_charm_nor_bundle(tmp_path):
     """Get the name from a zip that has no metadata.yaml nor bundle.yaml."""
     bad_zip = tmp_path / "badstuff.zip"
@@ -1583,6 +1588,7 @@ def test_status_with_base_in_none(caplog, store_mock, config):
 # -- tests for create library command
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_createlib_simple(caplog, store_mock, tmp_path, monkeypatch, config):
     """Happy path with result from the Store."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
@@ -1624,6 +1630,7 @@ def test_createlib_name_from_metadata_problem(store_mock, config):
         )
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_createlib_name_contains_dash(caplog, store_mock, tmp_path, monkeypatch, config):
     """'-' is valid in charm names but can't be imported"""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
@@ -1674,6 +1681,7 @@ def test_createlib_invalid_name(lib_name, config):
     )
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_createlib_path_already_there(tmp_path, monkeypatch, config):
     """The intended-to-be-created library is already there."""
     monkeypatch.chdir(tmp_path)
@@ -1690,6 +1698,7 @@ def test_createlib_path_already_there(tmp_path, monkeypatch, config):
     )
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_createlib_path_can_not_write(tmp_path, monkeypatch, store_mock, add_cleanup, config):
     """Disk error when trying to write the new lib (bad permissions, name too long, whatever)."""
     lib_dir = tmp_path / "lib" / "charms" / "test_charm_name" / "v0"
@@ -1765,6 +1774,7 @@ def test_publishlib_contains_dash(caplog, store_mock, tmp_path, monkeypatch, con
     assert [expected] == [rec.message for rec in caplog.records]
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_publishlib_all(caplog, store_mock, tmp_path, monkeypatch, config):
     """Publish all the libraries found in disk."""
     caplog.set_level(logging.DEBUG, logger="charmcraft.commands")
@@ -1814,6 +1824,7 @@ def test_publishlib_all(caplog, store_mock, tmp_path, monkeypatch, config):
     assert all(e in records for e in expected)
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_publishlib_not_found(caplog, store_mock, tmp_path, monkeypatch, config):
     """The indicated library is not found."""
     caplog.set_level(logging.INFO, logger="charmcraft.commands")
@@ -2123,6 +2134,7 @@ def test_getlibinfo_success_simple(tmp_path, monkeypatch):
     assert lib_data.charm_name == "testcharm"
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_getlibinfo_success_content(tmp_path, monkeypatch):
     """Check that content and its hash are ok."""
     monkeypatch.chdir(tmp_path)
@@ -2157,6 +2169,7 @@ def test_getlibinfo_bad_name(name):
     )
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 @pytest.mark.parametrize(
     "path",
     [
@@ -2227,6 +2240,7 @@ def test_getlibinfo_missing_library_from_path():
     assert lib_data.charm_name == "testcharm"
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_getlibinfo_malformed_metadata_field(tmp_path, monkeypatch):
     """Some metadata field is not really valid."""
     monkeypatch.chdir(tmp_path)
@@ -2534,6 +2548,7 @@ def test_fetchlib_simple_updated(caplog, store_mock, tmp_path, monkeypatch, conf
     assert saved_file.read_text() == new_lib_content
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_fetchlib_all(caplog, store_mock, tmp_path, monkeypatch, config):
     """Update all the libraries found in disk."""
     caplog.set_level(logging.DEBUG, logger="charmcraft.commands")
@@ -3001,6 +3016,7 @@ def test_uploadresource_filepath_call_ok(caplog, store_mock, config, tmp_path):
     assert test_resource.exists()  # provided by the user, don't touch it
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_uploadresource_image_call_already_uploaded(caplog, store_mock, config):
     """Upload an oci-image resource, the image itself already being in the registry."""
     caplog.set_level(logging.DEBUG, logger="charmcraft.commands")
@@ -3085,6 +3101,7 @@ def test_uploadresource_image_call_already_uploaded(caplog, store_mock, config):
     assert expected == [rec.message for rec in caplog.records]
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_uploadresource_image_call_upload_from_local(caplog, store_mock, config):
     """Upload an oci-image resource, the image is upload from local to Canonical's registry."""
     caplog.set_level(logging.DEBUG, logger="charmcraft.commands")

--- a/tests/commands/test_store_registry.py
+++ b/tests/commands/test_store_registry.py
@@ -21,6 +21,7 @@ import gzip
 import hashlib
 import io
 import json
+import sys
 import tarfile
 import logging
 from unittest.mock import patch
@@ -999,6 +1000,7 @@ def test_imagehandler_uploadblob_duplicated(caplog, tmp_path):
     assert expected == [rec.message for rec in caplog.records]
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_imagehandler_uploadfromlocal_complete(caplog, tmp_path, responses, monkeypatch):
     """Complete process of uploading a local image."""
     caplog.set_level(logging.DEBUG, logger="charmcraft")
@@ -1128,6 +1130,7 @@ def test_imagehandler_uploadfromlocal_not_found_locally(caplog, monkeypatch):
     assert expected == [rec.message for rec in caplog.records]
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_imagehandler_uploadfromlocal_no_config(caplog, tmp_path, monkeypatch):
     """Particular case of a manifest without config."""
     caplog.set_level(logging.DEBUG, logger="charmcraft")

--- a/tests/test_charm_builder.py
+++ b/tests/test_charm_builder.py
@@ -63,6 +63,7 @@ def test_build_generics_simple_files(tmp_path):
     assert linked_entrypoint == built_entrypoint
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_build_generics_simple_dir(tmp_path):
     """Check transferred any directory, with proper permissions."""
     build_dir = tmp_path / BUILD_DIRNAME
@@ -238,11 +239,13 @@ def _test_build_generics_tree(tmp_path, caplog, *, expect_hardlinks):
             assert p1.stat().st_mtime == pytest.approx(p2.stat().st_mtime)
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_build_generics_tree(tmp_path, caplog):
     """Manages ok a deep tree, including internal ignores."""
     _test_build_generics_tree(tmp_path, caplog, expect_hardlinks=True)
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_build_generics_tree_vagrant(tmp_path, caplog):
     """Manages ok a deep tree, including internal ignores, when hardlinks aren't allowed."""
     with patch("os.link") as mock_link:
@@ -250,6 +253,7 @@ def test_build_generics_tree_vagrant(tmp_path, caplog):
         _test_build_generics_tree(tmp_path, caplog, expect_hardlinks=False)
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_build_generics_tree_xdev(tmp_path, caplog):
     """Manages ok a deep tree, including internal ignores, when hardlinks can't be done."""
     with patch("os.link") as mock_link:
@@ -257,6 +261,7 @@ def test_build_generics_tree_xdev(tmp_path, caplog):
         _test_build_generics_tree(tmp_path, caplog, expect_hardlinks=False)
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_build_generics_symlink_file(tmp_path):
     """Respects a symlinked file."""
     build_dir = tmp_path / BUILD_DIRNAME
@@ -283,6 +288,7 @@ def test_build_generics_symlink_file(tmp_path):
     assert real_link == "crazycharm.py"
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_build_generics_symlink_dir(tmp_path):
     """Respects a symlinked dir."""
     build_dir = tmp_path / BUILD_DIRNAME
@@ -316,6 +322,7 @@ def test_build_generics_symlink_dir(tmp_path):
     assert (build_dir / "thelink" / "sanity check").exists()
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_build_generics_symlink_deep(tmp_path):
     """Correctly re-links a symlink across deep dirs."""
     build_dir = tmp_path / BUILD_DIRNAME
@@ -349,6 +356,7 @@ def test_build_generics_symlink_deep(tmp_path):
     assert real_link == "../dir1/file.real"
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_build_generics_symlink_file_outside(tmp_path, caplog):
     """Ignores (with warning) a symlink pointing a file outside projects dir."""
     caplog.set_level(logging.WARNING)
@@ -380,6 +388,7 @@ def test_build_generics_symlink_file_outside(tmp_path, caplog):
     assert expected in [rec.message for rec in caplog.records]
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_build_generics_symlink_directory_outside(tmp_path, caplog):
     """Ignores (with warning) a symlink pointing a dir outside projects dir."""
     caplog.set_level(logging.WARNING)
@@ -411,6 +420,7 @@ def test_build_generics_symlink_directory_outside(tmp_path, caplog):
     assert expected in [rec.message for rec in caplog.records]
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_build_generics_different_filetype(tmp_path, caplog, monkeypatch):
     """Ignores whatever is not a regular file, symlink or dir."""
     caplog.set_level(logging.DEBUG)
@@ -442,6 +452,7 @@ def test_build_generics_different_filetype(tmp_path, caplog, monkeypatch):
     assert expected in [rec.message for rec in caplog.records]
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_build_dispatcher_modern_dispatch_created(tmp_path):
     """The dispatcher script is properly built."""
     metadata = tmp_path / CHARM_METADATA
@@ -464,6 +475,7 @@ def test_build_dispatcher_modern_dispatch_created(tmp_path):
     assert dispatcher_code == DISPATCH_CONTENT.format(entrypoint_relative_path="somestuff.py")
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_build_dispatcher_modern_dispatch_respected(tmp_path):
     """The already included dispatcher script is left untouched."""
     metadata = tmp_path / CHARM_METADATA
@@ -486,6 +498,7 @@ def test_build_dispatcher_modern_dispatch_respected(tmp_path):
         assert fh.read() == b"abc"
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_build_dispatcher_classic_hooks_mandatory_created(tmp_path):
     """The mandatory classic hooks are implemented ok if not present."""
     metadata = tmp_path / CHARM_METADATA
@@ -511,6 +524,7 @@ def test_build_dispatcher_classic_hooks_mandatory_created(tmp_path):
     assert real_link == os.path.join("..", DISPATCH_FILENAME)
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_build_dispatcher_classic_hooks_mandatory_respected(tmp_path):
     """The already included mandatory classic hooks are left untouched."""
     metadata = tmp_path / CHARM_METADATA
@@ -538,6 +552,7 @@ def test_build_dispatcher_classic_hooks_mandatory_respected(tmp_path):
         assert fh.read() == b"abc"
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_build_dispatcher_classic_hooks_linking_charm_replaced(tmp_path, caplog):
     """Hooks that are just a symlink to the entrypoint are replaced."""
     caplog.set_level(logging.DEBUG, logger="charmcraft")
@@ -795,6 +810,7 @@ def test_builder_arguments_full(tmp_path):
 # --- subprocess runner tests
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_processrun_base(caplog):
     """Basic execution."""
     caplog.set_level(logging.ERROR, logger="charmcraft")
@@ -804,6 +820,7 @@ def test_processrun_base(caplog):
     assert not caplog.records
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_processrun_stdout_logged(caplog):
     """The standard output is logged in debug."""
     caplog.set_level(logging.DEBUG, logger="charmcraft")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -18,6 +18,7 @@ import datetime
 import logging
 import os
 import pathlib
+import sys
 from textwrap import dedent
 from unittest.mock import patch
 
@@ -122,6 +123,7 @@ def test_load_specific_directory_resolved(create_config, monkeypatch):
     assert config.project.dirpath == tmp_path
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_load_specific_directory_expanded(create_config, monkeypatch):
     """Ensure that the given directory is user-expanded."""
     tmp_path = create_config(

--- a/tests/test_infra.py
+++ b/tests/test_infra.py
@@ -19,6 +19,7 @@ import itertools
 import os
 import re
 import subprocess
+import sys
 from unittest.mock import patch
 
 import black
@@ -108,6 +109,7 @@ def test_ensure_copyright():
         pytest.fail(msg, pytrace=False)
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_setup_version():
     """Verify that setup.py is picking up the version correctly."""
     cmd = [os.path.abspath("setup.py"), "--version"]

--- a/tests/test_jujuignore.py
+++ b/tests/test_jujuignore.py
@@ -17,8 +17,11 @@
 import io
 import pathlib
 import subprocess
+import sys
 import textwrap
 import tempfile
+
+import pytest
 
 from charmcraft import jujuignore
 
@@ -344,6 +347,7 @@ def assertMatchedAndNonMatched(globs, matched, unmatched, skip_git=False):
     )
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_star_vs_star_start():
     assertMatchedAndNonMatched(
         ["/*.py", "**/foo"],
@@ -355,6 +359,7 @@ def test_star_vs_star_start():
     )
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_questionmark():
     assertMatchedAndNonMatched(
         ["foo?.py"],
@@ -363,6 +368,7 @@ def test_questionmark():
     )
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_brackets():
     assertMatchedAndNonMatched(
         ["*.py[cod]"],
@@ -371,6 +377,7 @@ def test_brackets():
     )
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_bracket_ranges():
     assertMatchedAndNonMatched(
         ["foo[1-9].py"],
@@ -379,6 +386,7 @@ def test_bracket_ranges():
     )
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_bracket_inverted():
     assertMatchedAndNonMatched(
         ["foo[!1-9].py", "bar[!a].py"],
@@ -398,6 +406,7 @@ def test_slashes_in_brackets():
     )
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_special_chars_in_brackets():
     assertMatchedAndNonMatched(
         [r"foo[a|b].py"],

--- a/tests/test_linters.py
+++ b/tests/test_linters.py
@@ -16,6 +16,7 @@
 
 """Tests for analyze and lint code."""
 
+import sys
 import pathlib
 from unittest.mock import patch
 
@@ -110,6 +111,7 @@ def test_checkdispatchpython_entrypoint_is_not_python(tmp_path):
     assert result is None
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_checkdispatchpython_entrypoint_no_exec(tmp_path):
     """The charm entrypoint is not executable."""
     dispatch = tmp_path / "dispatch"
@@ -375,6 +377,7 @@ def test_framework_reactive_no_entrypoint(tmp_path, monkeypatch):
     assert result is False
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_framework_reactive_unaccesible_entrypoint(tmp_path, monkeypatch):
     """Cannot read the entrypoint file."""
     # metdata file with needed name field

--- a/tests/test_parts.py
+++ b/tests/test_parts.py
@@ -26,6 +26,9 @@ from craft_parts import Step, plugins
 from charmcraft import charm_builder, parts
 
 
+pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
+
+
 class TestCharmPlugin:
     """Ensure plugin methods return expected data."""
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -17,6 +17,7 @@
 import logging
 import os
 import pathlib
+import sys
 from textwrap import dedent
 from unittest.mock import call, patch
 
@@ -55,6 +56,7 @@ def mock_is_charmcraft_running_in_managed_mode():
         yield mock_managed
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_make_executable_read_bits(tmp_path):
     pth = tmp_path / "test"
     pth.touch(mode=0o640)
@@ -117,6 +119,7 @@ def test_load_yaml_corrupted_format(tmp_path, caplog):
     assert "ParserError" in logged
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_load_yaml_file_problem(tmp_path, caplog):
     caplog.set_level(logging.ERROR, logger="charmcraft.commands")
 
@@ -197,6 +200,7 @@ def test_usefulfilepath_pathlib(tmp_path):
     assert isinstance(path, pathlib.Path)
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_usefulfilepath_home_expanded(tmp_path, monkeypatch):
     """Home-expand the indicated path."""
     fake_home = tmp_path / "homedir"
@@ -216,6 +220,7 @@ def test_usefulfilepath_missing():
     assert str(cm.value) == "Cannot access 'not_really_there.txt'."
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_usefulfilepath_inaccessible(tmp_path):
     """The indicated path is not readable."""
     test_file = tmp_path / "testfile.bin"


### PR DESCRIPTION
As a starting point for Windows testing, we disable all tests which fail
on Windows.  Over time we should update the tests to either work on
Windows, or mark them as specifically unsupported on Windows.

Tests are disabled entirely for the test_parts module, as craft-parts
does not yet support Windows.  In practice in may not be much effort
to enable it for these tests.

The rest of the tests are disabled on a per-test basis.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>