### PR TITLE
More isolation of the helptext module and simplification of its usage (CRAFT-528)

### DIFF
--- a/charmcraft/helptexts.py
+++ b/charmcraft/helptexts.py
@@ -73,12 +73,21 @@ class HelpBuilder:
         self.general_summary = general_summary
         self.command_groups = command_groups
 
-    def get_usage_message(self, fullcommand, error_message):
+    def get_usage_message(self, extra_command, error_message):
         """Build a usage and error message.
 
-        The fullcommand is the command used by the user (`charmcraft`, `charmcraft build`, etc),
-        and the error message is the specific problem in the given parameters.
+        The extra_command is the extra string used after the application name to build the
+        full command that will be shown in the usage message; for example, having an
+        application name of "someapp":
+        - if extra_command is "" it will be shown "Try 'appname -h' for help".
+        - if extra_command is "version" it will be shown "Try 'appname version -h' for help"
+
+        The error message is the specific problem in the given parameters.
         """
+        if extra_command:
+            fullcommand = f"{self.appname} {extra_command}"
+        else:
+            fullcommand = self.appname
         return USAGE.format(
             appname=self.appname, fullcommand=fullcommand, error_message=error_message
         )

--- a/charmcraft/helptexts.py
+++ b/charmcraft/helptexts.py
@@ -30,7 +30,7 @@ Usage:
 
 USAGE = """\
 Usage: {appname} [options] command [args]...
-Try '{fullcommand} -h' for help.
+Try '{full_command} -h' for help.
 
 Error: {error_message}
 """
@@ -73,23 +73,23 @@ class HelpBuilder:
         self.general_summary = general_summary
         self.command_groups = command_groups
 
-    def get_usage_message(self, extra_command, error_message):
+    def get_usage_message(self, error_message, command=""):
         """Build a usage and error message.
 
-        The extra_command is the extra string used after the application name to build the
+        The command is the extra string used after the application name to build the
         full command that will be shown in the usage message; for example, having an
         application name of "someapp":
-        - if extra_command is "" it will be shown "Try 'appname -h' for help".
-        - if extra_command is "version" it will be shown "Try 'appname version -h' for help"
+        - if command is "" it will be shown "Try 'appname -h' for help".
+        - if command is "version" it will be shown "Try 'appname version -h' for help"
 
         The error message is the specific problem in the given parameters.
         """
-        if extra_command:
-            fullcommand = f"{self.appname} {extra_command}"
+        if command:
+            full_command = f"{self.appname} {command}"
         else:
-            fullcommand = self.appname
+            full_command = self.appname
         return USAGE.format(
-            appname=self.appname, fullcommand=fullcommand, error_message=error_message
+            appname=self.appname, full_command=full_command, error_message=error_message
         )
 
     def get_full_help(self, global_options):

--- a/charmcraft/main.py
+++ b/charmcraft/main.py
@@ -86,7 +86,7 @@ class HelpCommand(BaseCommand):
         if parsed_args.command_to_help not in all_commands:
             # asked help on a command that doesn't exist
             msg = "no such command {!r}".format(parsed_args.command_to_help)
-            help_text = help_builder.get_usage_message("charmcraft", msg)
+            help_text = help_builder.get_usage_message(extra_command="", error_message=msg)
             raise ArgumentParsingError(help_text)
 
         cmd_class, group = all_commands[parsed_args.command_to_help]
@@ -175,8 +175,7 @@ class CustomArgumentParser(argparse.ArgumentParser):
 
     def error(self, message):
         """Show the usage, the error message, and no more."""
-        fullcommand = "charmcraft " + self.prog
-        full_msg = help_builder.get_usage_message(fullcommand, message)
+        full_msg = help_builder.get_usage_message(extra_command=self.prog, error_message=message)
         raise ArgumentParsingError(full_msg)
 
 
@@ -325,7 +324,7 @@ class Dispatcher:
             cmd_args = filtered_sysargs[1:]
             if command not in self.commands:
                 msg = "no such command {!r}".format(command)
-                help_text = help_builder.get_usage_message("charmcraft", msg)
+                help_text = help_builder.get_usage_message(extra_command="", error_message=msg)
                 raise ArgumentParsingError(help_text)
         else:
             # no command!

--- a/charmcraft/main.py
+++ b/charmcraft/main.py
@@ -86,7 +86,7 @@ class HelpCommand(BaseCommand):
         if parsed_args.command_to_help not in all_commands:
             # asked help on a command that doesn't exist
             msg = "no such command {!r}".format(parsed_args.command_to_help)
-            help_text = help_builder.get_usage_message(extra_command="", error_message=msg)
+            help_text = help_builder.get_usage_message(msg)
             raise ArgumentParsingError(help_text)
 
         cmd_class, group = all_commands[parsed_args.command_to_help]
@@ -175,7 +175,7 @@ class CustomArgumentParser(argparse.ArgumentParser):
 
     def error(self, message):
         """Show the usage, the error message, and no more."""
-        full_msg = help_builder.get_usage_message(extra_command=self.prog, error_message=message)
+        full_msg = help_builder.get_usage_message(message, command=self.prog)
         raise ArgumentParsingError(full_msg)
 
 
@@ -324,7 +324,7 @@ class Dispatcher:
             cmd_args = filtered_sysargs[1:]
             if command not in self.commands:
                 msg = "no such command {!r}".format(command)
