### PR TITLE
For bundles, do not show a deprecation message if 'bases' not included, and forbid its usage.

### DIFF
--- a/charmcraft/config.py
+++ b/charmcraft/config.py
@@ -343,6 +343,17 @@ class Config(ModelConfigDefaults, validate_all=False):
         validate_part(item)
         return item
 
+    @pydantic.validator("bases", pre=True)
+    def validate_bases_presence(cls, bases, values):
+        """Forbid 'bases' in bundles.
+
+        This is to avoid a posible confusion of expecting the bundle
+        to be built in a specific environment
+        """
+        if values.get("type") == "bundle":
+            raise ValueError("Field not allowed when type=bundle")
+        return bases
+
     @classmethod
     def expand_short_form_bases(cls, bases: List[Dict[str, Any]]) -> None:
         """Expand short-form base configuration into long-form in-place."""
@@ -390,7 +401,8 @@ class Config(ModelConfigDefaults, validate_all=False):
             # type will simplify user facing errors.
             bases = obj.get("bases")
             if bases is None:
-                notify_deprecation("dn03")
+                if obj["type"] in (None, "charm"):
+                    notify_deprecation("dn03")
                 # Set default bases to Ubuntu 20.04 to match strict snap's
                 # effective behavior.
                 bases = [

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -537,6 +537,40 @@ def test_no_bases_defaults_to_ubuntu_20_04_with_dn03(caplog, create_config, tmp_
     ]
 
 
+def test_no_bases_is_ok_for_bundles(caplog, create_config, tmp_path):
+    """Do not send a deprecation message if it is a bundle."""
+    caplog.set_level(logging.WARNING, logger="charmcraft")
+    create_config(
+        """
+        type: bundle
+    """
+    )
+
+    load(tmp_path)
+    assert not caplog.records
+
+
+def test_bases_forbidden_for_bundles(create_config, check_schema_error):
+    """Do not allow a bases configuration for bundles."""
+    create_config(
+        """
+        type: bundle
+        bases:
+          - build-on:
+              - name: test-build-name
+                channel: test-build-channel
+    """
+    )
+
+    check_schema_error(
+        dedent(
+            """\
+            Bad charmcraft.yaml content:
+            - Field not allowed when type=bundle in field 'bases'"""
+        )
+    )
+
+
 def test_bases_minimal_long_form(create_config):
     tmp_path = create_config(
         """


### PR DESCRIPTION
Fixes #479.