### PR TITLE
build: don't create implicit part if parts section specified (CRAFT-633)

### DIFF
--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -131,9 +131,20 @@ class Builder:
         self.config = config
         self.metadata = parse_metadata_yaml(self.charmdir)
 
-        self._parts = self.config.parts.copy()
-        self._charm_part = self._parts.setdefault("charm", {})
-        self._prime = self._charm_part.setdefault("prime", [])
+        if self.config.parts:
+            self._parts = self.config.parts.copy()
+        else:
+            # "parts" not declared, create an implicit "charm" part
+            self._parts = {"charm": {"plugin": "charm"}}
+
+        # a part named "charm" using plugin "charm" is special and has
+        # predefined values set automatically.
+        charm_part = self._parts.get("charm")
+        if charm_part and charm_part.get("plugin") == "charm":
+            self._charm_part = charm_part
+        else:
+            self._charm_part = None
+
         self.provider = get_provider()
 
     def show_linting_results(self, linting_results):
@@ -182,8 +193,6 @@ class Builder:
         :raises CommandError: on lifecycle exception.
         :raises RuntimeError: on unexpected lifecycle exception.
         """
-        self._handle_deprecated_cli_arguments()
-
         if env.is_charmcraft_running_in_managed_mode():
             work_dir = env.get_managed_environment_home_path()
         else:
@@ -191,11 +200,16 @@ class Builder:
 
         emit.progress(f"Building charm in {str(work_dir)!r}")
 
-        # add charm files to the prime filter
-        self._set_prime_filter()
+        if self._charm_part:
+            # all current deprecated arguments set charm plugin parameters
+            self._handle_deprecated_cli_arguments()
 
-        # set source for buiding
-        self._charm_part["source"] = str(self.charmdir)
+            # add charm files to the prime filter
+            self._set_prime_filter()
+
+            # set source if empty or not declared in charm part
+            if not self._charm_part.get("source"):
+                self._charm_part["source"] = str(self.charmdir)
 
         # run the parts lifecycle
         emit.trace(f"Parts definition: {self._parts}")
@@ -266,25 +280,27 @@ class Builder:
           dispatcher and the hooks directory.
         - A set of optional charm files.
         """
+        charm_part_prime = self._charm_part.setdefault("prime", [])
+
         # add entrypoint
         entrypoint = pathlib.Path(self._charm_part["charm-entrypoint"])
         if str(entrypoint) == entrypoint.name:
             # the entry point is in the root of the project, just include it
-            self._prime.append(str(entrypoint))
+            charm_part_prime.append(str(entrypoint))
         else:
             # the entry point is in a subdir, include the whole subtree
-            self._prime.append(str(entrypoint.parts[0]))
+            charm_part_prime.append(str(entrypoint.parts[0]))
 
         # add venv if there are requirements
         if self._charm_part["charm-requirements"]:
-            self._prime.append(VENV_DIRNAME)
+            charm_part_prime.append(VENV_DIRNAME)
 
         # add mandatory and optional charm files
-        self._prime.extend(CHARM_FILES)
+        charm_part_prime.extend(CHARM_FILES)
         for fn in CHARM_OPTIONAL:
             path = self.charmdir / fn
             if path.exists():
-                self._prime.append(fn)
+                charm_part_prime.append(fn)
 
     def plan(
         self, *, bases_indices: Optional[List[int]], destructive_mode: bool, managed_mode: bool

--- a/charmcraft/parts.py
+++ b/charmcraft/parts.py
@@ -35,8 +35,8 @@ from charmcraft.cmdbase import CommandError
 class CharmPluginProperties(plugins.PluginProperties, plugins.PluginModel):
     """Properties used in charm building."""
 
-    source: str = ""
-    charm_entrypoint: str = ""  # TODO: add default after removing --entrypoint
+    source: str
+    charm_entrypoint: str = "src/charm.py"
     charm_binary_python_packages: List[str] = []
     charm_python_packages: List[str] = []
     charm_requirements: List[str] = []
@@ -164,7 +164,7 @@ class CharmPlugin(plugins.Plugin):
 class BundlePluginProperties(plugins.PluginProperties, plugins.PluginModel):
     """Properties used to pack bundles."""
 
-    source: str = ""
+    source: str
 
     @classmethod
     def unmarshal(cls, data: Dict[str, Any]):
@@ -198,7 +198,7 @@ class BundlePlugin(plugins.Plugin):
 
     def get_build_packages(self) -> Set[str]:
         """Return a set of required packages to install in the build environment."""
-        return {}
+        return set()
 
     def get_build_environment(self) -> Dict[str, str]:
         """Return a dictionary with the environment to use in the build step."""

--- a/tests/commands/test_build.py
+++ b/tests/commands/test_build.py
@@ -2008,6 +2008,241 @@ def test_show_linters_lint_errors_forced(basic_project, emitter, config):
     )
 
 
