### PR TITLE
First step in isolating the help texts module from the app itself (CRAFT-530).

### DIFF
--- a/charmcraft/helptexts.py
+++ b/charmcraft/helptexts.py
@@ -59,8 +59,8 @@ def _build_item(title, text, title_space):
     return result
 
 
-class Helper:
-    """Produce the different helping texts."""
+class HelpBuilder:
+    """Produce the different help texts."""
 
     def __init__(self):
         self.appname = None
@@ -278,4 +278,4 @@ class Helper:
         return text
 
 
-helper = Helper()
+help_builder = HelpBuilder()

--- a/charmcraft/main.py
+++ b/charmcraft/main.py
@@ -24,7 +24,7 @@ from collections import namedtuple
 from charmcraft import config, env
 from charmcraft.cmdbase import BaseCommand, CommandError
 from charmcraft.commands import build, clean, init, pack, store, version, analyze
-from charmcraft.helptexts import helper
+from charmcraft.helptexts import help_builder
 from charmcraft.logsetup import message_handler
 from charmcraft.parts import setup_parts
 
@@ -86,7 +86,7 @@ class HelpCommand(BaseCommand):
         if parsed_args.command_to_help not in all_commands:
             # asked help on a command that doesn't exist
             msg = "no such command {!r}".format(parsed_args.command_to_help)
-            help_text = helper.get_usage_message("charmcraft", msg)
+            help_text = help_builder.get_usage_message("charmcraft", msg)
             raise ArgumentParsingError(help_text)
 
         cmd_class, group = all_commands[parsed_args.command_to_help]
@@ -176,7 +176,7 @@ class CustomArgumentParser(argparse.ArgumentParser):
     def error(self, message):
         """Show the usage, the error message, and no more."""
         fullcommand = "charmcraft " + self.prog
-        full_msg = helper.get_usage_message(fullcommand, message)
+        full_msg = help_builder.get_usage_message(fullcommand, message)
         raise ArgumentParsingError(full_msg)
 
 
@@ -200,7 +200,7 @@ def get_command_help(parser, command):
             dest = action.dest if action.metavar is None else action.metavar
             options.append((dest, action.help))
 
-    help_text = helper.get_command_help(command, options)
+    help_text = help_builder.get_command_help(command, options)
     return help_text
 
 
@@ -208,9 +208,9 @@ def get_general_help(detailed=False):
     """Produce the "general charmcraft" help."""
     options = _get_global_options()
     if detailed:
-        help_text = helper.get_detailed_help(options)
+        help_text = help_builder.get_detailed_help(options)
     else:
-        help_text = helper.get_full_help(options)
+        help_text = help_builder.get_full_help(options)
     return help_text
 
 
@@ -325,7 +325,7 @@ class Dispatcher:
             cmd_args = filtered_sysargs[1:]
             if command not in self.commands:
                 msg = "no such command {!r}".format(command)
-                help_text = helper.get_usage_message("charmcraft", msg)
+                help_text = help_builder.get_usage_message("charmcraft", msg)
                 raise ArgumentParsingError(help_text)
         else:
             # no command!
@@ -354,7 +354,7 @@ class Dispatcher:
 
 def main(argv=None):
     """Provide the main entry point."""
-    helper.init("charmcraft", GENERAL_SUMMARY, COMMAND_GROUPS)
+    help_builder.init("charmcraft", GENERAL_SUMMARY, COMMAND_GROUPS)
     message_handler.init(message_handler.NORMAL)
 
     if argv is None:

--- a/charmcraft/main.py
+++ b/charmcraft/main.py
@@ -21,13 +21,24 @@ import logging
 import sys
 from collections import namedtuple
 
-from charmcraft import config, env, helptexts
+from charmcraft import config, env
 from charmcraft.cmdbase import BaseCommand, CommandError
 from charmcraft.commands import build, clean, init, pack, store, version, analyze
+from charmcraft.helptexts import helper
 from charmcraft.logsetup import message_handler
 from charmcraft.parts import setup_parts
 
 logger = logging.getLogger(__name__)
+
+# the summary of the whole program
+GENERAL_SUMMARY = """
+Charmcraft helps build, package and publish operators on Charmhub.
+
+Together with the Python Operator Framework, charmcraft simplifies
+operator development and collaboration.
+
+See https://charmhub.io/publishing for more information.
+"""
 
 
 class ArgumentParsingError(Exception):
