### PR TITLE
Revisited all error usage to adapt to new craft-cli context.

### DIFF
--- a/charmcraft/commands/store/client.py
+++ b/charmcraft/commands/store/client.py
@@ -62,11 +62,18 @@ class Client(craft_store.StoreClient):
 
     def request_urlpath_text(self, method: str, urlpath: str, *args, **kwargs) -> str:
         """Return a request.Response to a urlpath."""
-        return super().request(method, self.api_base_url + urlpath, *args, **kwargs).text
+        try:
+            return super().request(method, self.api_base_url + urlpath, *args, **kwargs).text
+        except craft_store.errors.CraftStoreError as err:
+            raise CommandError(str(err)) from err
 
     def request_urlpath_json(self, method: str, urlpath: str, *args, **kwargs) -> Dict[str, Any]:
         """Return .json() from a request.Response to a urlpath."""
-        response = super().request(method, self.api_base_url + urlpath, *args, **kwargs)
+        try:
+            response = super().request(method, self.api_base_url + urlpath, *args, **kwargs)
+        except craft_store.errors.CraftStoreError as err:
+            raise CommandError(str(err)) from err
+
         try:
             return response.json()
         except JSONDecodeError as json_error:

--- a/charmcraft/parts.py
+++ b/charmcraft/parts.py
@@ -269,7 +269,7 @@ class PartsLifecycle:
                 ignore_local_sources=ignore_local_sources,
             )
         except PartsError as err:
-            raise CommandError(err)
+            raise CommandError(f"Error bootstrapping lifecycle manager: {err}") from err
 
     @property
     def prime_dir(self) -> pathlib.Path:

--- a/tests/commands/test_store_client.py
+++ b/tests/commands/test_store_client.py
@@ -19,8 +19,8 @@
 import json
 from unittest import mock
 from unittest.mock import call, patch
-import craft_store
 
+import craft_store
 import pytest
 import requests
 from requests_toolbelt import MultipartEncoder, MultipartEncoderMonitor
@@ -144,6 +144,34 @@ def test_client_request_success_without_json_parsing(client_class):
 
     assert client.request_mock.mock_calls == [call("GET", "http://api.test/somepath")]
     assert result == response_value
+
+
+def test_client_request_text_error(client_class):
+    """Hits the server in text mode, getting an error."""
+    client = client_class("http://api.test", "http://storage.test")
+    original_error_text = "bad bad server"
+    store_error = craft_store.errors.CraftStoreError(original_error_text)
+    client.request_mock.side_effect = store_error
+
+    with pytest.raises(CommandError) as cm:
+        client.request_urlpath_text("GET", "/somepath")
+    exc = cm.value
+    assert str(exc) == original_error_text
+    assert exc.__cause__ == store_error
+
+
+def test_client_request_json_error(client_class):
+    """Hits the server in json mode, getting an error."""
+    client = client_class("http://api.test", "http://storage.test")
+    original_error_text = "bad bad server"
+    store_error = craft_store.errors.CraftStoreError(original_error_text)
+    client.request_mock.side_effect = store_error
+
+    with pytest.raises(CommandError) as cm:
+        client.request_urlpath_json("GET", "/somepath")
+    exc = cm.value
+    assert str(exc) == original_error_text
+    assert exc.__cause__ == store_error
 
 
 def test_client_hit_success_withbody(client_class):

--- a/tests/commands/test_store_commands.py
+++ b/tests/commands/test_store_commands.py
@@ -390,6 +390,7 @@ def test_get_name_charm_bad_metadata(tmp_path, yaml_content):
         "Bad 'metadata.yaml' file inside charm zip "
         "'{}': must be a valid YAML with a 'name' key.".format(bad_zip)
     )
+    assert cm.value.__cause__ is not None
 
 
 def test_get_name_bundle_ok(tmp_path):