+# -- tests for implicit charm part
+
+
+@pytest.fixture
+def charmcraft_yaml():
+    """Create a charmcraft.yaml with the given parts data."""
+
+    def _write_yaml_file(project_dir, parts):
+        host_base = get_host_as_base()
+        header = dedent(
+            f"""
+            type: charm
+            bases:
+              - build-on:
+                  - name: {host_base.name!r}
+                    channel: {host_base.channel!r}
+                run-on:
+                  - name: {host_base.name!r}
+                    channel: {host_base.channel!r}
+            """
+        )
+
+        charmcraft_file = project_dir / "charmcraft.yaml"
+        charmcraft_file.write_text(header + parts)
+
+    return _write_yaml_file
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
+def test_parts_not_defined(basic_project, charmcraft_yaml, monkeypatch):
+    """Parts are not defined.
+
+    When the "parts" section does not exist, create an implicit "charm" part and
+    populate it with the default charm building parameters.
+    """
+    charmcraft_yaml(basic_project, "")
+
+    config = load(basic_project)
+    monkeypatch.chdir(basic_project)
+    builder = get_builder(config, entrypoint=None)
+
+    # create a requirements.txt file
+    pathlib.Path(basic_project, "requirements.txt").write_text("ops >= 1.2.0")
+
+    monkeypatch.setenv("CHARMCRAFT_MANAGED_MODE", "1")
+    with patch("charmcraft.parts.PartsLifecycle", autospec=True) as mock_lifecycle:
+        mock_lifecycle.side_effect = SystemExit()
+        with pytest.raises(SystemExit):
+            builder.run([0])
+    mock_lifecycle.assert_has_calls(
+        [
+            call(
+                {
+                    "charm": {
+                        "plugin": "charm",
+                        "charm-entrypoint": "src/charm.py",
+                        "charm-requirements": ["requirements.txt"],
+                        "source": str(basic_project),
+                        "prime": [
+                            "src",
+                            "venv",
+                            "metadata.yaml",
+                            "dispatch",
+                            "hooks",
+                            "lib",
+                            "LICENSE",
+                            "icon.svg",
+                            "README.md",
+                        ],
+                    }
+                },
+                work_dir=pathlib.Path("/root"),
+                project_dir=basic_project,
+                ignore_local_sources=["*.charm"],
+            )
+        ]
+    )
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
+def test_parts_with_charm_part(basic_project, charmcraft_yaml, monkeypatch):
+    """Parts are declared with a charm part with implicit plugin.
+
+    When the "parts" section exists in chamcraft.yaml and a part named "charm"
+    is defined with implicit plugin (or explicit "charm" plugin), populate it
+    with the defaults for charm building.
+    """
+    charmcraft_yaml(
+        basic_project,
+        dedent(
+            """
+            parts:
+              charm:
+                prime:
+                  - my_extra_file.txt
+            """
+        ),
+    )
+
+    config = load(basic_project)
+    monkeypatch.chdir(basic_project)
+    builder = get_builder(config, entrypoint=None)
+
+    # create a requirements.txt file
+    pathlib.Path(basic_project, "requirements.txt").write_text("ops >= 1.2.0")
+
+    monkeypatch.setenv("CHARMCRAFT_MANAGED_MODE", "1")
+    with patch("charmcraft.parts.PartsLifecycle", autospec=True) as mock_lifecycle:
+        mock_lifecycle.side_effect = SystemExit()
+        with pytest.raises(SystemExit):
+            builder.run([0])
+    mock_lifecycle.assert_has_calls(
+        [
+            call(
+                {
+                    "charm": {
+                        "plugin": "charm",
+                        "charm-entrypoint": "src/charm.py",
+                        "charm-requirements": ["requirements.txt"],
+                        "source": str(basic_project),
+                        "prime": [
+                            "my_extra_file.txt",
+                            "src",
+                            "venv",
+                            "metadata.yaml",
+                            "dispatch",
+                            "hooks",
+                            "lib",
+                            "LICENSE",
+                            "icon.svg",
+                            "README.md",
+                        ],
+                    }
+                },
+                work_dir=pathlib.Path("/root"),
+                project_dir=basic_project,
+                ignore_local_sources=["*.charm"],
+            )
+        ]
+    )
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
+def test_parts_without_charm_part(basic_project, charmcraft_yaml, monkeypatch):
+    """Parts are declared without a charm part.
+
+    When the "parts" section exists in chamcraft.yaml and a part named "charm"
+    is not defined, process parts normally and don't invoke the charm plugin.
+    This scenario is used to use parts processing to pack a generic hooks-based
+    charm.
+    """
+    charmcraft_yaml(
+        basic_project,
+        dedent(
+            """
+            parts:
+              foo:
+                plugin: nil
+            """
+        ),
+    )
+    config = load(basic_project)
+    monkeypatch.chdir(basic_project)
+    builder = get_builder(config, entrypoint=None)
+
+    # create a requirements.txt file
+    pathlib.Path(basic_project, "requirements.txt").write_text("ops >= 1.2.0")
+
+    monkeypatch.setenv("CHARMCRAFT_MANAGED_MODE", "1")
+    with patch("charmcraft.parts.PartsLifecycle", autospec=True) as mock_lifecycle:
+        mock_lifecycle.side_effect = SystemExit()
+        with pytest.raises(SystemExit):
+            builder.run([0])
+    mock_lifecycle.assert_has_calls(
+        [
+            call(
+                {
+                    "foo": {
+                        "plugin": "nil",
+                    }
+                },
+                work_dir=pathlib.Path("/root"),
+                project_dir=basic_project,
+                ignore_local_sources=["*.charm"],
+            )
+        ]
+    )
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
+def test_parts_with_charm_part_with_plugin(basic_project, charmcraft_yaml, monkeypatch):
+    """Parts are declared with a charm part that uses a different plugin.
+
+    When the "parts" section exists in chamcraft.yaml and a part named "charm"
+    is defined with a plugin that's not "charm", handle it as a regular part
+    without populating fields for charm building.
+    """
+    charmcraft_yaml(
+        basic_project,
+        dedent(
+            """
+            parts:
+              charm:
+                plugin: nil
+            """
+        ),
+    )
+    config = load(basic_project)
+    monkeypatch.chdir(basic_project)
+    builder = get_builder(config, entrypoint=None)
+
+    # create a requirements.txt file
+    pathlib.Path(basic_project, "requirements.txt").write_text("ops >= 1.2.0")
+
+    monkeypatch.setenv("CHARMCRAFT_MANAGED_MODE", "1")
+    with patch("charmcraft.parts.PartsLifecycle", autospec=True) as mock_lifecycle:
+        mock_lifecycle.side_effect = SystemExit()
+        with pytest.raises(SystemExit):
+            builder.run([0])
+    mock_lifecycle.assert_has_calls(
+        [
+            call(
+                {
+                    "charm": {
+                        "plugin": "nil",
+                    }
+                },
+                work_dir=pathlib.Path("/root"),
+                project_dir=basic_project,
+                ignore_local_sources=["*.charm"],
+            )
+        ]
+    )
+
+
 # --- tests for relativise helper
 
 

