### PR TITLE
Massive renaming of CommandError to CraftError (CRAFT-709).

### DIFF
--- a/charmcraft/charm_builder.py
+++ b/charmcraft/charm_builder.py
@@ -25,9 +25,8 @@ import sys
 import subprocess
 from typing import List
 
-from craft_cli import emit, EmitterMode
+from craft_cli import emit, EmitterMode, CraftError
 
-from charmcraft.cmdbase import CommandError
 from charmcraft.env import get_managed_environment_log_path
 from charmcraft.jujuignore import JujuIgnore, default_juju_ignore
 from charmcraft.utils import make_executable
@@ -283,7 +282,7 @@ def _find_venv_site_packages(basedir):
 def _process_run(cmd: List[str]) -> None:
     """Run an external command logging its output.
 
-    :raises CommandError: if execution crashes or ends with return code not zero.
+    :raises CraftError: if execution crashes or ends with return code not zero.
     """
     emit.progress(f"Running external command {cmd}")
     try:
@@ -294,14 +293,14 @@ def _process_run(cmd: List[str]) -> None:
             universal_newlines=True,
         )
     except Exception as err:
-        raise CommandError(f"Subprocess execution crashed for command {cmd}") from err
+        raise CraftError(f"Subprocess execution crashed for command {cmd}") from err
 
     for line in proc.stdout:
         emit.trace(f"   :: {line.rstrip()}")
     retcode = proc.wait()
 
     if retcode:
-        raise CommandError(f"Subprocess command {cmd} execution failed with retcode {retcode}")
+        raise CraftError(f"Subprocess command {cmd} execution failed with retcode {retcode}")
 
 
 def _parse_arguments() -> argparse.Namespace:

--- a/charmcraft/cmdbase.py
+++ b/charmcraft/cmdbase.py
@@ -16,20 +16,6 @@
 
 """Infrastructure for common base commands functionality."""
 
-from craft_cli import CraftError
-
-
-class CommandError(CraftError):
-    """Base exception for all error commands.
-
-    It optionally receives a `retcode` parameter that will be the returned code
-    by the process on exit, and a `argsparsing` one to indicate that the problem
-    is in the command line usage.
-    """
-
-    def __init__(self, message, retcode=1):
-        super().__init__(message, retcode=retcode)
-
 
 class BaseCommand:
     """Base class to build charmcraft commands.

--- a/charmcraft/commands/analyze.py
+++ b/charmcraft/commands/analyze.py
@@ -22,10 +22,10 @@ import tempfile
 import textwrap
 import zipfile
 
-from craft_cli import emit
+from craft_cli import emit, CraftError
 
 from charmcraft import linters
-from charmcraft.cmdbase import BaseCommand, CommandError
+from charmcraft.cmdbase import BaseCommand
 from charmcraft.utils import useful_filepath
 
 
@@ -68,7 +68,7 @@ class AnalyzeCommand(BaseCommand):
             zf = zipfile.ZipFile(str(filepath))
             zf.extractall(path=str(tmpdir))
         except Exception as exc:
-            raise CommandError(f"Cannot open charm file {str(filepath)!r}: {exc!r}.")
+            raise CraftError(f"Cannot open charm file {str(filepath)!r}: {exc!r}.")
 
         # fix permissions as extractall does not keep them (see https://bugs.python.org/issue15795)
         for name in zf.namelist():

--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -484,9 +484,7 @@ class Builder:
                         destination=cwd / charm_name,
                     )
                 except FileNotFoundError as error:
-                    raise CraftError(
-                        "Unexpected error retrieving charm from instance."
-                    ) from error
+                    raise CraftError("Unexpected error retrieving charm from instance.") from error
 
         emit.progress("Charm packed ok")
         return charm_name

--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -22,11 +22,11 @@ import subprocess
 import zipfile
 from typing import List, Optional, Tuple
 
-from craft_cli import emit, EmitterMode
+from craft_cli import emit, EmitterMode, CraftError
 
 from charmcraft import env, linters, parts
 from charmcraft.bases import check_if_base_matches_host
-from charmcraft.cmdbase import BaseCommand, CommandError
+from charmcraft.cmdbase import BaseCommand
 from charmcraft.config import Base, BasesConfiguration, Config
 from charmcraft.deprecations import notify_deprecation
 from charmcraft.manifest import create_manifest
@@ -179,7 +179,7 @@ class Builder:
             if self.force_packing:
                 emit.message("Packing anyway as requested.", intermediate=True)
             else:
-                raise CommandError(
+                raise CraftError(
                     "Aborting due to lint errors (use --force to override).", retcode=2
                 )
 
@@ -190,7 +190,7 @@ class Builder:
 
         :returns: File name of charm.
 
-        :raises CommandError: on lifecycle exception.
+        :raises CraftError: on lifecycle exception.
         :raises RuntimeError: on unexpected lifecycle exception.
         """
         if env.is_charmcraft_running_in_managed_mode():
@@ -241,7 +241,7 @@ class Builder:
         # verify if deprecated --requirement is used and update the plugin property
         if self._special_charm_part.get("charm-requirements"):
             if self.requirement_paths:
