### PR TITLE
store: send json when creating library ID

### DIFF
--- a/charmcraft/commands/store/store.py
+++ b/charmcraft/commands/store/store.py
@@ -322,7 +322,9 @@ class Store:
     def create_library_id(self, charm_name, lib_name):
         """Create a new library id."""
         endpoint = f"/v1/charm/libraries/{charm_name}"
-        response = self._client.request_urlpath_json("POST", endpoint, {"library-name": lib_name})
+        response = self._client.request_urlpath_json(
+            "POST", endpoint, json={"library-name": lib_name}
+        )
         lib_id = response["library-id"]
         return lib_id
 

--- a/tests/commands/test_store_api.py
+++ b/tests/commands/test_store_api.py
@@ -959,7 +959,7 @@ def test_create_library_id(client_mock, config):
         call.request_urlpath_json(
             "POST",
             "/v1/charm/libraries/test-charm-name",
-            {"library-name": "test-lib-name"},
+            json={"library-name": "test-lib-name"},
         ),
     ]
     assert result == "test-lib-id"


### PR DESCRIPTION
This is a regression fix from the craft-store integration.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>