--- a/tests/commands/test_build.py
+++ b/tests/commands/test_build.py
@@ -2173,9 +2173,6 @@ def test_parts_without_charm_part(basic_project, charmcraft_yaml, monkeypatch):
     monkeypatch.chdir(basic_project)
     builder = get_builder(config, entrypoint=None)
 
-    # create a requirements.txt file
-    pathlib.Path(basic_project, "requirements.txt").write_text("ops >= 1.2.0")
-
     monkeypatch.setenv("CHARMCRAFT_MANAGED_MODE", "1")
     with patch("charmcraft.parts.PartsLifecycle", autospec=True) as mock_lifecycle:
         mock_lifecycle.side_effect = SystemExit()
@@ -2218,9 +2215,6 @@ def test_parts_with_charm_part_with_plugin(basic_project, charmcraft_yaml, monke
     config = load(basic_project)
     monkeypatch.chdir(basic_project)
     builder = get_builder(config, entrypoint=None)
-
-    # create a requirements.txt file
-    pathlib.Path(basic_project, "requirements.txt").write_text("ops >= 1.2.0")
 
     monkeypatch.setenv("CHARMCRAFT_MANAGED_MODE", "1")
     with patch("charmcraft.parts.PartsLifecycle", autospec=True) as mock_lifecycle:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,7 +77,9 @@ def config(tmp_path):
         def set(self, prime=None, **kwargs):
             # prime is special, so we don't need to write all this structure in all tests
             if prime is not None:
-                self.parts["charm"] = {"prime": prime}
+                if self.parts is None:
+                    self.parts = {}
+                self.parts["charm"] = {"plugin": "charm", "prime": prime}
 
             # the rest is direct
             for k, v in kwargs.items():
@@ -89,14 +91,7 @@ def config(tmp_path):
         config_provided=True,
     )
 
