### PR TITLE
Proof of concept for packing declarative charms.

### DIFF
--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -129,7 +129,8 @@ class Builder:
 
         self.buildpath = self.charmdir / BUILD_DIRNAME
         self.config = config
-        self.metadata = parse_metadata_yaml(self.charmdir)
+        #self.metadata = parse_metadata_yaml(self.charmdir)
+        self.metadata_name = "declarativepoc"
 
         if self.config.parts:
             self._parts = self.config.parts.copy()
@@ -217,7 +218,7 @@ class Builder:
             self._parts,
             work_dir=work_dir,
             project_dir=self.charmdir,
-            project_name=self.metadata.name,
+            project_name=self.metadata_name,
             ignore_local_sources=["*.charm"],
         )
         lifecycle.run(Step.PRIME)
@@ -420,7 +421,7 @@ class Builder:
         self, *, bases_index: int, build_on: Base, build_on_index: int
     ) -> str:
         """Pack instance in Charm."""
-        charm_name = format_charm_file_name(self.metadata.name, self.config.bases[bases_index])
+        charm_name = format_charm_file_name(self.metadata_name, self.config.bases[bases_index])
 
         # If building in project directory, use the project path as the working
         # directory. The output charms will be placed in the correct directory
@@ -455,7 +456,7 @@ class Builder:
 
         emit.progress(f"Launching environment to pack for base {build_on}")
         with self.provider.launched_environment(
-            charm_name=self.metadata.name,
+            charm_name=self.metadata_name,
             project_path=self.charmdir,
             base=build_on,
             bases_index=bases_index,
@@ -492,7 +493,7 @@ class Builder:
     def handle_package(self, prime_dir, bases_config: Optional[BasesConfiguration] = None):
         """Handle the final package creation."""
         emit.progress("Creating the package itself")
-        zipname = format_charm_file_name(self.metadata.name, bases_config)
+        zipname = format_charm_file_name(self.metadata_name, bases_config)
         zipfh = zipfile.ZipFile(zipname, "w", zipfile.ZIP_DEFLATED)
         for dirpath, dirnames, filenames in os.walk(prime_dir, followlinks=True):
             dirpath = pathlib.Path(dirpath)

--- a/charmcraft/declarative_plugin.py
+++ b/charmcraft/declarative_plugin.py
@@ -1,0 +1,133 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Charmcraft's declarative plugin for craft-parts."""
+
+import io
+import pathlib
+import zipfile
+
+import jinja2
+import json
+import jsonschema
+import requests
+import yaml
+from craft_cli import emit, CraftError
+
+
+# TODO: probably this copyright should be removed/adapted
+METADATA_TEMPLATE = """# Copyright 2021 Ubuntu
+# See LICENSE file for licensing details.
+name: {{name}}
+description: |
+  {{description}}
+summary: |
+  {{summary}}
+containers:
+  application:
+    resource: application-image
+
+requires:
+{%- for relation in requires %}
+  {{ relation.name }}:
+    interface: {{ relation.interface }}
+{%- endfor %}
+
+resources:
+  application-image:
+    type: oci-image
+    description: |
+      OCI image containing the application to run.
+      Must have been built with Cloud Native Buildpacks (https://buildpacks.io)
+
+"""
+
+
+def prepare_charm(project_dir):
+    """Build a declarative charm.
+
+    Tthe build process is as follows:
+
+    - Get the remote base declarative charm with proper schema.
+
+    - Load the manifest and validate it with the retrieved schema.
+
+    - Generate the config files from manifest content.
+
+    - Pack the charm as a regular one.
+    """
+    emit.trace(f"Declarative building started from dir {project_dir}.")
+
+    manifest_filepath = project_dir / "manifest.yaml"
+    if not manifest_filepath.exists():
+        raise CraftError("Cannot find mandatory 'manifest.yaml' file.")
+    manifest_content = yaml.safe_load(manifest_filepath.read_text())
+    emit.trace("Manifest loaded ok.")
+
+    # TODO: we need to define a proper versioned location for this
+    emit.trace("Getting cnb-operator.")
+    url = "https://github.com/facundobatista/cnb-operator/archive/refs/heads/charmcraft-poc.zip"
+    resp = requests.get(url)
+    project_zipfile = zipfile.ZipFile(io.BytesIO(resp.content))
+    project_zipfile.extractall(project_dir)
+
+    # project inside the zip is under a project name directory, we want everything directly
+    intermediated_dir = project_dir / project_zipfile.filelist[0].filename
+    for path in intermediated_dir.iterdir():
+        path.rename(pathlib.Path(*path.parts[:-2], path.name))
+    intermediated_dir.rmdir()
+    emit.trace(f"Content extracted ok to {project_dir}.")
+    breakpoint()
+
+    schema_filepath = project_dir / "schema.json"
+    schema_content = json.loads(schema_filepath.read_text())
+    try:
+        jsonschema.validate(manifest_content, schema_content)
+    except Exception as exc:
+        raise CraftError(f"Manifest failed the schema validation: {exc}") from exc
+    schema_filepath.unlink()
+    emit.trace("Manifest validated ok.")
+
+    application_name = manifest_content["name"]
+    required_relations = []
+    for consumed_relation_name in manifest_content.get("requires", []):
+        required_relations.append({
+            "name": consumed_relation_name,
+            "interface": manifest_content["requires"][consumed_relation_name]["interface"]
+        })
+    summary = manifest_content.get("summary", "")
+    description = manifest_content.get("description", "")
+    data_for_metadata = {
+        "name": application_name,
+        "summary": summary,
+        "description": description,
+        "requires": required_relations
+    }
+    template_env = jinja2.Environment()
+    metadata_content = template_env.from_string(METADATA_TEMPLATE, data_for_metadata).render()
+    (project_dir / "metadata.yaml").write_text(metadata_content)
+    emit.trace("Metadata generated ok.")
+
+    config = {
+        "environment": manifest_content.get("environment", {}),
+        "files": manifest_content.get("files", {}),
+    }
+    (project_dir / "src" / "config.json").write_text(json.dumps(config))
+    emit.trace("Config generated ok.")
+
+    # remove "original" files
+    manifest_filepath.unlink()
+    (project_dir / "charmcraft.yaml").unlink()

--- a/charmcraft/parts.py
+++ b/charmcraft/parts.py
@@ -30,6 +30,7 @@ from xdg import BaseDirectory  # type: ignore
 
 from charmcraft import charm_builder
 from charmcraft.reactive_plugin import ReactivePlugin
+from charmcraft import declarative_plugin
 
 
 class CharmPluginProperties(plugins.PluginProperties, plugins.PluginModel):
@@ -219,9 +220,25 @@ class BundlePlugin(plugins.Plugin):
         return commands
 
 
+class DeclarativePlugin(CharmPlugin):
+    """Build a declarative charm using the charm plugin."""
+
+    def get_build_commands(self) -> List[str]:
+        """Hook to run declarative stuff."""
+        declarative_plugin.prepare_charm(self._part_info.part_build_dir)
+        return super().get_build_commands()
+
+
 def setup_parts():
     """Initialize craft-parts plugins."""
-    plugins.register({"charm": CharmPlugin, "bundle": BundlePlugin, "reactive": ReactivePlugin})
+    plugins.register(
+        {
+            "bundle": BundlePlugin,
+            "charm": CharmPlugin,
+            "declarative": DeclarativePlugin,
+            "reactive": ReactivePlugin,
+        }
+    )
 
 
 def validate_part(data: Dict[str, Any]) -> None:


### PR DESCRIPTION
To use this PoC run `charmcraft pack` in a directory with the following two files:

**charmcraft.yaml**
```
type: "charm"
bases:
  - build-on:
      - name: "ubuntu"
        channel: "20.04"
    run-on:
      - name: "ubuntu"
        channel: "20.04"
parts:
  charm:
    source: .  # FIXME we should not need this
    plugin: declarative
```

**manifest.yaml**
```
name: my_charm
summary: Declarative manifest.
description: An example declarative manifest to try the Charmcraft's PoC to build it.

requires:
  relations:
    interface: mongodb

environment:
  - name: SPRING_DATA_MONGODB_URI
    template: '{{relations.consumes.datasource.app.replica_set_uri}}'
```