@@ -421,6 +422,7 @@ def test_get_name_bundle_bad_data(tmp_path, yaml_content):
         "Bad 'bundle.yaml' file inside bundle zip '{}': "
         "must be a valid YAML with a 'name' key.".format(bad_zip)
     )
+    assert cm.value.__cause__ is not None
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
@@ -454,7 +456,8 @@ def test_upload_call_ok(emitter, store_mock, config, tmp_path):
     test_charm = tmp_path / "mystuff.charm"
     _build_zip_with_yaml(test_charm, "metadata.yaml", content={"name": "mycharm"})
     args = Namespace(filepath=test_charm, release=[])
-    UploadCommand(config).run(args)
+    retcode = UploadCommand(config).run(args)
+    assert retcode == 0
 
     assert store_mock.mock_calls == [call.upload("mycharm", test_charm)]
     expected = "Revision 7 of 'mycharm' created"
@@ -473,7 +476,8 @@ def test_upload_call_error(emitter, store_mock, config, tmp_path):
     test_charm = tmp_path / "mystuff.charm"
     _build_zip_with_yaml(test_charm, "metadata.yaml", content={"name": "mycharm"})
     args = Namespace(filepath=test_charm, release=[])
-    UploadCommand(config).run(args)
+    retcode = UploadCommand(config).run(args)
+    assert retcode == 1
 
     assert store_mock.mock_calls == [call.upload("mycharm", test_charm)]
     expected = [
@@ -2961,7 +2965,8 @@ def test_uploadresource_filepath_call_ok(emitter, store_mock, config, tmp_path):
         filepath=test_resource,
         image=None,
     )
-    UploadResourceCommand(config).run(args)
+    retcode = UploadResourceCommand(config).run(args)
+    assert retcode == 0
 
     assert store_mock.mock_calls == [
         call.upload_resource("mycharm", "myresource", "file", test_resource)
@@ -3203,7 +3208,8 @@ def test_uploadresource_call_error(emitter, store_mock, config, tmp_path):
     test_resource = tmp_path / "mystuff.bin"
     test_resource.write_text("sample stuff")
     args = Namespace(charm_name="mycharm", resource_name="myresource", filepath=test_resource)
-    UploadResourceCommand(config).run(args)
+    retcode = UploadResourceCommand(config).run(args)
+    assert retcode == 1
 
     emitter.assert_messages(
         [

--- a/tests/test_parts.py
+++ b/tests/test_parts.py
@@ -22,8 +22,10 @@ import craft_parts
 import pydantic
 import pytest
 from craft_parts import Step, plugins
+from craft_parts.errors import PartsError
 
 from charmcraft import charm_builder, parts
+from charmcraft.cmdbase import CommandError
 
 
 pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
@@ -115,6 +117,21 @@ class TestCharmPlugin:
 
 class TestPartsLifecycle:
     """Ensure parts data correctly used in lifecycle."""
+
+    def test_bad_bootstrap(self, tmp_path):
+        fake_error = PartsError("pumba")
+        with patch("craft_parts.LifecycleManager.__init__") as mock:
+            mock.side_effect = fake_error
+            with pytest.raises(CommandError) as cm:
+                parts.PartsLifecycle(
+                    all_parts={},
+                    work_dir="/some/workdir",
+                    project_dir=tmp_path,
+                    ignore_local_sources=["*.charm"],
+                )
+            exc = cm.value
+            assert str(exc) == "Error bootstrapping lifecycle manager: pumba"
+            assert exc.__cause__ == fake_error
 
     def test_prime_dir(self, tmp_path):
         data = {


### PR DESCRIPTION
In detail:

- ensured that when the error comes from a sub-process, use `from err` (no need for another error type, it's just handled by `craft-cli`)

- started to use `details` attribute in some errors, to provide extra info

- returned 1 from commands that actually end ok (raising CommandError) but show error messages that come from an unsuccesful call to the Store

- support `craft-store` raising StoreServerError and transform that correctly
