### PR TITLE
env: enable darwin (CRAFT-535)

### DIFF
--- a/charmcraft/env.py
+++ b/charmcraft/env.py
@@ -66,11 +66,11 @@ def is_charmcraft_running_in_managed_mode():
     return distutils.util.strtobool(managed_flag) == 1
 
 
-def is_charmcraft_running_in_supported_environment():
+def is_charmcraft_running_in_supported_environment() -> bool:
     """Check if Charmcraft is running in a supported environment."""
     if sys.platform == "linux":
         return is_charmcraft_running_from_snap()
-    elif sys.platform == "win32":
+    elif sys.platform in ("darwin", "win32"):
         return True
 
     return False

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -138,7 +138,7 @@ def test_is_charmcraft_running_in_supported_environment_linux(monkeypatch, as_sn
 def test_is_charmcraft_running_in_supported_environment_osx(monkeypatch):
     monkeypatch.setattr(sys, "platform", "darwin")
 
-    assert env.is_charmcraft_running_in_supported_environment() is False
+    assert env.is_charmcraft_running_in_supported_environment() is True
 
 
 def test_is_charmcraft_running_in_supported_environment_windows(monkeypatch):


### PR DESCRIPTION
It has the same mechanics as Windows but with much more similarities
at the platform level to Linux.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>