-                help_text = help_builder.get_usage_message(extra_command="", error_message=msg)
+                help_text = help_builder.get_usage_message(msg)
                 raise ArgumentParsingError(help_text)
         else:
             # no command!

--- a/tests/test_cmdbase.py
+++ b/tests/test_cmdbase.py
@@ -94,14 +94,14 @@ def test_basecommand_run_mandatory():
 
 @pytest.mark.parametrize("command", all_commands)
 def test_aesthetic_help_msg(command):
-    """All the real commands help msg start with uppercase and doesn't end with a dot."""
+    """All real commands help msgs start with uppercase and do not end with a dot."""
     msg = command.help_msg
     assert msg[0].isupper() and msg[-1] != "."
 
 
 @pytest.mark.parametrize("command", all_commands)
 def test_aesthetic_args_options_msg(command, config):
-    """All the real commands args help messages start with uppercase and dont' end with a dot."""
+    """All real commands args help messages start with uppercase and do not end with a dot."""
 
     class FakeParser:
         """A fake to get the arguments added."""

--- a/tests/test_cmdbase.py
+++ b/tests/test_cmdbase.py
@@ -87,3 +87,33 @@ def test_basecommand_run_mandatory():
     tc = TestClass("group", "config")
     with pytest.raises(NotImplementedError):
         tc.run([])
+
+
+# -- tests for strings in commands
+
+
+@pytest.mark.parametrize("command", all_commands)
+def test_aesthetic_help_msg(command):
+    """All the real commands help msg start with uppercase and doesn't end with a dot."""
+    msg = command.help_msg
+    assert msg[0].isupper() and msg[-1] != "."
+
+
+@pytest.mark.parametrize("command", all_commands)
+def test_aesthetic_args_options_msg(command, config):
+    """All the real commands args help messages start with uppercase and dont' end with a dot."""
+
+    class FakeParser:
+        """A fake to get the arguments added."""
+
+        def add_mutually_exclusive_group(self, *args, **kwargs):
+            """Return self, as it is used to add arguments too."""
+            return self
+
+        def add_argument(self, *args, **kwargs):
+            """Verify that all commands have a correctly formatted help."""
+            help_msg = kwargs.get("help")
+            assert help_msg, "The help message must be present in each option"
+            assert help_msg[0].isupper() and help_msg[-1] != "."
+
+    command("group", config).fill_parser(FakeParser())

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -38,7 +38,7 @@ def help_builder():
 def test_get_usage_message_with_command(help_builder):
     """Check the general "usage" text passing a command."""
     help_builder.init("testapp", "general summary", [])
-    text = help_builder.get_usage_message("build", "bad parameter for the build")
+    text = help_builder.get_usage_message("bad parameter for the build", "build")
     expected = textwrap.dedent(
         """\
         Usage: testapp [options] command [args]...
@@ -53,7 +53,7 @@ def test_get_usage_message_with_command(help_builder):
 def test_get_usage_message_no_command(help_builder):
     """Check the general "usage" text not passing a command."""
     help_builder.init("testapp", "general summary", [])
-    text = help_builder.get_usage_message("", "missing a mandatory command")
+    text = help_builder.get_usage_message("missing a mandatory command")
     expected = textwrap.dedent(
         """\
         Usage: testapp [options] command [args]...
@@ -651,8 +651,7 @@ def test_tool_exec_help_command_on_command_wrong():
     error = cm.value
 
     # check the given information to the help text builder
-    expected_call = call(extra_command="", error_message="no such command 'wrongcommand'")
-    assert mock.mock_calls == [expected_call]
+    assert mock.call_args[0] == ("no such command 'wrongcommand'",)
 
     # check the result of the full help builder is what is shown
     assert str(error) == "test help"

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -16,7 +16,7 @@
 
 import logging
 import textwrap
-from unittest.mock import patch, call
+from unittest.mock import patch
 
 import pytest
 
@@ -32,26 +32,26 @@ def help_builder():
     return help_builder
 
 
-# -- bulding of the "usage" help
+# -- bulding "usage" help
 
 
 def test_get_usage_message_with_command(help_builder):
     """Check the general "usage" text passing a command."""
     help_builder.init("testapp", "general summary", [])
-    text = help_builder.get_usage_message("bad parameter for the build", "build")
+    text = help_builder.get_usage_message("bad parameter for build", "build")
     expected = textwrap.dedent(
         """\
         Usage: testapp [options] command [args]...
         Try 'testapp build -h' for help.
 
-        Error: bad parameter for the build
+        Error: bad parameter for build
     """
     )
     assert text == expected
 
 
 def test_get_usage_message_no_command(help_builder):
-    """Check the general "usage" text not passing a command."""
+    """Check the general "usage" text when not passing a command."""
     help_builder.init("testapp", "general summary", [])
     text = help_builder.get_usage_message("missing a mandatory command")
     expected = textwrap.dedent(


### PR DESCRIPTION
In detail:

- Stop passing (again) the application name when calling `get_usage_message`

- Moved two tests from "help suite" to "cmdbase suite" as they were more about the command's content than the help infrastructure

- Fixed/improved tests so they don't depend anymore on `COMMAND_GROUPS` nor `VersionCommand`, which are app-specific
