### PR TITLE
charm_builder: build dependencies locally (CRAFT-537)

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -113,6 +113,7 @@ jobs:
           sg lxd -c "charmcraft -v pack"
           test -f *.charm
           test ! -d build
+          unzip -l charm-smoke-test_*.charm | grep "venv/ops/charm.py"
           sg lxd -c "charmcraft -v clean"
           popd
 
@@ -122,6 +123,7 @@ jobs:
           test -f *.charm
           test ! -d build
           test ! -d ../charm-smoke-test/build
+          unzip -l another-test_*.charm | grep "venv/ops/charm.py"
           sg lxd -c "charmcraft -v clean --project-dir ../charm-smoke-test"
           popd
 
@@ -157,6 +159,7 @@ jobs:
           sudo apt install -y hello
           charmcraft -v pack --destructive-mode
           unzip -c build-packages-test_*.charm hello.txt | grep "^Hello, world!"
+          unzip -l build-packages-test_*.charm | grep "venv/ops/charm.py"
           popd
 
           sudo snap set charmcraft provider=lxd

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -123,7 +123,7 @@ jobs:
           test -f *.charm
           test ! -d build
           test ! -d ../charm-smoke-test/build
-          unzip -l another-test_*.charm | grep "venv/ops/charm.py"
+          unzip -l charm-smoke-test_*.charm | grep "venv/ops/charm.py"
           sg lxd -c "charmcraft -v clean --project-dir ../charm-smoke-test"
           popd
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -88,7 +88,7 @@ jobs:
       - name: Install test dependencies
         run: |
           sudo apt update
-          sudo apt install -y python3-pip python3-setuptools python3-wheel
+          sudo apt install -y python3-pip python3-setuptools python3-wheel python3-distutils
       - name: Install LXD dependency on 18.04
         if: ${{ matrix.os == 'ubuntu-18.04' }}
         run: |

--- a/charmcraft/charm_builder.py
+++ b/charmcraft/charm_builder.py
@@ -78,6 +78,7 @@ class CharmBuilder:
         self.python_packages = python_packages
         self.requirement_paths = requirements
         self.ignore_rules = self._load_juju_ignore()
+        self.ignore_rules.extend_patterns([f"/{STAGING_VENV_DIRNAME}"])
 
     def build_charm(self) -> None:
         """Build the charm."""
@@ -136,10 +137,7 @@ class CharmBuilder:
                 rel_path = rel_basedir / name
                 abs_path = abs_basedir / name
 
-                if name == STAGING_VENV_DIRNAME:
-                    logger.debug("Ignoring staging venv directory: %r", STAGING_VENV_DIRNAME)
-                    ignored.append(pos)
-                elif self.ignore_rules.match(str(rel_path), is_dir=True):
+                if self.ignore_rules.match(str(rel_path), is_dir=True):
                     logger.debug("Ignoring directory because of rules: %r", str(rel_path))
                     ignored.append(pos)
                 elif abs_path.is_symlink():

--- a/charmcraft/charm_builder.py
+++ b/charmcraft/charm_builder.py
@@ -233,7 +233,7 @@ class CharmBuilder:
 
             _process_run([pip_cmd, "--version"])
 
-            cmd = [pip_cmd, "install", "--no-binary", ":all:"]  # base command
+            cmd = [pip_cmd, "install", "--upgrade", "--no-binary", ":all:"]  # base command
             for reqspath in self.requirement_paths:
                 cmd.append("--requirement={}".format(reqspath))  # the dependencies file(s)
             _process_run(cmd)

--- a/charmcraft/charm_builder.py
+++ b/charmcraft/charm_builder.py
@@ -23,6 +23,7 @@ import os
 import pathlib
 import shutil
 import site
+import sys
 import subprocess
 from typing import List
 
@@ -229,7 +230,7 @@ class CharmBuilder:
         if self.requirement_paths:
             staging_venv_dir = self.charmdir / STAGING_VENV_DIRNAME
             _process_run(["python3", "-m", "venv", str(staging_venv_dir)])
-            pip_cmd = str(staging_venv_dir / "bin" / "pip3")
+            pip_cmd = str(_find_venv_bin(staging_venv_dir, "pip3"))
 
             _process_run([pip_cmd, "--version"])
 
