### PR TITLE
add prometheus charm pack test

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -232,6 +232,7 @@ jobs:
             echo "configure script failure"
             exit 1
           fi
+          sudo snap set charmcraft provider=lxd
       - name: Test building the prometheus-k8s-charm
         run: |
           git clone https://github.com/canonical/prometheus-k8s-operator

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -232,7 +232,13 @@ jobs:
             echo "configure script failure"
             exit 1
           fi
-
+      - name: Test building the prometheus-k8s-charm
+        run: |
+          git clone https://github.com/canonical/prometheus-k8s-operator
+          cd prometheus-k8s-operator
+          export TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
+          git checkout $TAG
+          sg lxd -c "charmcraft -v pack"
   windows-build:
     runs-on: windows-2019
     steps:


### PR DESCRIPTION
To avoid regressions like the one described in https://github.com/canonical/charmcraft/issues/625, this adds a test where we build the prometheus-k8s-operator, which at the moment is the most complex charm of the observability team.