### PR TITLE
tests: warn if LXD cannot be refresh in 20.04's GHA

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -97,7 +97,7 @@ jobs:
       - name: Refresh LXD dependency on 20.04
         if: ${{ matrix.os == 'ubuntu-20.04' }}
         run: |
-          sudo snap refresh lxd
+          sudo snap refresh lxd || echo "Cannot refresh LXD dependency, using $(lxd --version)"
       - name: Configured LXD
         run: |
           sudo groupadd --force --system lxd


### PR DESCRIPTION
LXD is preinstalled on the 20.04 images, it can still work without
refreshing to the latest.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>