-                raise CommandError(
+                raise CraftError(
                     "--requirement not supported when charm-requirements "
                     "specified in charmcraft.yaml"
                 )
@@ -261,7 +261,7 @@ class Builder:
         # verify if deprecated --entrypoint is used and update the plugin property
         if self._special_charm_part.get("charm-entrypoint"):
             if self.entrypoint:
-                raise CommandError(
+                raise CraftError(
                     "--entrypoint not supported when charm-entrypoint "
                     "specified in charmcraft.yaml"
                 )
@@ -383,7 +383,7 @@ class Builder:
             managed_mode=managed_mode,
         )
         if not build_plan:
-            raise CommandError(
+            raise CraftError(
                 "No suitable 'build-on' environment found in any 'bases' configuration."
             )
 
@@ -398,7 +398,7 @@ class Builder:
 
                 try:
                     charm_name = self.build_charm(bases_config)
-                except (CommandError, RuntimeError) as error:
+                except (CraftError, RuntimeError) as error:
                     if self.debug:
                         emit.trace(f"Launching shell as charm building ended in error: {error}")
                         launch_shell()
@@ -473,7 +473,7 @@ class Builder:
                     )
             except subprocess.CalledProcessError as error:
                 capture_logs_from_instance(instance)
-                raise CommandError(
+                raise CraftError(
                     f"Failed to build charm for bases index '{bases_index}'."
                 ) from error
 
@@ -484,7 +484,7 @@ class Builder:
                         destination=cwd / charm_name,
                     )
                 except FileNotFoundError as error:
-                    raise CommandError(
+                    raise CraftError(
                         "Unexpected error retrieving charm from instance."
                     ) from error
 
@@ -540,15 +540,15 @@ class Validator:
 
         for bases_index in bases_indices:
             if bases_index < 0:
-                raise CommandError(f"Bases index '{bases_index}' is invalid (must be >= 0).")
+                raise CraftError(f"Bases index '{bases_index}' is invalid (must be >= 0).")
 
             if not self.config.bases:
-                raise CommandError(
+                raise CraftError(
                     "No bases configuration found, required when using --bases-index.",
                 )
 
             if bases_index >= len(self.config.bases):
-                raise CommandError(
+                raise CraftError(
                     f"No bases configuration found for specified index '{bases_index}'."
                 )
 
@@ -571,9 +571,9 @@ class Validator:
             dirpath = dirpath.expanduser().absolute()
 
         if not dirpath.exists():
-            raise CommandError("Charm directory was not found: {!r}".format(str(dirpath)))
+            raise CraftError("Charm directory was not found: {!r}".format(str(dirpath)))
         if not dirpath.is_dir():
-            raise CommandError(
+            raise CraftError(
                 "Charm directory is not really a directory: {!r}".format(str(dirpath))
             )
 
@@ -588,13 +588,13 @@ class Validator:
         filepath = filepath.expanduser().absolute()
 
         if not filepath.exists():
-            raise CommandError("Charm entry point was not found: {!r}".format(str(filepath)))
+            raise CraftError("Charm entry point was not found: {!r}".format(str(filepath)))
         if self.basedir not in filepath.parents:
-            raise CommandError(
+            raise CraftError(
                 "Charm entry point must be inside the project: {!r}".format(str(filepath))
             )
         if not os.access(filepath, os.X_OK):
-            raise CommandError("Charm entry point must be executable: {!r}".format(str(filepath)))
+            raise CraftError("Charm entry point must be executable: {!r}".format(str(filepath)))
         return filepath
 
     def validate_requirement(self, filepaths):
@@ -608,7 +608,7 @@ class Validator:
         filepaths = [x.expanduser().absolute() for x in filepaths]
         for fpath in filepaths:
             if not fpath.exists():
-                raise CommandError("the requirements file was not found: {!r}".format(str(fpath)))
+                raise CraftError("the requirements file was not found: {!r}".format(str(fpath)))
         return filepaths
 
     def validate_shell(self, value):

--- a/charmcraft/commands/init.py
+++ b/charmcraft/commands/init.py
@@ -21,9 +21,9 @@ import re
 from datetime import date
 from typing import Optional
 
-from craft_cli import emit
+from craft_cli import emit, CraftError
 
-from charmcraft.cmdbase import BaseCommand, CommandError
+from charmcraft.cmdbase import BaseCommand
 from charmcraft.utils import make_executable, get_templates_environment
 
 try:
@@ -100,14 +100,14 @@ class InitCommand(BaseCommand):
             init_dirpath.mkdir(parents=True)
         elif any(init_dirpath.iterdir()) and not args.force:
             tpl = "{!r} is not empty (consider using --force to work on nonempty directories)"
-            raise CommandError(tpl.format(str(init_dirpath)))
+            raise CraftError(tpl.format(str(init_dirpath)))
         emit.trace(f"Using project directory {str(init_dirpath)!r}")
 
         if args.author is None and pwd is not None:
             args.author = _get_users_full_name_gecos()
 
         if not args.author:
-            raise CommandError(
+            raise CraftError(
                 "Unable to automatically determine author's name, specify it with --author"
             )
 
@@ -116,7 +116,7 @@ class InitCommand(BaseCommand):
             emit.trace(f"Set project name to '{args.name}'")
 
         if not re.match(r"[a-z][a-z0-9-]*[a-z0-9]$", args.name):
-            raise CommandError("{} is not a valid charm name".format(args.name))
+            raise CraftError("{} is not a valid charm name".format(args.name))
 
         context = {
             "name": args.name,

--- a/charmcraft/commands/pack.py
+++ b/charmcraft/commands/pack.py
@@ -141,9 +141,7 @@ class PackCommand(BaseCommand):
             if parsed_args.entrypoint is not None:
                 raise CraftError("The -e/--entry option is valid only when packing a charm")
             if parsed_args.requirement is not None:
-                raise CraftError(
-                    "The -r/--requirement option is valid only when packing a charm"
-                )
+                raise CraftError("The -r/--requirement option is valid only when packing a charm")
             self._pack_bundle(parsed_args)
         else:
             raise CraftError("Unknown type {!r} in charmcraft.yaml".format(self.config.type))

--- a/charmcraft/commands/store/__init__.py
+++ b/charmcraft/commands/store/__init__.py
@@ -927,9 +927,7 @@ def _get_lib_info(*, full_name=None, lib_path=None):
     charm_name = create_charm_name_from_importable(importable_charm_name)
 
     if v_api[0] != "v" or not v_api[1:].isdigit():
-        raise CraftError(
-            "The API version in the library path must be 'vN' where N is an integer."
-        )
+        raise CraftError("The API version in the library path must be 'vN' where N is an integer.")
     api_from_path = int(v_api[1:])
 
     lib_name = lib_path.stem
@@ -956,9 +954,7 @@ def _get_lib_info(*, full_name=None, lib_path=None):
                 try:
                     field, value = [x.strip() for x in line.split(b"=")]
                 except ValueError:
-                    raise CraftError(
-                        "Bad metadata line in {!r}: {!r}".format(str(lib_path), line)
-                    )
+                    raise CraftError("Bad metadata line in {!r}: {!r}".format(str(lib_path), line))
                 metadata[field] = value
             else:
                 hasher.update(line)
@@ -1121,9 +1117,7 @@ class CreateLibCommand(BaseCommand):
             lib_path.parent.mkdir(parents=True, exist_ok=True)
             lib_path.write_text(template.render(context))
         except OSError as exc:
-            raise CraftError(
-                "Error writing the library in {!r}: {!r}.".format(str(lib_path), exc)
-            )
+            raise CraftError("Error writing the library in {!r}: {!r}.".format(str(lib_path), exc))
 
         emit.message(f"Library {full_name} created with id {lib_id}.")
         emit.message(f"Consider 'git add {lib_path}'.")

--- a/charmcraft/commands/store/registry.py
+++ b/charmcraft/commands/store/registry.py
@@ -31,8 +31,6 @@ import requests
 import requests_unixsocket
 from craft_cli import emit, CraftError
 
-from charmcraft.cmdbase import CommandError
-
 # some mimetypes
 CONFIG_MIMETYPE = "application/vnd.docker.container.image.v1+json"
 MANIFEST_V2_MIMETYPE = "application/vnd.docker.distribution.manifest.v2+json"
@@ -71,7 +69,7 @@ def assert_response_ok(
 
     result = response.json()
     if "errors" in result:
-        raise CommandError("Response with errors from server: {}".format(result["errors"]))
+        raise CraftError("Response with errors from server: {}".format(result["errors"]))
     return result
 
 
@@ -137,7 +135,7 @@ class OCIRegistry:
             try:
                 auth_info = self._get_auth_info(response)
             except (ValueError, KeyError) as exc:
-                raise CommandError(
+                raise CraftError(
                     "Bad 401 response: {}; headers: {!r}".format(exc, response.headers)
                 )
             self.auth_token = self._authenticate(auth_info)
@@ -258,7 +256,7 @@ class OCIRegistry:
         assert_response_ok(response, expected_status=201)
         emit.progress("Upload finished OK")
         if response.headers["Docker-Content-Digest"] != digest:
-            raise CommandError("Server error: the upload is corrupted")
+            raise CraftError("Server error: the upload is corrupted")
 
 
 class HashingTemporaryFile(io.FileIO):

--- a/charmcraft/commands/store/store.py
+++ b/charmcraft/commands/store/store.py
@@ -155,9 +155,7 @@ def _store_client_wrapper(auto_login=True):
                             "Regenerate them and try again."
                         )
                     if not auto_login:
-                        raise CraftError(
-                            "Existing credentials are no longer valid for Charmhub."
-                        )
+                        raise CraftError("Existing credentials are no longer valid for Charmhub.")
                     emit.progress("Existing credentials no longer valid. Trying to log in...")
                 else:
                     raise CraftError(str(error)) from error

--- a/charmcraft/commands/store/store.py
+++ b/charmcraft/commands/store/store.py
@@ -23,11 +23,10 @@ from collections import namedtuple
 from functools import wraps
 
 import craft_store
-from craft_cli import emit
+from craft_cli import emit, CraftError
 from craft_store import attenuations, endpoints
 from dateutil import parser
 
-from charmcraft.cmdbase import CommandError
 from charmcraft.commands.store.client import Client, ALTERNATE_AUTH_ENV_VAR
 
 # helpers to build responses from this layer
@@ -151,19 +150,19 @@ def _store_client_wrapper(auto_login=True):
             except craft_store.errors.StoreServerError as error:
                 if error.response.status_code == 401:
                     if os.getenv(ALTERNATE_AUTH_ENV_VAR):
-                        raise CommandError(
+                        raise CraftError(
                             "Provided credentials are no longer valid for Charmhub. "
                             "Regenerate them and try again."
                         )
                     if not auto_login:
-                        raise CommandError(
+                        raise CraftError(
                             "Existing credentials are no longer valid for Charmhub."
                         )
                     emit.progress("Existing credentials no longer valid. Trying to log in...")
                 else:
-                    raise CommandError(str(error)) from error
+                    raise CraftError(str(error)) from error
             except craft_store.errors.CraftStoreError as error:
-                raise CommandError(
+                raise CraftError(
                     f"Server error while communicating to the Store: {error!s}"
                 ) from error
 
@@ -210,7 +209,7 @@ class Store:
         try:
             return self._client.login(**kwargs)
         except craft_store.errors.CraftStoreError as error:
-            raise CommandError(str(error)) from error
+            raise CraftError(str(error)) from error
 
     def logout(self):
         """Logout from the store.

--- a/charmcraft/config.py
+++ b/charmcraft/config.py
@@ -71,8 +71,8 @@ import pathlib
 from typing import Any, Dict, List, Optional, Tuple
 
 import pydantic
+from craft_cli import CraftError
 
-from charmcraft.cmdbase import CommandError
 from charmcraft.deprecations import notify_deprecation
 from charmcraft.env import (
     get_managed_environment_project_path,
@@ -384,7 +384,7 @@ class Config(ModelConfigDefaults, validate_all=False):
                 for pydantic_error in pydantic_errors:
                     pydantic_error["loc"] = ("bases", index, pydantic_error["loc"][0])
 
-                raise CommandError(format_pydantic_errors(pydantic_errors))
+                raise CraftError(format_pydantic_errors(pydantic_errors))
 
             base.clear()
             base["build-on"] = [converted_base.dict()]
@@ -400,7 +400,7 @@ class Config(ModelConfigDefaults, validate_all=False):
 
         :returns: valid CharmcraftConfig.
 
-        :raises CommandError: On failure to unmarshal object.
+        :raises CraftError: On failure to unmarshal object.
         """
         try:
             # Ensure optional type is specified if loading the yaml.
@@ -432,7 +432,7 @@ class Config(ModelConfigDefaults, validate_all=False):
 
             return cls.parse_obj({"project": project, **obj})
         except pydantic.error_wrappers.ValidationError as error:
-            raise CommandError(format_pydantic_errors(error.errors()))
+            raise CraftError(format_pydantic_errors(error.errors()))
 
     @classmethod
     def schema(cls, **kwargs) -> Dict[str, Any]:

--- a/charmcraft/main.py
+++ b/charmcraft/main.py
@@ -24,7 +24,6 @@ from collections import namedtuple
 from craft_cli import emit, EmitterMode, CraftError
 
 from charmcraft import config, __version__
-from charmcraft.cmdbase import CommandError
 from charmcraft.commands import build, clean, init, pack, store, version, analyze
 from charmcraft.helptexts import help_builder
 from charmcraft.parts import setup_parts
@@ -389,7 +388,7 @@ def main(argv=None):
         print(err, file=sys.stderr)  # to stderr, as argparse normally does
         emit.ended_ok()
         retcode = 0
-    except CommandError as err:
+    except CraftError as err:
         emit.error(err)
         retcode = err.retcode
     except KeyboardInterrupt as exc:

--- a/charmcraft/metadata.py
+++ b/charmcraft/metadata.py
@@ -21,9 +21,8 @@ from typing import Any, Dict
 
 import pydantic
 import yaml
-from craft_cli import emit
+from craft_cli import emit, CraftError
 
-from charmcraft.cmdbase import CommandError
 from charmcraft.config import format_pydantic_errors
 
 CHARM_METADATA = "metadata.yaml"
@@ -42,12 +41,12 @@ class CharmMetadata(pydantic.BaseModel, frozen=True, validate_all=True):
 
         :returns: valid CharmMetadata.
 
-        :raises CommandError: On failure to unmarshal object.
+        :raises CraftError: On failure to unmarshal object.
         """
         try:
             return cls.parse_obj(obj)
         except pydantic.error_wrappers.ValidationError as error:
-            raise CommandError(format_pydantic_errors(error.errors(), file_name=CHARM_METADATA))
+            raise CraftError(format_pydantic_errors(error.errors(), file_name=CHARM_METADATA))
 
 
 def parse_metadata_yaml(charm_dir: pathlib.Path) -> CharmMetadata:
@@ -55,13 +54,13 @@ def parse_metadata_yaml(charm_dir: pathlib.Path) -> CharmMetadata:
 
     :returns: a CharmMetadata object.
 
-    :raises: CommandError if metadata does not exist.
+    :raises: CraftError if metadata does not exist.
     """
     metadata_path = charm_dir / CHARM_METADATA
     emit.trace(f"Parsing {str(metadata_path)!r}")
 
     if not metadata_path.exists():
-        raise CommandError("Missing mandatory metadata.yaml.")
+        raise CraftError("Missing mandatory metadata.yaml.")
 
     with metadata_path.open("rt", encoding="utf8") as fh:
         metadata = yaml.safe_load(fh)

--- a/charmcraft/parts.py
+++ b/charmcraft/parts.py
@@ -22,14 +22,13 @@ import shlex
 import sys
 from typing import Any, Dict, List, Set, cast
 
-from craft_cli import emit
+from craft_cli import emit, CraftError
 from craft_parts import LifecycleManager, Step, plugins
 from craft_parts.errors import PartsError
 from craft_parts.parts import PartSpec
 from xdg import BaseDirectory  # type: ignore
 
 from charmcraft import charm_builder
-from charmcraft.cmdbase import CommandError
 from charmcraft.reactive_plugin import ReactivePlugin
 
 
@@ -285,7 +284,7 @@ class PartsLifecycle:
                 project_name=project_name,
             )
         except PartsError as err:
-            raise CommandError(f"Error bootstrapping lifecycle manager: {err}") from err
+            raise CraftError(f"Error bootstrapping lifecycle manager: {err}") from err
 
     @property
     def prime_dir(self) -> pathlib.Path:
@@ -297,7 +296,7 @@ class PartsLifecycle:
 
         :param target_step: The final step to execute.
 
-        :raises CommandError: On error during lifecycle ops.
+        :raises CraftError: On error during lifecycle ops.
         :raises RuntimeError: On unexpected error.
         """
         previous_dir = os.getcwd()
@@ -325,9 +324,9 @@ class PartsLifecycle:
             msg = err.strerror
             if err.filename:
                 msg = f"{err.filename}: {msg}"
-            raise CommandError(f"Parts processing error: {msg}") from err
+            raise CraftError(f"Parts processing error: {msg}") from err
         except Exception as err:
-            raise CommandError(f"Parts processing error: {err}") from err
+            raise CraftError(f"Parts processing error: {err}") from err
         finally:
             os.chdir(previous_dir)
 

--- a/charmcraft/providers/_get_provider.py
+++ b/charmcraft/providers/_get_provider.py
@@ -19,7 +19,8 @@
 import os
 import sys
 
-from charmcraft.cmdbase import CommandError
+from craft_cli import CraftError
+
 from charmcraft.env import is_charmcraft_running_from_snap, is_charmcraft_running_in_developer_mode
 from charmcraft.snap import get_snap_configuration
 
@@ -65,4 +66,4 @@ def get_provider():
     elif provider == "multipass":
         return MultipassProvider()
 
-    raise CommandError(f"Unsupported provider specified {provider!r}.")
+    raise CraftError(f"Unsupported provider specified {provider!r}.")

--- a/charmcraft/providers/_provider.py
+++ b/charmcraft/providers/_provider.py
@@ -56,7 +56,7 @@ class Provider(ABC):
     def ensure_provider_is_available(cls) -> None:
         """Ensure provider is available, prompting the user to install it if required.
 
-        :raises CommandError: if provider is not available.
+        :raises CraftError: if provider is not available.
         """
 
     def get_command_environment(self) -> Dict[str, str]:

--- a/charmcraft/utils.py
+++ b/charmcraft/utils.py
@@ -25,10 +25,9 @@ from dataclasses import dataclass
 from stat import S_IRGRP, S_IROTH, S_IRUSR, S_IXGRP, S_IXOTH, S_IXUSR
 
 import yaml
-from craft_cli import emit
+from craft_cli import emit, CraftError
 from jinja2 import Environment, FileSystemLoader, PackageLoader, StrictUndefined
 
-from charmcraft.cmdbase import CommandError
 from charmcraft.env import is_charmcraft_running_in_managed_mode
 
 OSPlatform = namedtuple("OSPlatform", "system release machine")
@@ -155,13 +154,13 @@ class ResourceOption:
 def useful_filepath(filepath):
     """Return a valid Path with user name expansion for filepath.
 
-    CommandError is raised if filepath is not a valid file or is not readable.
+    CraftError is raised if filepath is not a valid file or is not readable.
     """
     filepath = pathlib.Path(filepath).expanduser()
     if not os.access(filepath, os.R_OK):
-        raise CommandError("Cannot access {!r}.".format(str(filepath)))
+        raise CraftError("Cannot access {!r}.".format(str(filepath)))
     if not filepath.is_file():
-        raise CommandError("{!r} is not a file.".format(str(filepath)))
+        raise CraftError("{!r} is not a file.".format(str(filepath)))
     return filepath
 
 

--- a/tests/commands/test_analyze.py
+++ b/tests/commands/test_analyze.py
@@ -21,9 +21,9 @@ from argparse import Namespace, ArgumentParser
 from unittest.mock import patch, ANY
 
 import pytest
+from craft_cli import CraftError
 
 from charmcraft import linters
-from charmcraft.cmdbase import CommandError
 from charmcraft.commands.analyze import AnalyzeCommand, JSON_FORMAT
 from charmcraft.utils import useful_filepath
 
@@ -107,7 +107,7 @@ def test_corrupt_charm(tmp_path, config):
     charm_file.write_text("this is not a real zip content")
 
     args = Namespace(filepath=charm_file, force=None, format=None)
-    with pytest.raises(CommandError) as cm:
+    with pytest.raises(CraftError) as cm:
         AnalyzeCommand(config).run(args)
     assert str(cm.value) == (
         "Cannot open charm file '{}': BadZipFile('File is not a zip file').".format(charm_file)

--- a/tests/commands/test_init.py
+++ b/tests/commands/test_init.py
@@ -22,8 +22,8 @@ from argparse import Namespace
 from unittest.mock import patch
 
 import pytest
+from craft_cli import CraftError
 
-from charmcraft.cmdbase import CommandError
 from charmcraft.commands.init import InitCommand
 from charmcraft.config import Project
 from charmcraft.utils import S_IXALL
@@ -99,7 +99,7 @@ def test_force(tmp_path, config):
 
 def test_bad_name(config):
     cmd = InitCommand(config)
-    with pytest.raises(CommandError):
+    with pytest.raises(CraftError):
         cmd.run(Namespace(name="1234", author="שראלה ישראל", force=False))
 
 
@@ -154,7 +154,7 @@ def test_gecos_missing_in_getpwuid_response(config):
         # return a fack passwd struct with an empty gecos (5th parameter)
         mock_pwd.return_value = pwd.struct_passwd(("user", "pass", 1, 1, "", "dir", "shell"))
         msg = "Unable to automatically determine author's name, specify it with --author"
-        with pytest.raises(CommandError, match=msg):
+        with pytest.raises(CraftError, match=msg):
             cmd.run(Namespace(name="my-charm", author=None, force=False))
 
 
@@ -166,7 +166,7 @@ def test_gecos_missing_user_information(config):
     with patch("pwd.getpwuid") as mock_pwd:
         mock_pwd.side_effect = KeyError("no user")
         msg = "Unable to automatically determine author's name, specify it with --author"
-        with pytest.raises(CommandError, match=msg):
+        with pytest.raises(CraftError, match=msg):
             cmd.run(Namespace(name="my-charm", author=None, force=False))
 
 

--- a/tests/commands/test_store_client.py
+++ b/tests/commands/test_store_client.py
@@ -24,9 +24,9 @@ from unittest.mock import call, patch
 import craft_store
 import pytest
 import requests
+from craft_cli import CraftError
 from requests_toolbelt import MultipartEncoder, MultipartEncoderMonitor
 
-from charmcraft.cmdbase import CommandError
 from charmcraft.commands.store.client import (
     Client,
     build_user_agent,
@@ -176,7 +176,7 @@ def test_client_request_text_error(client_class):
     store_error = craft_store.errors.CraftStoreError(original_error_text)
     client.request_mock.side_effect = store_error
 
-    with pytest.raises(CommandError) as cm:
+    with pytest.raises(CraftError) as cm:
         client.request_urlpath_text("GET", "/somepath")
     exc = cm.value
     assert str(exc) == original_error_text
@@ -190,7 +190,7 @@ def test_client_request_json_error(client_class):
     store_error = craft_store.errors.CraftStoreError(original_error_text)
     client.request_mock.side_effect = store_error
 
-    with pytest.raises(CommandError) as cm:
+    with pytest.raises(CraftError) as cm:
         client.request_urlpath_json("GET", "/somepath")
     exc = cm.value
     assert str(exc) == original_error_text
@@ -298,7 +298,7 @@ def test_client_push_response_unsuccessful(tmp_path, client_class):
 
     client = client_class("http://api.test", "https://local.test:1234/")
     with patch.object(client, "_storage_push", return_value=fake_response):
-        with pytest.raises(CommandError) as error:
+        with pytest.raises(CraftError) as error:
             client.push_file(test_filepath)
             expected_error = (
                 "Server error while pushing file: {'successful': False, 'upload_id': None}"
@@ -330,7 +330,7 @@ def test_alternate_auth_login_forbidden(client_class, monkeypatch):
     """Login functionality cannot be used if alternate auth is present."""
     monkeypatch.setenv("CHARMCRAFT_AUTH", ENCODED_CREDENTIALS)
     client = client_class("http://api.test", "http://storage.test")
-    with pytest.raises(CommandError) as cm:
+    with pytest.raises(CraftError) as cm:
         client.login()
     expected_error = (
         "Cannot login when using alternative auth through CHARMCRAFT_AUTH environment variable."
@@ -342,7 +342,7 @@ def test_alternate_auth_logout_forbidden(client_class, monkeypatch):
     """Logout functionality cannot be used if alternate auth is present."""
     monkeypatch.setenv("CHARMCRAFT_AUTH", ENCODED_CREDENTIALS)
     client = client_class("http://api.test", "http://storage.test")
-    with pytest.raises(CommandError) as cm:
+    with pytest.raises(CraftError) as cm:
         client.logout()
     expected_error = (
         "Cannot logout when using alternative auth through CHARMCRAFT_AUTH environment variable."

--- a/tests/commands/test_store_registry.py
+++ b/tests/commands/test_store_registry.py
@@ -29,7 +29,6 @@ import pytest
 import requests
 from craft_cli import CraftError
 
-from charmcraft.cmdbase import CommandError
 from charmcraft.commands.store import registry
 from charmcraft.commands.store.registry import (
     CONFIG_MIMETYPE,
@@ -94,7 +93,7 @@ def test_assert_response_errors_in_result():
     errors = [{"foo": "bar"}]
     test_content = {"errors": errors}
     response = create_response(json_content=test_content)
-    with pytest.raises(CommandError) as cm:
+    with pytest.raises(CraftError) as cm:
         assert_response_ok(response)
     assert str(cm.value) == "Response with errors from server: {}".format(errors)
 
@@ -272,7 +271,7 @@ def test_hit_simple_re_auth_problems(responses):
     expected = (
         "Bad 401 response: Bearer not found; " "headers: {.*'Www-Authenticate': 'broken header'.*}"
     )
-    with pytest.raises(CommandError, match=expected):
+    with pytest.raises(CraftError, match=expected):
         ocireg._hit("GET", "https://fakereg.com/api/stuff")
 
 
@@ -730,7 +729,7 @@ def test_ociregistry_upload_blob_bad_final_digest(tmp_path, responses):
 
     # call!
     msg = "Server error: the upload is corrupted"
-    with pytest.raises(CommandError, match=msg):
+    with pytest.raises(CraftError, match=msg):
         ocireg.upload_blob(bytes_source, 8, "test-digest")
 
 

--- a/tests/providers/test_lxd.py
+++ b/tests/providers/test_lxd.py
@@ -20,11 +20,11 @@ from unittest import mock
 from unittest.mock import call
 
 import pytest
+from craft_cli import CraftError
 from craft_providers import bases
 from craft_providers.lxd import LXDError, LXDInstallationError
 
 from charmcraft import providers
-from charmcraft.cmdbase import CommandError
 from charmcraft.config import Base
 
 
@@ -191,7 +191,7 @@ def test_clean_project_environments_list_failure(mock_lxc, mock_path):
     mock_lxc.list_names.side_effect = LXDError(brief="fail")
     provider = providers.LXDProvider(lxc=mock_lxc)
 
-    with pytest.raises(CommandError, match="fail"):
+    with pytest.raises(CraftError, match="fail"):
         provider.clean_project_environments(
             charm_name="charm",
             project_path=mock_path,
@@ -204,7 +204,7 @@ def test_clean_project_environments_delete_failure(mock_lxc, mock_path):
     mock_lxc.delete.side_effect = error
     provider = providers.LXDProvider(lxc=mock_lxc)
 
-    with pytest.raises(CommandError, match="fail") as exc_info:
+    with pytest.raises(CraftError, match="fail") as exc_info:
         provider.clean_project_environments(
             charm_name="testcharm",
             project_path=mock_path,
@@ -228,7 +228,7 @@ def test_ensure_provider_is_available_errors_when_user_declines(
     provider = providers.LXDProvider()
 
     with pytest.raises(
-        CommandError,
+        CraftError,
         match=re.escape(
             "LXD is required, but not installed. Visit https://snapcraft.io/lxd for "
             "instructions on how to install the LXD snap for your distribution"
@@ -255,7 +255,7 @@ def test_ensure_provider_is_available_errors_when_lxd_install_fails(
     provider = providers.LXDProvider()
 
     with pytest.raises(
-        CommandError,
+        CraftError,
         match=re.escape(
             "Failed to install LXD. Visit https://snapcraft.io/lxd for "
             "instructions on how to install the LXD snap for your distribution"
@@ -283,7 +283,7 @@ def test_ensure_provider_is_available_errors_when_lxd_not_ready(
     provider = providers.LXDProvider()
 
     with pytest.raises(
-        CommandError,
+        CraftError,
         match=re.escape("some error\nsome details\nsome resolution"),
     ) as exc_info:
         provider.ensure_provider_is_available()
@@ -471,7 +471,7 @@ def test_launched_environment_launch_base_configuration_error(
     base = Base(name="ubuntu", channel="20.04", architectures=["host-arch"])
     provider = providers.LXDProvider()
 
-    with pytest.raises(CommandError, match="fail") as exc_info:
+    with pytest.raises(CraftError, match="fail") as exc_info:
         with provider.launched_environment(
             charm_name="test-charm",
             project_path=tmp_path,
@@ -492,7 +492,7 @@ def test_launched_environment_launch_lxd_error(
     base = Base(name="ubuntu", channel="20.04", architectures=["host-arch"])
     provider = providers.LXDProvider()
 
-    with pytest.raises(CommandError, match="fail") as exc_info:
+    with pytest.raises(CraftError, match="fail") as exc_info:
         with provider.launched_environment(
             charm_name="test-charm",
             project_path=tmp_path,
@@ -536,7 +536,7 @@ def test_launched_environment_unmount_all_error(
     base = Base(name="ubuntu", channel="20.04", architectures=["host-arch"])
     provider = providers.LXDProvider()
 
-    with pytest.raises(CommandError, match="fail") as exc_info:
+    with pytest.raises(CraftError, match="fail") as exc_info:
         with provider.launched_environment(
             charm_name="test-charm",
             project_path=tmp_path,
@@ -557,7 +557,7 @@ def test_launched_environment_stop_error(
     base = Base(name="ubuntu", channel="20.04", architectures=["host-arch"])
     provider = providers.LXDProvider()
 
-    with pytest.raises(CommandError, match="fail") as exc_info:
+    with pytest.raises(CraftError, match="fail") as exc_info:
         with provider.launched_environment(
             charm_name="test-charm",
             project_path=tmp_path,

--- a/tests/providers/test_multipass.py
+++ b/tests/providers/test_multipass.py
@@ -20,11 +20,11 @@ from unittest import mock
 from unittest.mock import call
 
 import pytest
+from craft_cli import CraftError
 from craft_providers import bases
 from craft_providers.multipass import MultipassError, MultipassInstallationError
 
 from charmcraft import providers
-from charmcraft.cmdbase import CommandError
 from charmcraft.config import Base
 
 
@@ -179,7 +179,7 @@ def test_clean_project_environments_list_failure(mock_multipass, mock_path):
     mock_multipass.list.side_effect = error
     provider = providers.MultipassProvider(multipass=mock_multipass)
 
-    with pytest.raises(CommandError, match="fail") as exc_info:
+    with pytest.raises(CraftError, match="fail") as exc_info:
         provider.clean_project_environments(
             charm_name="charm",
             project_path=mock_path,
@@ -194,7 +194,7 @@ def test_clean_project_environments_delete_failure(mock_multipass, mock_path):
     mock_multipass.delete.side_effect = error
     provider = providers.MultipassProvider(multipass=mock_multipass)
 
-    with pytest.raises(CommandError, match="fail") as exc_info:
+    with pytest.raises(CraftError, match="fail") as exc_info:
         provider.clean_project_environments(
             charm_name="testcharm",
             project_path=mock_path,
@@ -221,7 +221,7 @@ def test_ensure_provider_is_available_errors_when_user_declines(
         "Multipass is required, but not installed. Visit https://multipass.run/ for "
         "instructions on installing Multipass for your operating system."
     )
-    with pytest.raises(CommandError, match=match):
+    with pytest.raises(CraftError, match=match):
         provider.ensure_provider_is_available()
 
     assert mock_confirm_with_user.mock_calls == [
@@ -246,7 +246,7 @@ def test_ensure_provider_is_available_errors_when_multipass_install_fails(
         "Failed to install Multipass. Visit https://multipass.run/ for "
         "instructions on installing Multipass for your operating system."
     )
-    with pytest.raises(CommandError, match=match) as exc_info:
+    with pytest.raises(CraftError, match=match) as exc_info:
         provider.ensure_provider_is_available()
 
     assert mock_confirm_with_user.mock_calls == [
@@ -274,7 +274,7 @@ def test_ensure_provider_is_available_errors_when_multipass_not_ready(
     provider = providers.MultipassProvider()
 
     with pytest.raises(
-        CommandError,
+        CraftError,
         match=re.escape("some error\nsome details\nsome resolution"),
     ) as exc_info:
         provider.ensure_provider_is_available()
@@ -480,7 +480,7 @@ def test_launched_environment_launch_base_configuration_error(
     base = Base(name="ubuntu", channel="20.04", architectures=["host-arch"])
     provider = providers.MultipassProvider()
 
-    with pytest.raises(CommandError, match="fail") as exc_info:
+    with pytest.raises(CraftError, match="fail") as exc_info:
         with provider.launched_environment(
             charm_name="test-charm",
             project_path=tmp_path,
@@ -501,7 +501,7 @@ def test_launched_environment_launch_multipass_error(
     base = Base(name="ubuntu", channel="20.04", architectures=["host-arch"])
     provider = providers.MultipassProvider()
 
-    with pytest.raises(CommandError, match="fail") as exc_info:
+    with pytest.raises(CraftError, match="fail") as exc_info:
         with provider.launched_environment(
             charm_name="test-charm",
             project_path=tmp_path,
@@ -522,7 +522,7 @@ def test_launched_environment_unmount_all_error(
     base = Base(name="ubuntu", channel="20.04", architectures=["host-arch"])
     provider = providers.MultipassProvider()
 
-    with pytest.raises(CommandError, match="fail") as exc_info:
+    with pytest.raises(CraftError, match="fail") as exc_info:
         with provider.launched_environment(
             charm_name="test-charm",
             project_path=tmp_path,
@@ -543,7 +543,7 @@ def test_launched_environment_stop_error(
     base = Base(name="ubuntu", channel="20.04", architectures=["host-arch"])
     provider = providers.MultipassProvider()
 
-    with pytest.raises(CommandError, match="fail") as exc_info:
+    with pytest.raises(CraftError, match="fail") as exc_info:
         with provider.launched_environment(
             charm_name="test-charm",
             project_path=tmp_path,

--- a/tests/test_charm_builder.py
+++ b/tests/test_charm_builder.py
@@ -23,10 +23,10 @@ import sys
 from unittest.mock import call, patch
 
 import pytest
+from craft_cli import CraftError
 
 from charmcraft import charm_builder
 from charmcraft.charm_builder import STAGING_VENV_DIRNAME, VENV_DIRNAME, CharmBuilder, _process_run
-from charmcraft.cmdbase import CommandError
 from charmcraft.commands.build import BUILD_DIRNAME, DISPATCH_CONTENT, DISPATCH_FILENAME
 from charmcraft.metadata import CHARM_METADATA
 
@@ -903,7 +903,7 @@ def test_processrun_stderr_logged(emitter):
 def test_processrun_failed():
     """It's logged in error if cmd fails."""
     cmd = [sys.executable, "-c", "exit(3)"]
-    with pytest.raises(CommandError) as cm:
+    with pytest.raises(CraftError) as cm:
         _process_run(cmd)
     assert str(cm.value) == f"Subprocess command {cmd} execution failed with retcode 3"
 
@@ -912,7 +912,7 @@ def test_processrun_crashed(tmp_path):
     """It's logged in error if cmd fails."""
     nonexistent = tmp_path / "whatever"
     cmd = [str(nonexistent)]
-    with pytest.raises(CommandError) as cm:
+    with pytest.raises(CraftError) as cm:
         _process_run(cmd)
     assert str(cm.value) == f"Subprocess execution crashed for command {cmd}"
 

--- a/tests/test_cmdbase.py
+++ b/tests/test_cmdbase.py
@@ -17,20 +17,21 @@
 """Tests for the commands infraestructure."""
 
 import pytest
+from craft_cli import CraftError
 
-from charmcraft.cmdbase import CommandError, BaseCommand
+from charmcraft.cmdbase import BaseCommand
 from charmcraft.main import COMMAND_GROUPS
 
 
 def test_commanderror_retcode_default():
-    """The CommandError return code default."""
-    err = CommandError("problem")
+    """The CraftError return code default."""
+    err = CraftError("problem")
     assert err.retcode == 1
 
 
 def test_commanderror_retcode_given():
-    """The CommandError holds the return code."""
-    err = CommandError("problem", retcode=4)
+    """The CraftError holds the return code."""
+    err = CraftError("problem", retcode=4)
     assert err.retcode == 4
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -22,9 +22,9 @@ from textwrap import dedent
 from unittest.mock import patch
 
 import pytest
+from craft_cli import CraftError
 
 from charmcraft import linters
-from charmcraft.cmdbase import CommandError
 from charmcraft.config import Base, BasesConfiguration, CharmhubConfig, load
 from charmcraft.utils import get_host_architecture
 
@@ -140,7 +140,7 @@ def check_schema_error(tmp_path):
         which of the verifications it will fail. After 3.5 is dropped this could be changed
         to receive only one message and compare with equality below, not inclusion.
         """
-        with pytest.raises(CommandError) as cm:
+        with pytest.raises(CraftError) as cm:
             load(tmp_path)
         assert str(cm.value) == expected_msg
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -34,7 +34,7 @@ from charmcraft.main import (
     ProvideHelpException,
     main,
 )
-from charmcraft.cmdbase import BaseCommand, CommandError
+from charmcraft.cmdbase import BaseCommand
 from tests.factory import create_command
 
 
@@ -463,8 +463,8 @@ def test_main_no_args():
 
 
 def test_main_controlled_error():
-    """Work raised CommandError: message handler notified properly, use indicated return code."""
-    simulated_exception = CommandError("boom", retcode=33)
+    """Work raised CraftError: message handler notified properly, use indicated return code."""
+    simulated_exception = CraftError("boom", retcode=33)
     with patch("charmcraft.main.emit") as emit_mock:
         with patch("charmcraft.main.Dispatcher.run") as d_mock:
             d_mock.side_effect = simulated_exception

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -18,8 +18,8 @@ import re
 from textwrap import dedent
 
 import pytest
+from craft_cli import CraftError
 
-from charmcraft.cmdbase import CommandError
 from charmcraft.metadata import parse_metadata_yaml
 
 
@@ -61,10 +61,10 @@ def test_parse_metadata_yaml_error_invalid_names(tmp_path, name):
         Bad metadata.yaml content:
         - string type expected in field 'name'"""
     )
-    with pytest.raises(CommandError, match=re.escape(expected_error_msg)):
+    with pytest.raises(CraftError, match=re.escape(expected_error_msg)):
         parse_metadata_yaml(tmp_path)
 
 
 def test_parse_metadata_yaml_error_missing(tmp_path):
-    with pytest.raises(CommandError, match=r"Missing mandatory metadata.yaml."):
+    with pytest.raises(CraftError, match=r"Missing mandatory metadata.yaml."):
         parse_metadata_yaml(tmp_path)

--- a/tests/test_parts.py
+++ b/tests/test_parts.py
@@ -21,11 +21,11 @@ from unittest.mock import patch
 import craft_parts
 import pydantic
 import pytest
+from craft_cli import CraftError
 from craft_parts import Step, plugins
 from craft_parts.errors import PartsError
 
 from charmcraft import charm_builder, parts
-from charmcraft.cmdbase import CommandError
 
 
 pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
@@ -184,7 +184,7 @@ class TestPartsLifecycle:
         fake_error = PartsError("pumba")
         with patch("craft_parts.LifecycleManager.__init__") as mock:
             mock.side_effect = fake_error
-            with pytest.raises(CommandError) as cm:
+            with pytest.raises(CraftError) as cm:
                 parts.PartsLifecycle(
                     all_parts={},
                     work_dir="/some/workdir",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -21,8 +21,8 @@ from textwrap import dedent
 from unittest.mock import call, patch
 
 import pytest
+from craft_cli import CraftError
 
-from charmcraft.cmdbase import CommandError
 from charmcraft.utils import (
     ResourceOption,
     SingleOptionEnsurer,
@@ -204,7 +204,7 @@ def test_usefulfilepath_home_expanded(tmp_path, monkeypatch):
 
 def test_usefulfilepath_missing():
     """The indicated path is not there."""
-    with pytest.raises(CommandError) as cm:
+    with pytest.raises(CraftError) as cm:
         useful_filepath("not_really_there.txt")
     assert str(cm.value) == "Cannot access 'not_really_there.txt'."
 
@@ -214,14 +214,14 @@ def test_usefulfilepath_inaccessible(tmp_path):
     """The indicated path is not readable."""
     test_file = tmp_path / "testfile.bin"
     test_file.touch(mode=0o000)
-    with pytest.raises(CommandError) as cm:
+    with pytest.raises(CraftError) as cm:
         useful_filepath(str(test_file))
     assert str(cm.value) == "Cannot access {!r}.".format(str(test_file))
 
 
 def test_usefulfilepath_not_a_file(tmp_path):
     """The indicated path is not a file."""
-    with pytest.raises(CommandError) as cm:
+    with pytest.raises(CraftError) as cm:
         useful_filepath(str(tmp_path))
     assert str(cm.value) == "{!r} is not a file.".format(str(tmp_path))
 


### PR DESCRIPTION
The only "real changes" are the import changes from cmdbase to craft_cli, and of course the removal of the no longer used CommandError definition.