### PR TITLE
Transformed the help management to be implemented not using a command (CRAFT-542).

### DIFF
--- a/completion.bash
+++ b/completion.bash
@@ -26,7 +26,7 @@ _charmcraft()
         close
         create-lib 
         fetch-lib 
-        help init 
+        init 
         list-lib 
         login 
         logout 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -23,7 +23,13 @@ import sys
 from unittest.mock import patch
 
 from charmcraft import __version__, logsetup
-from charmcraft.main import Dispatcher, main, COMMAND_GROUPS, ArgumentParsingError
+from charmcraft.main import (
+    Dispatcher,
+    main,
+    COMMAND_GROUPS,
+    ArgumentParsingError,
+    ProvideHelpException,
+)
 from charmcraft.cmdbase import BaseCommand, CommandError
 from tests.factory import create_command
 
@@ -456,6 +462,21 @@ def test_main_controlled_arguments_error(capsys):
     out, err = capsys.readouterr()
     assert not out
     assert err == "test error\n"
+
+
+def test_main_providing_help(capsys):
+    """The execution ended up providing a help message."""
+    with patch("charmcraft.main.message_handler") as mh_mock:
+        with patch("charmcraft.main.Dispatcher.run") as d_mock:
+            d_mock.side_effect = ProvideHelpException("nice and shiny help message")
+            retcode = main(["charmcraft", "version"])
+
+    assert retcode == 0
+    mh_mock.ended_ok.assert_called_once_with()
+
+    out, err = capsys.readouterr()
+    assert not out
+    assert err == "nice and shiny help message\n"
 
 
 # --- Tests for the bootstrap version message


### PR DESCRIPTION
This has several benefits:

- The help handling is now more straightforward

- The COMMAND_GROUPS constant does not include anything related to help anymore (more app isolation ot a future lib)

- We're able to provide better messages when help was "requested wrong" (e.g. with too many parameters or an incorrect command); IMO this is very important, as we're able to guide the user better in a situation when they're a little lost (there is a reason they are asking for help...)

- All help handling happens on the "initial args pre-parsing", and not one part there and one part when the command is run (this is transparent for the user, but useful for when Dispatcher will be in other lib)

We have only one minor drawbacks: 'help' itself, as a command, is not listed in the "basic commands group" anymore.

Note I added a ProvideHelpException exception to interrupt the normal flow of execution and finish the process providing a guiding text when **help was requested correctly**. This was a simple way to achieve this branch targets without moving a lot of code around, it may change in the future to be more simple when we isolate the Dispatcher further.
