### PR TITLE
Show more information about current credentials in the whoami command (CRAFT-651).

### DIFF
--- a/charmcraft/commands/store/client.py
+++ b/charmcraft/commands/store/client.py
@@ -127,7 +127,8 @@ class Client(craft_store.StoreClient):
 
     def _storage_push(self, monitor) -> requests.Response:
         """Push bytes to the storage."""
-        return super().post(
+        return super().request(
+            "POST",
             self.storage_base_url + "/unscanned-upload/",
             headers={"Content-Type": monitor.content_type, "Accept": "application/json"},
             data=monitor,

--- a/charmcraft/commands/store/store.py
+++ b/charmcraft/commands/store/store.py
@@ -31,7 +31,9 @@ from charmcraft.cmdbase import CommandError
 from charmcraft.commands.store.client import Client, ALTERNATE_AUTH_ENV_VAR
 
 # helpers to build responses from this layer
-User = namedtuple("User", "name username userid")
+Account = namedtuple("Account", "name username id")
+Package = namedtuple("Package", "id name type")
+MacaroonInfo = namedtuple("MacaroonInfo", "account channels packages permissions")
 Entity = namedtuple("Charm", "entity_type name private status")
 Uploaded = namedtuple("Uploaded", "ok status revision errors")
 # XXX Facundo 2020-07-23: Need to do a massive rename to call `revno` to the "revision as
@@ -210,10 +212,20 @@ class Store:
         """Return authenticated user details."""
         response = self._client.whoami()
 
-        result = User(
-            name=response["display-name"],
-            username=response["username"],
-            userid=response["id"],
+        acc = response["account"]
+        account = Account(name=acc["display-name"], username=acc["username"], id=acc["id"])
+        if response["packages"] is None:
+            packages = None
+        else:
+            packages = [
+                Package(type=pkg["type"], name=pkg.get("name"), id=pkg.get("id"))
+                for pkg in response["packages"]
+            ]
+        result = MacaroonInfo(
+            account=account,
+            packages=packages,
+            channels=response["channels"],
+            permissions=response["permissions"],
         )
         return result
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,7 @@ click==8.0.3
 coverage==6.1.2
 craft-parts==1.0.4
 craft-providers==1.0.3
-craft-store==1.1.0
+craft-store==1.2.0
 cryptography==35.0.0
 flake8==4.0.1
 humanize==3.12.0
@@ -23,6 +23,7 @@ MarkupSafe==2.0.1
 mccabe==0.6.1
 mypy-extensions==0.4.3
 ops==1.2.0
+overrides==6.1.0
 packaging==21.3
 pathspec==0.9.0
 platformdirs==2.4.0
@@ -59,6 +60,7 @@ tabulate==0.8.9
 toml==0.10.2
 tomli==1.2.2
 typing-extensions==4.0.0
+typing-utils==0.1.0
 urllib3==1.26.7
 zipp==3.6.0
 git+git://github.com/canonical/craft-cli.git@4af19f9c0da733321dc754be1180aea28f3feeb1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ cffi==1.15.0
 charset-normalizer==2.0.7
 craft-parts==1.0.4
 craft-providers==1.0.3
-craft-store==1.1.0
+craft-store==1.2.0
 cryptography==35.0.0
 humanize==3.12.0
 idna==3.3
@@ -15,6 +15,7 @@ jsonschema==4.2.1
 keyring==23.2.1
 macaroonbakery==1.3.1
 MarkupSafe==2.0.1
+overrides==6.1.0
 packaging==21.3
 protobuf==3.19.1
 pycparser==2.21
@@ -38,6 +39,7 @@ six==1.16.0
 snap-helpers==0.2.0
 tabulate==0.8.9
 typing-extensions==4.0.0
+typing-utils==0.1.0
 urllib3==1.26.7
 zipp==3.6.0
 git+git://github.com/canonical/craft-cli.git@4af19f9c0da733321dc754be1180aea28f3feeb1

--- a/tests/commands/test_store_api.py
+++ b/tests/commands/test_store_api.py
@@ -250,10 +250,19 @@ def test_logout(client_mock, config):
     assert result is None
 
 
-def test_whoami(client_mock, config):
+def test_whoami_simple(client_mock, config):
     """Simple whoami case."""
     store = Store(config.charmhub)
-    auth_response = {"display-name": "John Doe", "username": "jdoe", "id": "-1"}
+    auth_response = {
+        "account": {
+            "display-name": "John Doe",
+            "id": "3.14",
+            "username": "jdoe",
+        },
+        "channels": None,
+        "packages": None,
+        "permissions": ["perm1", "perm2"],
+    }
     client_mock.whoami.return_value = auth_response
 
     result = store.whoami()
@@ -261,9 +270,59 @@ def test_whoami(client_mock, config):
     assert client_mock.mock_calls == [
         call.whoami(),
     ]
-    assert result.name == "John Doe"
-    assert result.username == "jdoe"
-    assert result.userid == "-1"
+    assert result.account.name == "John Doe"
+    assert result.account.username == "jdoe"
+    assert result.account.id == "3.14"
+    assert result.channels is None
+    assert result.packages is None
+    assert result.permissions == ["perm1", "perm2"]
+
+
+def test_whoami_packages(client_mock, config):
+    """Whoami case that specify packages with name or id."""
+    store = Store(config.charmhub)
+    auth_response = {
+        "account": {
+            "display-name": "John Doe",
+            "id": "3.14",
+            "username": "jdoe",
+        },
+        "channels": None,
+        "packages": [
+            {"type": "charm", "id": "charmid"},
+            {"type": "bundle", "name": "bundlename"},
+        ],
+        "permissions": ["perm1", "perm2"],
+    }
+    client_mock.whoami.return_value = auth_response
+
+    result = store.whoami()
+    pkg_1, pkg_2 = result.packages
+    assert pkg_1.type == "charm"
+    assert pkg_1.id == "charmid"
+    assert pkg_1.name is None
+    assert pkg_2.type == "bundle"
+    assert pkg_2.id is None
+    assert pkg_2.name == "bundlename"
+
+
+def test_whoami_channels(client_mock, config):
+    """Whoami case with channels indicated."""
+    store = Store(config.charmhub)
+    auth_response = {
+        "account": {
+            "display-name": "John Doe",
+            "id": "3.14",
+            "username": "jdoe",
+        },
+        "channels": ["edge", "beta"],
+        "packages": None,
+        "permissions": ["perm1", "perm2"],
+    }
+    client_mock.whoami.return_value = auth_response
+
+    result = store.whoami()
+    assert result.channels == ["edge", "beta"]
 
 
 # -- tests for register and list names
@@ -1204,7 +1263,7 @@ def test_get_tips_empty(client_mock, config):
     test_lib_id = "test-lib-id"
 
     store = Store(config.charmhub)
-    client_mock.post.return_value = {"libraries": []}
+    client_mock.request_urlpath_json.return_value = {"libraries": []}
 
     query_info = [
         {"lib_id": test_lib_id},
@@ -1216,8 +1275,6 @@ def test_get_tips_empty(client_mock, config):
     ]
     assert client_mock.mock_calls == [
         call.request_urlpath_json("POST", "/v1/charm/libraries/bulk", json=payload),
-        call.request_urlpath_json().__getitem__("libraries"),
-        call.request_urlpath_json().__getitem__().__iter__(),
     ]
     assert result == {}
 
@@ -1303,7 +1360,7 @@ def test_get_tips_several(client_mock, config):
 def test_get_tips_query_combinations(client_mock, config):
     """Use all the combinations to specify what's queried."""
     store = Store(config.charmhub)
-    client_mock.post.return_value = {"libraries": []}
+    client_mock.request_urlpath_json.return_value = {"libraries": []}
 
     query_info = [
         {"lib_id": "test-lib-id-1"},
@@ -1329,8 +1386,6 @@ def test_get_tips_query_combinations(client_mock, config):
     ]
     assert client_mock.mock_calls == [
         call.request_urlpath_json("POST", "/v1/charm/libraries/bulk", json=payload),
-        call.request_urlpath_json().__getitem__("libraries"),
-        call.request_urlpath_json().__getitem__().__iter__(),
     ]
 
 

--- a/tests/commands/test_store_client.py
+++ b/tests/commands/test_store_client.py
@@ -313,8 +313,7 @@ def test_storage_push_succesful(client_class):
     )
 
     client = client_class("http://api.test", "http://test.url:0000")
-    with patch.object(client, "request") as http_request_mock:
-        client._storage_push(test_monitor)
+    client._storage_push(test_monitor)
 
     # check request was properly called
     url = "http://test.url:0000/unscanned-upload/"
@@ -322,7 +321,9 @@ def test_storage_push_succesful(client_class):
         "Content-Type": test_monitor.content_type,
         "Accept": "application/json",
     }
-    assert http_request_mock.mock_calls == [call("POST", url, headers=headers, data=test_monitor)]
+    assert client.request_mock.mock_calls == [
+        call("POST", url, headers=headers, data=test_monitor)
+    ]
 
 
 def test_alternate_auth_login_forbidden(client_class, monkeypatch):


### PR DESCRIPTION
For this I had to update the `craft-store` version, which implied a couple of unexpected API changes (very small, so I just left them here).