### PR TITLE
dispatch: Use exec to save an indermediate process

### DIFF
--- a/charmcraft/charm_builder.py
+++ b/charmcraft/charm_builder.py
@@ -45,7 +45,8 @@ DISPATCH_FILENAME = "dispatch"
 # to be the value it would've otherwise been.
 DISPATCH_CONTENT = """#!/bin/sh
 
-JUJU_DISPATCH_PATH="${{JUJU_DISPATCH_PATH:-$0}}" PYTHONPATH=lib:venv ./{entrypoint_relative_path}
+JUJU_DISPATCH_PATH="${{JUJU_DISPATCH_PATH:-$0}}" PYTHONPATH=lib:venv \\
+  exec ./{entrypoint_relative_path}
 """
 
 # The minimum set of hooks to be provided for compatibility with old Juju

--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -46,7 +46,8 @@ DISPATCH_FILENAME = "dispatch"
 # to be the value it would've otherwise been.
 DISPATCH_CONTENT = """#!/bin/sh
 
-JUJU_DISPATCH_PATH="${{JUJU_DISPATCH_PATH:-$0}}" PYTHONPATH=lib:venv ./{entrypoint_relative_path}
+JUJU_DISPATCH_PATH="${{JUJU_DISPATCH_PATH:-$0}}" PYTHONPATH=lib:venv \\
+  exec ./{entrypoint_relative_path}
 """
 
 # The minimum set of hooks to be provided for compatibility with old Juju


### PR DESCRIPTION
This will save ourselves from having an intermediate `sh` process for the duration of the hook's execution.