### PR TITLE
parts,charm_builder: add charm-python-packages plugin property (CRAFT-552)

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -162,6 +162,19 @@ jobs:
           unzip -l build-packages-test_*.charm | grep "venv/ops/charm.py"
           popd
 
+          mkdir -p python-packages-test
+          pushd python-packages-test
+          charmcraft -v init --author testuser
+          sed -i "s|20.04|$VERSION_ID|g" charmcraft.yaml
+          cat <<- EOF >> charmcraft.yaml
+          parts:
+            charm:
+              charm-python-packages: [bump2version]
+          EOF
+          sg lxd -c "charmcraft -v pack"
+          unzip -l python-packages-test_*.charm | grep "venv/bumpversion/__init__.py"
+          popd
+
           sudo snap set charmcraft provider=lxd
           sudo snap set charmcraft provider=multipass
           if sudo snap set charmcraft provider=invalid; then

--- a/charmcraft/parts.py
+++ b/charmcraft/parts.py
@@ -39,6 +39,7 @@ class CharmPluginProperties(plugins.PluginProperties, plugins.PluginModel):
 
     source: str = ""
     charm_entrypoint: str = ""  # TODO: add default after removing --entrypoint
+    charm_python_packages: List[str] = []
     charm_requirements: List[str] = []
 
     @classmethod
@@ -67,6 +68,10 @@ class CharmPlugin(plugins.Plugin):
       - ``charm-entrypoint``
         (string)
         The path to the main charm executable, relative to the charm root.
+
+      - ``charm-python-packages``
+        (list of strings)
+        A list of python packages to install from PyPI before installing requirements.
 
       - ``charm-requirements``
         (list of strings)
@@ -134,6 +139,9 @@ class CharmPlugin(plugins.Plugin):
         if options.charm_entrypoint:
             entrypoint = self._part_info.part_build_dir / options.charm_entrypoint
             build_cmd.extend(["--entrypoint", str(entrypoint)])
+
+        for pkg in options.charm_python_packages:
+            build_cmd.extend(["-p", pkg])
 
         for req in options.charm_requirements:
             build_cmd.extend(["-r", req])

--- a/tests/test_parts.py
+++ b/tests/test_parts.py
@@ -38,6 +38,7 @@ class TestCharmPlugin:
         spec = {
             "plugin": "charm",
             "charm-entrypoint": "entrypoint",
+            "charm-python-packages": ["pkg1", "pkg2"],
             "charm-requirements": ["reqs1.txt", "reqs2.txt"],
         }
         plugin_properties = parts.CharmPluginProperties.unmarshal(spec)
@@ -93,6 +94,8 @@ class TestCharmPlugin:
             "--charmdir {work_dir}/parts/foo/build "
             "--builddir {work_dir}/parts/foo/install "
             "--entrypoint {work_dir}/parts/foo/build/entrypoint "
+            "-p pkg1 "
+            "-p pkg2 "
             "-r reqs1.txt "
             "-r reqs2.txt".format(
                 python=sys.executable,
@@ -133,6 +136,7 @@ class TestPartsLifecycle:
             "plugin": "charm",
             "source": ".",
             "charm-entrypoint": "my-entrypoint",
+            "charm-python-packages": ["pkg1", "pkg2"],
             "charm-requirements": ["reqs1.txt", "reqs2.txt"],
         }
 
@@ -164,6 +168,7 @@ class TestPartsLifecycle:
             "plugin": "charm",
             "source": ".",
             "charm-entrypoint": "src/charm.py",
+            "charm-python-packages": ["pkg1", "pkg2"],
             "charm-requirements": ["reqs1.txt", "reqs2.txt"],
         }
 
@@ -195,6 +200,7 @@ class TestPartsLifecycle:
             "plugin": "charm",
             "source": ".",
             "charm-entrypoint": "my-entrypoint",
+            "charm-python-packages": ["pkg1", "pkg2"],
             "charm-requirements": ["reqs1.txt", "reqs2.txt"],
         }
 


### PR DESCRIPTION
Packages listed in the `charm-python-packages` property are installed
before dependencies listed in the requirements file. This mirrors
`python-packages` that exists in the python plugin.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>