@@ -75,7 +86,7 @@ class HelpCommand(BaseCommand):
         if parsed_args.command_to_help not in all_commands:
             # asked help on a command that doesn't exist
             msg = "no such command {!r}".format(parsed_args.command_to_help)
-            help_text = helptexts.get_usage_message("charmcraft", msg)
+            help_text = helper.get_usage_message("charmcraft", msg)
             raise ArgumentParsingError(help_text)
 
         cmd_class, group = all_commands[parsed_args.command_to_help]
@@ -165,7 +176,7 @@ class CustomArgumentParser(argparse.ArgumentParser):
     def error(self, message):
         """Show the usage, the error message, and no more."""
         fullcommand = "charmcraft " + self.prog
-        full_msg = helptexts.get_usage_message(fullcommand, message)
+        full_msg = helper.get_usage_message(fullcommand, message)
         raise ArgumentParsingError(full_msg)
 
 
@@ -189,7 +200,7 @@ def get_command_help(parser, command):
             dest = action.dest if action.metavar is None else action.metavar
             options.append((dest, action.help))
 
-    help_text = helptexts.get_command_help(COMMAND_GROUPS, command, options)
+    help_text = helper.get_command_help(command, options)
     return help_text
 
 
@@ -197,9 +208,9 @@ def get_general_help(detailed=False):
     """Produce the "general charmcraft" help."""
     options = _get_global_options()
     if detailed:
-        help_text = helptexts.get_detailed_help(COMMAND_GROUPS, options)
+        help_text = helper.get_detailed_help(options)
     else:
-        help_text = helptexts.get_full_help(COMMAND_GROUPS, options)
+        help_text = helper.get_full_help(options)
     return help_text
 
 
@@ -314,7 +325,7 @@ class Dispatcher:
             cmd_args = filtered_sysargs[1:]
             if command not in self.commands:
                 msg = "no such command {!r}".format(command)
-                help_text = helptexts.get_usage_message("charmcraft", msg)
+                help_text = helper.get_usage_message("charmcraft", msg)
                 raise ArgumentParsingError(help_text)
         else:
             # no command!
@@ -343,6 +354,7 @@ class Dispatcher:
 
 def main(argv=None):
     """Provide the main entry point."""
+    helper.init("charmcraft", GENERAL_SUMMARY, COMMAND_GROUPS)
     message_handler.init(message_handler.NORMAL)
 
     if argv is None:

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -32,10 +32,10 @@ all_commands = list.__add__(*[commands for _, _, commands in COMMAND_GROUPS])
 
 
 @pytest.fixture
-def helper():
-    """Provide a clean and fresh helper instance, ensuring the module also has it."""
-    helper = helptexts.helper = main.helper = helptexts.Helper()
-    return helper
+def help_builder():
+    """Provide a clean and fresh help_builder instance, ensuring the module also has it."""
+    help_builder = helptexts.help_builder = main.help_builder = helptexts.HelpBuilder()
+    return help_builder
 
 
 @pytest.mark.parametrize("command", all_commands)
@@ -65,10 +65,10 @@ def test_aesthetic_args_options_msg(command, config):
     command("group", config).fill_parser(FakeParser())
 
 
-def test_get_usage_message(helper):
+def test_get_usage_message(help_builder):
     """Check the general "usage" text."""
