### PR TITLE
store: get oci image blobs by posting, not getting

### DIFF
--- a/charmcraft/commands/store/store.py
+++ b/charmcraft/commands/store/store.py
@@ -409,6 +409,6 @@ class Store:
         """Get the blob that points to the OCI image in the Canonical's OCI Registry."""
         payload = {"image-digest": digest}
         endpoint = f"/v1/charm/{charm_name}/resources/{resource_name}/oci-image/blob"
-        content = self._client.request_urlpath_text("GET", endpoint, json=payload)
+        content = self._client.request_urlpath_text("POST", endpoint, json=payload)
         # the response here is returned as is, because it's opaque to charmcraft
         return content

--- a/tests/commands/test_store_api.py
+++ b/tests/commands/test_store_api.py
@@ -1434,7 +1434,7 @@ def test_get_oci_image_blob(client_mock, config):
 
     assert client_mock.mock_calls == [
         call.request_urlpath_text(
-            "GET",
+            "POST",
             "/v1/charm/charm-name/resources/resource-name/oci-image/blob",
             json={"image-digest": "a-very-specific-digest"},
         )


### PR DESCRIPTION
Regression from the integration of craft-store.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>