-    # implicit plugin is added by the validator during unmarshal
-    parts = {
-        "charm": {
-            "plugin": "charm",
-        }
-    }
-
-    return TestConfig(type="charm", parts=parts, project=project)
+    return TestConfig(type="charm", project=project)
 
 
 @pytest.fixture
@@ -109,7 +104,9 @@ def bundle_config(tmp_path):
         def set(self, prime=None, **kwargs):
             # prime is special, so we don't need to write all this structure in all tests
             if prime is not None:
-                self.parts["bundle"] = {"prime": prime}
+                if self.parts is None:
+                    self.parts = {}
+                self.parts["bundle"] = {"plugin": "bundle", "prime": prime}
 
             # the rest is direct
             for k, v in kwargs.items():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -467,6 +467,44 @@ def test_schema_additional_part(create_config, check_schema_error):
     )
 
 
+def test_schema_other_charm_part_no_source(create_config, check_schema_error):
+    """Schema validation, basic prime with bad part."""
+    create_config(
+        """
+        type: charm  # mandatory
+        parts:
+            other-part:
+                plugin: charm
+    """
+    )
+    check_schema_error(
+        dedent(
+            """\
+            Bad charmcraft.yaml content:
+            - field 'source' required in 'parts.other-part' configuration"""
+        )
+    )
+
+
+def test_schema_other_bundle_part_no_source(create_config, check_schema_error):
+    """Schema validation, basic prime with bad part."""
+    create_config(
+        """
+        type: bundle  # mandatory
+        parts:
+            other-part:
+                plugin: bundle
+    """
+    )
+    check_schema_error(
+        dedent(
+            """\
+            Bad charmcraft.yaml content:
+            - field 'source' required in 'parts.other-part' configuration"""
+        )
+    )
+
+
 # -- tests for Charmhub config
 
 

--- a/tests/test_parts.py
+++ b/tests/test_parts.py
@@ -157,10 +157,16 @@ class TestBundlePlugin:
         assert self._plugin.get_build_environment() == {}
 
     def test_get_build_commands(self, tmp_path):
-        assert self._plugin.get_build_commands() == [
-            f'mkdir -p "{str(tmp_path)}/parts/foo/install"',
-            f'cp --archive --link --no-dereference * "{str(tmp_path)}/parts/foo/install"',
-        ]
+        if sys.platform == "linux":
+            assert self._plugin.get_build_commands() == [
+                f'mkdir -p "{str(tmp_path)}/parts/foo/install"',
+                f'cp --archive --link --no-dereference * "{str(tmp_path)}/parts/foo/install"',
+            ]
+        else:
+            assert self._plugin.get_build_commands() == [
+                f'mkdir -p "{str(tmp_path)}/parts/foo/install"',
+                f'cp -R -p -P * "{str(tmp_path)}/parts/foo/install"',
+            ]
 
     def test_invalid_properties(self):
         with pytest.raises(pydantic.ValidationError) as raised:


### PR DESCRIPTION
The `charm` part is implicitly created in a charm project if no parts are specified by the user. If the toplevel `parts:` property is declared, the implicit part is not created. Do the same with the `bundle` part in bundle projects.

Fixes #590

**Note to reviewers**: tests for the following cases have been added to the charm and bundle building tests:

* No `parts` section defined
* `parts` section defined and `charm` or `bundle` part declared with additional files in `prime`.
* `parts` section defined without `charm` or `bundle` part declared. In the charm project case this can be used to create generic hooks-based charms.
* `parts` section defined and `charm` or `bundle` part declared with a non `charm` or `bundle` plugin.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>