@@ -243,6 +244,14 @@ class CharmBuilder:
 
             # The charm builder is executed with PYTHONUSERBASE set to the staging venv dir
             shutil.copytree(site.USER_SITE, self.buildpath / VENV_DIRNAME)
+
+
+def _find_venv_bin(basedir, exec_base):
+    """Determine the venv executable in different platforms."""
+    if sys.platform == "win32":
+        return basedir / "Scripts" / f"{exec_base}.exe"
+
+    return basedir / "bin" / exec_base
 
 
 def _pip_needs_system():

--- a/charmcraft/charm_builder.py
+++ b/charmcraft/charm_builder.py
@@ -24,7 +24,6 @@ import pathlib
 import shutil
 import site
 import subprocess
-import venv
 from typing import List
 
 from charmcraft.cmdbase import CommandError
@@ -231,8 +230,7 @@ class CharmBuilder:
         # virtualenv with other dependencies (if any)
         if self.requirement_paths:
             staging_venv_dir = self.charmdir / STAGING_VENV_DIRNAME
-            envbuilder = venv.EnvBuilder(symlinks=True, with_pip=True)
-            envbuilder.create(staging_venv_dir)
+            _process_run(["python3", "-m", "venv", str(staging_venv_dir)])
             pip_cmd = str(staging_venv_dir / "bin" / "pip3")
 
             _process_run([pip_cmd, "--version"])

--- a/charmcraft/charm_builder.py
+++ b/charmcraft/charm_builder.py
@@ -240,6 +240,9 @@ class CharmBuilder:
             _process_run(cmd)
 
             # The charm builder is executed with PYTHONUSERBASE set to the staging venv dir
+            # so that site.USER_SITE points to the inner directory inside STAGING_VENV_DIRNAME
+            # where the packages are actually installed. This is the directory that dispatch
+            # expects as /venv.
             shutil.copytree(site.USER_SITE, self.buildpath / VENV_DIRNAME)
 
 

--- a/charmcraft/charm_builder.py
+++ b/charmcraft/charm_builder.py
@@ -235,9 +235,6 @@ class CharmBuilder:
             _process_run([pip_cmd, "--version"])
 
             cmd = [pip_cmd, "install", "--no-binary", ":all:"]  # base command
-            if _pip_needs_system():
-                logger.debug("adding --system to work around pip3 defaulting to --user")
-                cmd.append("--system")
             for reqspath in self.requirement_paths:
                 cmd.append("--requirement={}".format(reqspath))  # the dependencies file(s)
             _process_run(cmd)
@@ -252,20 +249,6 @@ def _find_venv_bin(basedir, exec_base):
         return basedir / "Scripts" / f"{exec_base}.exe"
 
     return basedir / "bin" / exec_base
-
-
-def _pip_needs_system():
-    """Determine whether pip3 defaults to --user, needing --system to turn it off."""
-    cmd = [
-        "python3",
-        "-c",
-        (
-            "from pip.commands.install import InstallCommand; "
-            'assert InstallCommand().cmd_opts.get_option("--system") is not None'
-        ),
-    ]
-    proc = subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-    return proc.returncode == 0
 
 
 def _process_run(cmd: List[str]) -> None:

--- a/charmcraft/parts.py
+++ b/charmcraft/parts.py
@@ -101,11 +101,7 @@ class CharmPlugin(plugins.Plugin):
         """Return a list of commands to run during the build step."""
         options = cast(CharmPluginProperties, self._options)
 
-        build_env = dict(
-            LANG="C.UTF-8",
-            LC_ALL="C.UTF-8",
-            PYTHONUSERBASE=self._part_info.part_build_dir / charm_builder.STAGING_VENV_DIRNAME,
-        )
+        build_env = dict(LANG="C.UTF-8", LC_ALL="C.UTF-8")
         for key in [
             "PATH",
             "SNAP",

--- a/charmcraft/parts.py
+++ b/charmcraft/parts.py
@@ -89,6 +89,8 @@ class CharmPlugin(plugins.Plugin):
             "python3-pip",
             "python3-setuptools",
             "python3-wheel",
+            "python3-venv",
+            "python3-dev",
         }
 
     def get_build_environment(self) -> Dict[str, str]:

