### PR TITLE
Formalize the command groups to be proper objects, not a tuple of values (CRAFT-560).

### DIFF
--- a/charmcraft/main.py
+++ b/charmcraft/main.py
@@ -53,49 +53,44 @@ class ProvideHelpException(Exception):
 # declared in each command because it's much easier to do this separation/grouping in one
 # central place and not distributed in several classes/files. Also note that order here is
 # important when listing commands and showing help.
+_basic_commands = [
+    analyze.AnalyzeCommand,
+    build.BuildCommand,
+    clean.CleanCommand,
+    pack.PackCommand,
+    init.InitCommand,
+    version.VersionCommand,
+]
+_charmhub_commands = [
+    # auth
+    store.LoginCommand,
+    store.LogoutCommand,
+    store.WhoamiCommand,
+    # name handling
+    store.RegisterCharmNameCommand,
+    store.RegisterBundleNameCommand,
+    store.ListNamesCommand,
+    # pushing files and checking revisions
+    store.UploadCommand,
+    store.ListRevisionsCommand,
+    # release process, and show status
+    store.ReleaseCommand,
+    store.StatusCommand,
+    store.CloseCommand,
+    # libraries support
+    store.CreateLibCommand,
+    store.PublishLibCommand,
+    store.ListLibCommand,
+    store.FetchLibCommand,
+    # resources support
+    store.ListResourcesCommand,
+    store.UploadResourceCommand,
+    store.ListResourceRevisionsCommand,
+]
+CommandGroup = namedtuple("CommandGroup", "name commands")
 COMMAND_GROUPS = [
-    (
-        "basic",
-        "Basic",
-        [
-            analyze.AnalyzeCommand,
-            build.BuildCommand,
-            clean.CleanCommand,
-            pack.PackCommand,
-            init.InitCommand,
-            version.VersionCommand,
-        ],
-    ),
-    (
-        "store",
-        "Charmhub",
-        [
-            # auth
-            store.LoginCommand,
-            store.LogoutCommand,
-            store.WhoamiCommand,
-            # name handling
-            store.RegisterCharmNameCommand,
-            store.RegisterBundleNameCommand,
-            store.ListNamesCommand,
-            # pushing files and checking revisions
-            store.UploadCommand,
-            store.ListRevisionsCommand,
-            # release process, and show status
-            store.ReleaseCommand,
-            store.StatusCommand,
-            store.CloseCommand,
-            # libraries support
-            store.CreateLibCommand,
-            store.PublishLibCommand,
-            store.ListLibCommand,
-            store.FetchLibCommand,
-            # resources support
-            store.ListResourcesCommand,
-            store.UploadResourceCommand,
-            store.ListResourceRevisionsCommand,
-        ],
-    ),
+    CommandGroup("Basic", _basic_commands),
+    CommandGroup("Charmhub", _charmhub_commands),
 ]
 
 
@@ -180,8 +175,8 @@ class Dispatcher:
     def _get_commands_info(self, commands_groups):
         """Process the commands groups structure for easier programmable access."""
         commands = {}