-    helper.init("testapp", "general summary", [])
-    text = helper.get_usage_message("testapp build", "bad parameter for the build")
+    help_builder.init("testapp", "general summary", [])
+    text = help_builder.get_usage_message("testapp build", "bad parameter for the build")
     expected = textwrap.dedent(
         """\
         Usage: testapp [options] command [args]...
@@ -83,7 +83,7 @@ def test_get_usage_message(helper):
 # -- bulding of the big help text outputs
 
 
-def test_default_help_text(helper):
+def test_default_help_text(help_builder):
     """All different parts for the default help."""
     cmd1 = create_command("cmd1", "Cmd help which is very long but whatever.", common_=True)
     cmd2 = create_command("command-2", "Cmd help.", common_=True)
@@ -109,8 +109,8 @@ def test_default_help_text(helper):
         ("-q, --quiet", "Only show warnings and errors, not progress."),
     ]
 
-    helper.init("testapp", fake_summary, command_groups)
-    text = helper.get_full_help(global_options)
+    help_builder.init("testapp", fake_summary, command_groups)
+    text = help_builder.get_full_help(global_options)
 
     expected = textwrap.dedent(
         """\
@@ -145,7 +145,7 @@ def test_default_help_text(helper):
     assert text == expected
 
 
-def test_detailed_help_text(helper):
+def test_detailed_help_text(help_builder):
     """All different parts for the detailed help, showing all commands."""
     cmd1 = create_command("cmd1", "Cmd help which is very long but whatever.", common_=True)
     cmd2 = create_command("command-2", "Cmd help.", common_=True)
@@ -171,8 +171,8 @@ def test_detailed_help_text(helper):
         ("-q, --quiet", "Only show warnings and errors, not progress."),
     ]
 
