### PR TITLE
github actions: don't upgrade pip on Windows

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -26,9 +26,14 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install/update pip, wheel, and setuptools
+      - name: Install/update pip, wheel, and setuptools on non Windows
+        if: ${{ matrix.os != 'windows-2019' }}
         run: |
           pip install -U pip wheel setuptools
+      - name: Install/update pip, wheel, and setuptools on Windows
+        if: ${{ matrix.os == 'windows-2019' }}
+        run: |
+          pip install -U wheel setuptools
       - name: Install Ubuntu-specific dependencies
         if: ${{ matrix.os == 'ubuntu-18.04' || matrix.os == 'ubuntu-20.04' }}
         run: |


### PR DESCRIPTION
Fix for:

```
Run pip install -U pip wheel setuptools
Requirement already satisfied: pip in c:\hostedtoolcache\windows\python\3.8.10\x64\lib\site-packages (21.2.4)
Collecting pip
  Downloading pip-21.3-py3-none-any.whl (1.7 MB)
Collecting wheel
  Downloading wheel-0.37.0-py2.py3-none-any.whl (35 kB)
Requirement already satisfied: setuptools in c:\hostedtoolcache\windows\python\3.8.10\x64\lib\site-packages (56.0.0)
Collecting setuptools
  Downloading setuptools-58.2.0-py3-none-any.whl (946 kB)
Installing collected packages: wheel, setuptools, pip
  Attempting uninstall: setuptools
    Found existing installation: setuptools 56.0.0
    Uninstalling setuptools-56.0.0:
      Successfully uninstalled setuptools-56.0.0
  Attempting uninstall: pip
    Found existing installation: pip 21.2.4
    Uninstalling pip-21.2.4:
      Successfully uninstalled pip-21.2.4
ERROR: Could not install packages due to an OSError: [WinError 5] Access is denied: 'C:\\Users\\runneradmin\\AppData\\Local\\Temp\\pip-uninstall-uudsaahd\\pip.exe'
Consider using the `--user` option or check the permissions.
```

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>