-        for _cmd_group, _, _cmd_classes in commands_groups:
-            for _cmd_class in _cmd_classes:
+        for command_group in commands_groups:
+            for _cmd_class in command_group.commands:
                 if _cmd_class.name in commands:
                     _stored_class = commands[_cmd_class.name]
                     raise RuntimeError(

--- a/tests/test_cmdbase.py
+++ b/tests/test_cmdbase.py
@@ -34,7 +34,7 @@ def test_commanderror_retcode_given():
     assert err.retcode == 4
 
 
-all_commands = list.__add__(*[commands for _, _, commands in COMMAND_GROUPS])
+all_commands = list.__add__(*[cgroup.commands for cgroup in COMMAND_GROUPS])
 
 
 @pytest.mark.parametrize("command", all_commands)

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -20,7 +20,7 @@ from unittest.mock import patch
 import pytest
 
 from charmcraft import helptexts, main
-from charmcraft.main import Dispatcher, ArgumentParsingError, ProvideHelpException
+from charmcraft.main import Dispatcher, ArgumentParsingError, ProvideHelpException, CommandGroup
 from tests.factory import create_command
 
 
@@ -78,9 +78,9 @@ def test_default_help_text(help_builder):
     cmd7 = create_command("cmd7", "More help.")
 
     command_groups = [
-        ("group1", "help text for g1", [cmd6, cmd2]),
-        ("group3", "help text for g3", [cmd7]),
-        ("group2", "help text for g2", [cmd3, cmd4, cmd5, cmd1]),
+        CommandGroup("group1", [cmd6, cmd2]),
+        CommandGroup("group3", [cmd7]),
+        CommandGroup("group2", [cmd3, cmd4, cmd5, cmd1]),
     ]
     fake_summary = textwrap.dedent(
         """
@@ -140,9 +140,9 @@ def test_detailed_help_text(help_builder):
     cmd7 = create_command("cmd7", "More help.")
 
     command_groups = [
-        ("group1", "Group 1 description", [cmd6, cmd2]),
-        ("group3", "Group 3 help text", [cmd7]),
-        ("group2", "Group 2 stuff", [cmd3, cmd4, cmd5, cmd1]),
+        CommandGroup("Group 1 description", [cmd6, cmd2]),
+        CommandGroup("Group 3 help text", [cmd7]),
+        CommandGroup("Group 2 stuff", [cmd3, cmd4, cmd5, cmd1]),
     ]
     fake_summary = textwrap.dedent(
         """
@@ -208,8 +208,8 @@ def test_command_help_text_no_parameters(config, help_builder):
     cmd3 = create_command("other-cmd-3", "Some help.")
     cmd4 = create_command("other-cmd-4", "Some help.")
     command_groups = [
-        ("group1", "help text for g1", [cmd1, cmd2, cmd4]),
-        ("group2", "help text for g2", [cmd3]),
+        CommandGroup("group1", [cmd1, cmd2, cmd4]),
+        CommandGroup("group2", [cmd3]),
     ]
 
     options = [
@@ -258,7 +258,7 @@ def test_command_help_text_with_parameters(config, help_builder):
     cmd1 = create_command("somecommand", "Command one line help.", overview_=overview)
     cmd2 = create_command("other-cmd-2", "Some help.")
     command_groups = [
-        ("group1", "help text for g1", [cmd1, cmd2]),
+        CommandGroup("group1", [cmd1, cmd2]),
     ]
 
     options = [
@@ -304,8 +304,8 @@ def test_command_help_text_loneranger(config, help_builder):
     cmd1 = create_command("somecommand", "Command one line help.", overview_=overview)
     cmd2 = create_command("other-cmd-2", "Some help.")
     command_groups = [
-        ("group1", "help text for g1", [cmd1]),
-        ("group2", "help text for g2", [cmd2]),
+        CommandGroup("group1", [cmd1]),
+        CommandGroup("group2", [cmd2]),
     ]
 
     options = [
@@ -470,7 +470,7 @@ def test_tool_exec_help_on_too_many_things(sysargv, help_builder):
 def test_tool_exec_command_dash_help_simple(help_option):
     """Execute a command (that needs no params) asking for help."""
     cmd = create_command("somecommand", "This command does that.")
-    command_groups = [("group", "help text", [cmd])]
+    command_groups = [CommandGroup("group", [cmd])]
 
     with patch("charmcraft.helptexts.HelpBuilder.get_command_help") as mock:
         mock.return_value = "test help"
@@ -495,7 +495,7 @@ def test_tool_exec_command_dash_help_simple(help_option):
 def test_tool_exec_command_dash_help_reverse(help_option):
     """Execute a command (that needs no params) asking for help."""
     cmd = create_command("somecommand", "This command does that.")
-    command_groups = [("group", "help text", [cmd])]
+    command_groups = [CommandGroup("group", [cmd])]
 
     with patch("charmcraft.helptexts.HelpBuilder.get_command_help") as mock:
         mock.return_value = "test help"
@@ -525,7 +525,7 @@ def test_tool_exec_command_dash_help_missing_params(help_option):
 
     cmd = create_command("somecommand", "This command does that.")
     cmd.fill_parser = fill_parser
-    command_groups = [("group", "help text", [cmd])]
+    command_groups = [CommandGroup("group", [cmd])]
 
     with patch("charmcraft.helptexts.HelpBuilder.get_command_help") as mock:
         mock.return_value = "test help"
@@ -550,7 +550,7 @@ def test_tool_exec_command_dash_help_missing_params(help_option):
 def test_tool_exec_command_wrong_option(help_builder):
     """Execute a correct command but with a wrong option."""
     cmd = create_command("somecommand", "This command does that.")
-    command_groups = [("group", "help text", [cmd])]
+    command_groups = [CommandGroup("group", [cmd])]
     help_builder.init("testapp", "general summary", command_groups)
     with pytest.raises(ArgumentParsingError) as cm:
         Dispatcher(["somecommand", "--whatever"], command_groups)
@@ -577,7 +577,7 @@ def test_tool_exec_command_bad_option_type(help_builder):
     cmd = create_command("somecommand", "This command does that.")
     cmd.fill_parser = fill_parser
 
-    command_groups = [("group", "help text", [cmd])]
+    command_groups = [CommandGroup("group", [cmd])]
     help_builder.init("testapp", "general summary", command_groups)
     with pytest.raises(ArgumentParsingError) as cm:
         Dispatcher(["somecommand", "--number=foo"], command_groups)
@@ -598,7 +598,7 @@ def test_tool_exec_command_bad_option_type(help_builder):
 def test_tool_exec_help_command_on_command_ok():
     """Execute charmcraft asking for help on a command ok."""
     cmd = create_command("somecommand", "This command does that.")
-    command_groups = [("group", "help text", [cmd])]
+    command_groups = [CommandGroup("group", [cmd])]
 
     with patch("charmcraft.helptexts.HelpBuilder.get_command_help") as mock:
         mock.return_value = "test help"
@@ -631,7 +631,7 @@ def test_tool_exec_help_command_on_command_complex():
 
     cmd = create_command("somecommand", "This command does that.")
     cmd.fill_parser = fill_parser
-    command_groups = [("group", "help text", [cmd])]
+    command_groups = [CommandGroup("group", [cmd])]
 
     with patch("charmcraft.helptexts.HelpBuilder.get_command_help") as mock:
         mock.return_value = "test help"
@@ -660,7 +660,7 @@ def test_tool_exec_help_command_on_command_complex():
 
 def test_tool_exec_help_command_on_command_wrong():
     """Execute charmcraft asking for help on a command which does not exist."""
-    command_groups = [("group", "help", [])]
+    command_groups = [CommandGroup("group", [])]
 
     with patch("charmcraft.helptexts.HelpBuilder.get_usage_message") as mock:
         mock.return_value = "test help"
@@ -677,7 +677,7 @@ def test_tool_exec_help_command_on_command_wrong():
 
 def test_tool_exec_help_command_all():
     """Execute charmcraft asking for detailed help."""
-    command_groups = [("group", "help", [])]
+    command_groups = [CommandGroup("group", [])]
 
     with patch("charmcraft.helptexts.HelpBuilder.get_detailed_help") as mock:
         mock.return_value = "test help"

--- a/tests/test_infra.py
+++ b/tests/test_infra.py
@@ -132,8 +132,8 @@ def test_bashcompletion_all_commands():
         pytest.fail("Failed to find commands in the bash completion file")
 
     real_command_names = set()
-    for _, _, cmds in main.COMMAND_GROUPS:
-        real_command_names.update(cmd.name for cmd in cmds)
+    for cgroup in main.COMMAND_GROUPS:
+        real_command_names.update(cmd.name for cmd in cgroup.commands)
 
     assert completed_commands == real_command_names
 


### PR DESCRIPTION
This is a requirement for when the command groups will be defined and used by different codes (lib and app), after the split of part of `charmcraft` code to `craft-cli`.

While doing this, I also removed the group's "codename" and just left the "description", which is what should be used for showing to the user.
