### PR TITLE
requirements: update craft-parts to 1.0.1 (CRAFT-430, CRAFT-520)

### DIFF
--- a/charmcraft/parts.py
+++ b/charmcraft/parts.py
@@ -260,7 +260,6 @@ class PartsLifecycle:
                 cache_dir=cache_dir,
                 ignore_local_sources=ignore_local_sources,
             )
-            self._lcm.refresh_packages_list()
         except PartsError as err:
             raise CommandError(err)
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ cffi==1.14.6
 charset-normalizer==2.0.4
 click==8.0.1
 coverage==5.5
-craft-parts==1.0.0
+craft-parts==1.0.1
 craft-providers==1.0.3
 flake8==3.9.2
 humanize==3.11.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ attrs==21.2.0
 certifi==2021.5.30
 cffi==1.14.6
 charset-normalizer==2.0.4
-craft-parts==1.0.0
+craft-parts==1.0.1
 craft-providers==1.0.3
 humanize==3.11.0
 idna==3.2


### PR DESCRIPTION
Update dependencies to require Craft-parts 1.0.1 and remove refreshing
of stage packages (Craft-parts now uses the host state for apt cache).

Time comparison for non-parallel execution of regression tests:
* with Craft-parts 1.0.0: `81.14user 15.46system 1:30.80elapsed`
* with Craft-parts 1.0.1: `41.76user 3.97system 0:37.82elapsed`

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>