### PR TITLE
env: remove strict DEVELOPER environment (CRAFT-573)

### DIFF
--- a/charmcraft/env.py
+++ b/charmcraft/env.py
@@ -20,10 +20,7 @@
 import distutils.util
 import os
 import pathlib
-import sys
 from typing import Optional
-
-from charmcraft.cmdbase import CommandError
 
 
 def get_managed_environment_home_path():
@@ -64,28 +61,3 @@ def is_charmcraft_running_in_managed_mode():
     """Check if charmcraft is running in a managed environment."""
     managed_flag = os.getenv("CHARMCRAFT_MANAGED_MODE", "n")
     return distutils.util.strtobool(managed_flag) == 1
-
-
-def is_charmcraft_running_in_supported_environment() -> bool:
-    """Check if Charmcraft is running in a supported environment."""
-    if sys.platform == "linux":
-        return is_charmcraft_running_from_snap()
-    elif sys.platform in ("darwin", "win32"):
-        return True
-
-    return False
-
-
-def ensure_charmcraft_environment_is_supported():
-    """Assert that environment is supported.
-
-    :raises CommandError: if unsupported environment.
-    """
-    if (
-        not is_charmcraft_running_in_supported_environment()
-        and not is_charmcraft_running_in_developer_mode()
-    ):
-        raise CommandError(
-            "For a supported user experience, please use the Charmcraft snap. "
-            "For more information, please see https://juju.is/docs/sdk/setting-up-charmcraft"
-        )

--- a/charmcraft/main.py
+++ b/charmcraft/main.py
@@ -21,7 +21,7 @@ import logging
 import sys
 from collections import namedtuple
 
-from charmcraft import config, env
+from charmcraft import config
 from charmcraft.cmdbase import CommandError
 from charmcraft.commands import build, clean, init, pack, store, version, analyze
 from charmcraft.helptexts import help_builder
@@ -350,7 +350,6 @@ def main(argv=None):
 
     # process
     try:
-        env.ensure_charmcraft_environment_is_supported()
         setup_parts()
 
         # load the dispatcher and put everything in motion

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -15,12 +15,10 @@
 # For further info, check https://github.com/canonical/charmcraft
 
 import pathlib
-import sys
 
 import pytest
 
 from charmcraft import env
-from charmcraft.cmdbase import CommandError
 
 
 def test_get_managed_environment_home_path():
@@ -122,61 +120,3 @@ def test_is_charmcraft_running_in_managed_mode(monkeypatch, managed, result):
         monkeypatch.setenv("CHARMCRAFT_MANAGED_MODE", managed)
 
     assert env.is_charmcraft_running_in_managed_mode() == result
-
-
-@pytest.mark.parametrize(
-    "as_snap",
-    [False, True],
-)
-def test_is_charmcraft_running_in_supported_environment_linux(monkeypatch, as_snap):
-    monkeypatch.setattr(env, "is_charmcraft_running_from_snap", lambda: as_snap)
-    monkeypatch.setattr(sys, "platform", "linux")
-
-    assert env.is_charmcraft_running_in_supported_environment() == as_snap
-
-
-def test_is_charmcraft_running_in_supported_environment_osx(monkeypatch):
-    monkeypatch.setattr(sys, "platform", "darwin")
-
-    assert env.is_charmcraft_running_in_supported_environment() is True
-
-
-def test_is_charmcraft_running_in_supported_environment_windows(monkeypatch):
-    monkeypatch.setattr(sys, "platform", "win32")
-
-    assert env.is_charmcraft_running_in_supported_environment() is True
-
-
-@pytest.mark.parametrize(
-    "developer_mode,supported_environment",
-    [
-        (False, True),
-        (True, False),
-        (True, True),
-    ],
-)
-def test_ensure_environment_is_supported(monkeypatch, developer_mode, supported_environment):
-    monkeypatch.setattr(env, "is_charmcraft_running_in_developer_mode", lambda: developer_mode)
-    monkeypatch.setattr(
-        env,
-        "is_charmcraft_running_in_supported_environment",
-        lambda: supported_environment,
-    )
-    monkeypatch.setattr(sys, "platform", "linux")
-
-    env.ensure_charmcraft_environment_is_supported()
-
-
-def test_ensure_environment_is_supported_error(monkeypatch):
-    monkeypatch.setattr(env, "is_charmcraft_running_in_developer_mode", lambda: False)
-    monkeypatch.setattr(env, "is_charmcraft_running_in_supported_environment", lambda: False)
-    monkeypatch.setattr(sys, "platform", "linux")
-
-    with pytest.raises(
-        CommandError,
-        match=(
-            "For a supported user experience, please use the Charmcraft snap. "
-            "For more information, please see https://juju.is/docs/sdk/setting-up-charmcraft"
-        ),
-    ):
-        env.ensure_charmcraft_environment_is_supported()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -39,13 +39,6 @@ from tests.factory import create_command
 import pytest
 
 
-@pytest.fixture(autouse=True)
-def mock_ensure_charmcraft_environment_is_supported(monkeypatch):
-    """Bypass entry point check for running as snap."""
-    with patch("charmcraft.env.ensure_charmcraft_environment_is_supported") as mock_supported:
-        yield mock_supported
-
-
 # --- Tests for the Dispatcher
 
 
@@ -454,17 +447,6 @@ def test_main_controlled_return_code():
 
     assert retcode == 9
     mh_mock.ended_ok.assert_called_once_with()
-
-
-def test_main_environment_is_supported_error(mock_ensure_charmcraft_environment_is_supported):
-    mock_ensure_charmcraft_environment_is_supported.side_effect = CommandError("not supported!")
-    with patch("charmcraft.main.message_handler") as mh_mock:
-        with patch("charmcraft.main.Dispatcher.run") as d_mock:
-            d_mock.return_value = None
-            retcode = main(["charmcraft", "version"])
-
-    assert retcode == 1
-    assert mh_mock.ended_cmderror.call_count == 1
 
 
 def test_main_crash():


### PR DESCRIPTION
Keep the flag for use of other features, like switching providers, but
do not enforce it to allow for HOMEBREW Linux to work.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>