--- a/charmcraft/parts.py
+++ b/charmcraft/parts.py
@@ -99,7 +99,11 @@ class CharmPlugin(plugins.Plugin):
         """Return a list of commands to run during the build step."""
         options = cast(CharmPluginProperties, self._options)
 
-        build_env = dict(LANG="C.UTF-8", LC_ALL="C.UTF-8")
+        build_env = dict(
+            LANG="C.UTF-8",
+            LC_ALL="C.UTF-8",
+            PYTHONUSERBASE=self._part_info.part_build_dir / charm_builder.STAGING_VENV_DIRNAME,
+        )
         for key in [
             "PATH",
             "SNAP",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ cffi==1.14.6
 charset-normalizer==2.0.4
 click==8.0.1
 coverage==5.5
-craft-parts==1.0.1
+craft-parts==1.0.2
 craft-providers==1.0.3
 flake8==3.9.2
 humanize==3.11.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ attrs==21.2.0
 certifi==2021.5.30
 cffi==1.14.6
 charset-normalizer==2.0.4
-craft-parts==1.0.1
+craft-parts==1.0.2
 craft-providers==1.0.3
 humanize==3.11.0
 idna==3.2

--- a/tests/test_charm_builder.py
+++ b/tests/test_charm_builder.py
@@ -606,11 +606,9 @@ def test_build_dependencies_virtualenv_simple(tmp_path):
         requirements=["reqs.txt"],
     )
 
-    with patch("charmcraft.charm_builder.subprocess.run") as mock_run:
-        mock_run.return_value.returncode = 1
-        with patch("charmcraft.charm_builder._process_run") as mock:
-            with patch("shutil.copytree") as mock_copytree:
-                builder.handle_dependencies()
+    with patch("charmcraft.charm_builder._process_run") as mock:
+        with patch("shutil.copytree") as mock_copytree:
+            builder.handle_dependencies()
 
     pip_cmd = str(charm_builder._find_venv_bin(tmp_path / STAGING_VENV_DIRNAME, "pip3"))
 
@@ -618,58 +616,6 @@ def test_build_dependencies_virtualenv_simple(tmp_path):
         call(["python3", "-m", "venv", str(tmp_path / STAGING_VENV_DIRNAME)]),
         call([pip_cmd, "--version"]),
         call([pip_cmd, "install", "--no-binary", ":all:", "--requirement=reqs.txt"]),
-    ]
-    assert mock_run.mock_calls == [
-        call(
-            [
-                "python3",
-                "-c",
-                (
-                    "from pip.commands.install import InstallCommand; "
-                    'assert InstallCommand().cmd_opts.get_option("--system") is not None'
-                ),
-            ],
-            stdout=-3,
-            stderr=-3,
-        ),
-    ]
-    assert mock_copytree.mock_calls == [call(site.USER_SITE, build_dir / VENV_DIRNAME)]
-
-
-def test_build_dependencies_needs_system(tmp_path, config):
-    """pip3 is called with --system when pip3 needs it."""
-    metadata = tmp_path / CHARM_METADATA
-    metadata.write_text("name: crazycharm")
-    build_dir = tmp_path / BUILD_DIRNAME
-    build_dir.mkdir()
-
-    builder = CharmBuilder(
-        charmdir=tmp_path,
-        builddir=build_dir,
-        entrypoint=pathlib.Path("whatever"),
-        requirements=["reqs"],
-    )
-
-    with patch("charmcraft.charm_builder.subprocess.run") as mock_run:
-        mock_run.return_value.returncode = 0
-        with patch("charmcraft.charm_builder._process_run") as mock:
-            with patch("shutil.copytree") as mock_copytree:
-                builder.handle_dependencies()
-
-    pip_cmd = str(charm_builder._find_venv_bin(tmp_path / STAGING_VENV_DIRNAME, "pip3"))
-    assert mock.mock_calls == [
-        call(["python3", "-m", "venv", str(tmp_path / STAGING_VENV_DIRNAME)]),
-        call([pip_cmd, "--version"]),
-        call(
-            [
-                pip_cmd,
-                "install",
-                "--no-binary",
-                ":all:",
-                "--system",
-                "--requirement=reqs",
-            ]
-        ),
     ]
     assert mock_copytree.mock_calls == [call(site.USER_SITE, build_dir / VENV_DIRNAME)]
 