-    helper.init("testapp", fake_summary, command_groups)
-    text = helper.get_detailed_help(global_options)
+    help_builder.init("testapp", fake_summary, command_groups)
+    text = help_builder.get_detailed_help(global_options)
 
     expected = textwrap.dedent(
         """\
@@ -210,7 +210,7 @@ def test_detailed_help_text(helper):
     assert text == expected
 
 
-def test_command_help_text_no_parameters(config, helper):
+def test_command_help_text_no_parameters(config, help_builder):
     """All different parts for a specific command help that doesn't have parameters."""
     overview = textwrap.dedent(
         """
@@ -235,8 +235,8 @@ def test_command_help_text_no_parameters(config, helper):
         ("--revision", "The revision to release (defaults to latest)."),
     ]
 
-    helper.init("testapp", "general summary", command_groups)
-    text = helper.get_command_help(cmd1("group1", config), options)
+    help_builder.init("testapp", "general summary", command_groups)
+    text = help_builder.get_command_help(cmd1("group1", config), options)
 
     expected = textwrap.dedent(
         """\
@@ -264,7 +264,7 @@ def test_command_help_text_no_parameters(config, helper):
     assert text == expected
 
 
-def test_command_help_text_with_parameters(config, helper):
+def test_command_help_text_with_parameters(config, help_builder):
     """All different parts for a specific command help that has parameters."""
     overview = textwrap.dedent(
         """
@@ -285,8 +285,8 @@ def test_command_help_text_with_parameters(config, helper):
         ("--other-option", "Other option."),
     ]
 
-    helper.init("testapp", "general summary", command_groups)
-    text = helper.get_command_help(cmd1("group1", config), options)
+    help_builder.init("testapp", "general summary", command_groups)
+    text = help_builder.get_command_help(cmd1("group1", config), options)
 
     expected = textwrap.dedent(
         """\
@@ -310,7 +310,7 @@ def test_command_help_text_with_parameters(config, helper):
     assert text == expected
 
 
-def test_command_help_text_loneranger(config, helper):
+def test_command_help_text_loneranger(config, help_builder):
     """All different parts for a specific command that's the only one in its group."""
     overview = textwrap.dedent(
         """
@@ -329,8 +329,8 @@ def test_command_help_text_loneranger(config, helper):
         ("-q, --quiet", "Only show warnings and errors, not progress."),
     ]
 
-    helper.init("testapp", "general summary", command_groups)
-    text = helper.get_command_help(cmd1("group1", config), options)
+    help_builder.init("testapp", "general summary", command_groups)
+    text = help_builder.get_command_help(cmd1("group1", config), options)
 
     expected = textwrap.dedent(
         """\
@@ -355,7 +355,7 @@ def test_command_help_text_loneranger(config, helper):
 
 def test_tool_exec_no_arguments_help():
     """Execute charmcraft without any option at all."""
-    with patch("charmcraft.helptexts.Helper.get_full_help") as mock:
+    with patch("charmcraft.helptexts.HelpBuilder.get_full_help") as mock:
         mock.return_value = "test help"
         with pytest.raises(ArgumentParsingError) as cm:
             dispatcher = Dispatcher([], COMMAND_GROUPS)
@@ -389,7 +389,7 @@ def test_tool_exec_full_help(sysargv, caplog):
     """Execute charmcraft explicitly asking for help."""
     caplog.set_level(logging.INFO, logger="charmcraft")
 
-    with patch("charmcraft.helptexts.Helper.get_full_help") as mock:
+    with patch("charmcraft.helptexts.HelpBuilder.get_full_help") as mock:
         mock.return_value = "test help"
         dispatcher = Dispatcher(sysargv, COMMAND_GROUPS)
         retcode = dispatcher.run()
@@ -420,10 +420,10 @@ def test_tool_exec_full_help(sysargv, caplog):
         ["-h", "wrongcommand", "--help"],
     ],
 )
-def test_tool_exec_command_incorrect(sysargv, helper):
+def test_tool_exec_command_incorrect(sysargv, help_builder):
     """Execute a command that doesn't exist."""
     command_groups = COMMAND_GROUPS + [("group", "help text", [])]
-    helper.init("charmcraft", "general summary", command_groups)
+    help_builder.init("charmcraft", "general summary", command_groups)
     with pytest.raises(ArgumentParsingError) as cm:
         dispatcher = Dispatcher(sysargv, command_groups)
         dispatcher.run()
@@ -450,7 +450,7 @@ def test_tool_exec_command_dash_help_simple(help_option, caplog):
 
     dispatcher = Dispatcher(["somecommand", help_option], command_groups)
 
-    with patch("charmcraft.helptexts.Helper.get_command_help") as mock:
+    with patch("charmcraft.helptexts.HelpBuilder.get_command_help") as mock:
         mock.return_value = "test help"
         retcode = dispatcher.run()
     assert retcode is None
@@ -479,7 +479,7 @@ def test_tool_exec_command_dash_help_reverse(help_option, caplog):
 
     dispatcher = Dispatcher([help_option, "somecommand"], command_groups)
 
-    with patch("charmcraft.helptexts.Helper.get_command_help") as mock:
+    with patch("charmcraft.helptexts.HelpBuilder.get_command_help") as mock:
         mock.return_value = "test help"
         retcode = dispatcher.run()
     assert retcode is None
@@ -513,7 +513,7 @@ def test_tool_exec_command_dash_help_missing_params(help_option, caplog):
 
     dispatcher = Dispatcher(["somecommand", help_option], command_groups)
 
-    with patch("charmcraft.helptexts.Helper.get_command_help") as mock:
+    with patch("charmcraft.helptexts.HelpBuilder.get_command_help") as mock:
         mock.return_value = "test help"
         retcode = dispatcher.run()
     assert retcode is None
@@ -534,11 +534,11 @@ def test_tool_exec_command_dash_help_missing_params(help_option, caplog):
     assert [expected] == [rec.message for rec in caplog.records]
 
 
-def test_tool_exec_command_wrong_option(helper):
+def test_tool_exec_command_wrong_option(help_builder):
     """Execute a correct command but with a wrong option."""
     cmd = create_command("somecommand", "This command does that.")
     command_groups = [("group", "help text", [cmd])]
-    helper.init("charmcraft", "general summary", command_groups)
+    help_builder.init("charmcraft", "general summary", command_groups)
     with pytest.raises(ArgumentParsingError) as cm:
         Dispatcher(["somecommand", "--whatever"], command_groups)
 
@@ -555,7 +555,7 @@ def test_tool_exec_command_wrong_option(helper):
     assert str(error) == expected
 
 
-def test_tool_exec_command_bad_option_type(helper):
+def test_tool_exec_command_bad_option_type(help_builder):
     """Execute a correct command but giving the valid option a bad value."""
 
     def fill_parser(self, parser):
@@ -565,7 +565,7 @@ def test_tool_exec_command_bad_option_type(helper):
     cmd.fill_parser = fill_parser
 
     command_groups = [("group", "help text", [cmd])]
-    helper.init("charmcraft", "general summary", command_groups)
+    help_builder.init("charmcraft", "general summary", command_groups)
     with pytest.raises(ArgumentParsingError) as cm:
         Dispatcher(["somecommand", "--number=foo"], command_groups)
 
@@ -587,7 +587,7 @@ def test_tool_exec_help_command_on_command_ok(caplog):
     caplog.set_level(logging.INFO, logger="charmcraft")
     dispatcher = Dispatcher(["help", "version"], COMMAND_GROUPS)
 
-    with patch("charmcraft.helptexts.Helper.get_command_help") as mock:
+    with patch("charmcraft.helptexts.HelpBuilder.get_command_help") as mock:
         mock.return_value = "test help"
         retcode = dispatcher.run()
     assert retcode is None
@@ -624,7 +624,7 @@ def test_tool_exec_help_command_on_command_complex(caplog):
 
     dispatcher = Dispatcher(["help", "somecommand"], command_groups)
 
-    with patch("charmcraft.helptexts.Helper.get_command_help") as mock:
+    with patch("charmcraft.helptexts.HelpBuilder.get_command_help") as mock:
         mock.return_value = "test help"
         retcode = dispatcher.run()
     assert retcode is None
@@ -654,7 +654,7 @@ def test_tool_exec_help_command_on_command_wrong():
     """Execute charmcraft asking for help on a command which does not exist."""
     dispatcher = Dispatcher(["help", "wrongcommand"], COMMAND_GROUPS)
 
-    with patch("charmcraft.helptexts.Helper.get_usage_message") as mock:
+    with patch("charmcraft.helptexts.HelpBuilder.get_usage_message") as mock:
         mock.return_value = "test help"
         with pytest.raises(ArgumentParsingError) as cm:
             dispatcher.run()
@@ -672,7 +672,7 @@ def test_tool_exec_help_command_all(caplog):
     caplog.set_level(logging.INFO, logger="charmcraft")
     dispatcher = Dispatcher(["help", "--all"], COMMAND_GROUPS)
 
-    with patch("charmcraft.helptexts.Helper.get_detailed_help") as mock:
+    with patch("charmcraft.helptexts.HelpBuilder.get_detailed_help") as mock:
         mock.return_value = "test help"
         retcode = dispatcher.run()
     assert retcode is None

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -276,7 +276,7 @@ def test_dispatcher_generic_setup_projectdir_without_param_confusing(options):
     """Generic parameter handling for 'project dir' taking confusingly the command as the arg."""
     cmd = create_command("somecommand")
     groups = [("test-group", "title", [cmd])]
-    with patch("charmcraft.helptexts.Helper.get_full_help") as mock_helper:
+    with patch("charmcraft.helptexts.HelpBuilder.get_full_help") as mock_helper:
         mock_helper.return_value = "help text"
         with pytest.raises(ArgumentParsingError) as err:
             Dispatcher(options, groups)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -276,11 +276,13 @@ def test_dispatcher_generic_setup_projectdir_without_param_confusing(options):
     """Generic parameter handling for 'project dir' taking confusingly the command as the arg."""
     cmd = create_command("somecommand")
     groups = [("test-group", "title", [cmd])]
-    with pytest.raises(ArgumentParsingError) as err:
-        Dispatcher(options, groups)
+    with patch("charmcraft.helptexts.Helper.get_full_help") as mock_helper:
+        mock_helper.return_value = "help text"
+        with pytest.raises(ArgumentParsingError) as err:
+            Dispatcher(options, groups)
 
     # generic usage message because "no command" (as 'somecommand' was consumed by --project-dir)
-    assert "Usage" in str(err.value)
+    assert str(err.value) == "help text"
 
 
 def test_dispatcher_build_commands_ok():


### PR DESCRIPTION

This includes:

- not having the general summary or app name anymore hardcoded in the module

- moved the functions at module level to be methods inside a class; this is for the system to be able to be "initiated" with the app specific information. 

- those moved in functions are exactly the same, with some minor structural changes:

    - `get_full_help` and `get_detailed_help` do not receive the "command groups" 

    - `get_usage_message` now formats `USAGE` passing also the `appname`

    - `get_full_help` and `get_detailed_help` indents the "general summary" (as the app text doesn't need to be passed indented)

**Note** on initiating `Helper`: currently there's no guard on using it before calling its `init`, as I'm not 100% sure the form this will have when both this help texts module and the dispatcher will be in the craft-cli library, but for sure the final form will be more robust.

**Note 2**: the PR is too big, but most of it is just moving code around, and zillion changes in the texts because of two functions not receiving command groups anymore, and the need to init the helper before usage.