@@ -688,11 +634,9 @@ def test_build_dependencies_virtualenv_multiple(tmp_path):
         requirements=["reqs1.txt", "reqs2.txt"],
     )
 
-    with patch("charmcraft.charm_builder.subprocess.run") as mock_run:
-        mock_run.return_value.returncode = 1
-        with patch("charmcraft.charm_builder._process_run") as mock:
-            with patch("shutil.copytree") as mock_copytree:
-                builder.handle_dependencies()
+    with patch("charmcraft.charm_builder._process_run") as mock:
+        with patch("shutil.copytree") as mock_copytree:
+            builder.handle_dependencies()
 
     pip_cmd = str(charm_builder._find_venv_bin(tmp_path / STAGING_VENV_DIRNAME, "pip3"))
     assert mock.mock_calls == [

--- a/tests/test_charm_builder.py
+++ b/tests/test_charm_builder.py
@@ -613,25 +613,13 @@ def test_build_dependencies_virtualenv_simple(tmp_path):
                 builder.handle_dependencies()
 
     pip_cmd = str(tmp_path / STAGING_VENV_DIRNAME / "bin" / "pip3")
+
     assert mock.mock_calls == [
+        call(["python3", "-m", "venv", str(tmp_path / STAGING_VENV_DIRNAME)]),
         call([pip_cmd, "--version"]),
         call([pip_cmd, "install", "--no-binary", ":all:", "--requirement=reqs.txt"]),
     ]
     assert mock_run.mock_calls == [
-        call(
-            [
-                str(tmp_path / STAGING_VENV_DIRNAME / "bin" / "python"),
-                "-Im",
-                "ensurepip",
-                "--upgrade",
-                "--default-pip",
-            ],
-            stdout=-1,
-            timeout=None,
-            check=True,
-            stderr=-2,
-            universal_newlines=True,
-        ),
         call(
             [
                 "python3",
@@ -670,6 +658,7 @@ def test_build_dependencies_needs_system(tmp_path, config):
 
     pip_cmd = str(tmp_path / STAGING_VENV_DIRNAME / "bin" / "pip3")
     assert mock.mock_calls == [
+        call(["python3", "-m", "venv", str(tmp_path / STAGING_VENV_DIRNAME)]),
         call([pip_cmd, "--version"]),
         call(
             [
@@ -707,6 +696,7 @@ def test_build_dependencies_virtualenv_multiple(tmp_path):
 
     pip_cmd = str(tmp_path / STAGING_VENV_DIRNAME / "bin" / "pip3")
     assert mock.mock_calls == [
+        call(["python3", "-m", "venv", str(tmp_path / STAGING_VENV_DIRNAME)]),
         call([pip_cmd, "--version"]),
         call(
             [

--- a/tests/test_charm_builder.py
+++ b/tests/test_charm_builder.py
@@ -612,7 +612,7 @@ def test_build_dependencies_virtualenv_simple(tmp_path):
             with patch("shutil.copytree") as mock_copytree:
                 builder.handle_dependencies()
 
-    pip_cmd = str(tmp_path / STAGING_VENV_DIRNAME / "bin" / "pip3")
+    pip_cmd = str(charm_builder._find_venv_bin(tmp_path / STAGING_VENV_DIRNAME, "pip3"))
 
     assert mock.mock_calls == [
         call(["python3", "-m", "venv", str(tmp_path / STAGING_VENV_DIRNAME)]),
@@ -656,7 +656,7 @@ def test_build_dependencies_needs_system(tmp_path, config):
             with patch("shutil.copytree") as mock_copytree:
                 builder.handle_dependencies()
 
-    pip_cmd = str(tmp_path / STAGING_VENV_DIRNAME / "bin" / "pip3")
+    pip_cmd = str(charm_builder._find_venv_bin(tmp_path / STAGING_VENV_DIRNAME, "pip3"))
     assert mock.mock_calls == [
         call(["python3", "-m", "venv", str(tmp_path / STAGING_VENV_DIRNAME)]),
         call([pip_cmd, "--version"]),
@@ -694,7 +694,7 @@ def test_build_dependencies_virtualenv_multiple(tmp_path):
             with patch("shutil.copytree") as mock_copytree:
                 builder.handle_dependencies()
 
-    pip_cmd = str(tmp_path / STAGING_VENV_DIRNAME / "bin" / "pip3")
+    pip_cmd = str(charm_builder._find_venv_bin(tmp_path / STAGING_VENV_DIRNAME, "pip3"))
     assert mock.mock_calls == [
         call(["python3", "-m", "venv", str(tmp_path / STAGING_VENV_DIRNAME)]),
         call([pip_cmd, "--version"]),

--- a/tests/test_charm_builder.py
+++ b/tests/test_charm_builder.py
@@ -615,7 +615,7 @@ def test_build_dependencies_virtualenv_simple(tmp_path):
     assert mock.mock_calls == [
         call([sys.executable, "-m", "venv", str(tmp_path / STAGING_VENV_DIRNAME)]),
         call([pip_cmd, "--version"]),
-        call([pip_cmd, "install", "--no-binary", ":all:", "--requirement=reqs.txt"]),
+        call([pip_cmd, "install", "--upgrade", "--no-binary", ":all:", "--requirement=reqs.txt"]),
     ]
 
     site_packages_dir = charm_builder._find_venv_site_packages(pathlib.Path(STAGING_VENV_DIRNAME))
@@ -648,6 +648,7 @@ def test_build_dependencies_virtualenv_multiple(tmp_path):
             [
                 pip_cmd,
                 "install",
+                "--upgrade",
                 "--no-binary",
                 ":all:",
                 "--requirement=reqs1.txt",

--- a/tests/test_parts.py
+++ b/tests/test_parts.py
@@ -63,6 +63,8 @@ class TestCharmPlugin:
             "python3-pip",
             "python3-setuptools",
             "python3-wheel",
+            "python3-venv",
+            "python3-dev",
         }
 
     def test_get_build_snaps(self):

--- a/tests/test_parts.py
+++ b/tests/test_parts.py
@@ -84,9 +84,7 @@ class TestCharmPlugin:
         monkeypatch.setenv("no_proxy", "no_proxy_value")
 
         assert self._plugin.get_build_commands() == [
-            "env -i LANG=C.UTF-8 LC_ALL=C.UTF-8 "
-            "PYTHONUSERBASE={work_dir}/parts/foo/build/staging-venv "
-            "PATH=/some/path SNAP=snap_value "
+            "env -i LANG=C.UTF-8 LC_ALL=C.UTF-8 PATH=/some/path SNAP=snap_value "
             "SNAP_ARCH=snap_arch_value SNAP_NAME=snap_name_value "
             "SNAP_VERSION=snap_version_value http_proxy=http_proxy_value "
             "https_proxy=https_proxy_value no_proxy=no_proxy_value "

--- a/tests/test_parts.py
+++ b/tests/test_parts.py
@@ -82,7 +82,9 @@ class TestCharmPlugin:
         monkeypatch.setenv("no_proxy", "no_proxy_value")
 
         assert self._plugin.get_build_commands() == [
-            "env -i LANG=C.UTF-8 LC_ALL=C.UTF-8 PATH=/some/path SNAP=snap_value "
+            "env -i LANG=C.UTF-8 LC_ALL=C.UTF-8 "
+            "PYTHONUSERBASE={work_dir}/parts/foo/build/staging-venv "
+            "PATH=/some/path SNAP=snap_value "
             "SNAP_ARCH=snap_arch_value SNAP_NAME=snap_name_value "
             "SNAP_VERSION=snap_version_value http_proxy=http_proxy_value "
             "https_proxy=https_proxy_value no_proxy=no_proxy_value "


### PR DESCRIPTION
Comply with the requirement of not installing binary dependencies,
building them locally instead. The process may take a long time to
complete, so use the venv module to install requirements to a persistent
staging virtualenv so that dependencies already installed won't be
reinstalled (and rebuilt) when the charm is repacked.

Note: This solution installs additional dependencies to venv
(setup-tools, pip, and pkg_resources).
    
Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>