### PR TITLE
craft store: update to 2.0.0 (CRAFT-773)

### DIFF
--- a/charmcraft/commands/store/__init__.py
+++ b/charmcraft/commands/store/__init__.py
@@ -30,7 +30,7 @@ import yaml
 from craft_cli import emit
 from craft_cli.errors import CraftError
 from craft_store import attenuations
-from craft_store.errors import NotLoggedIn
+from craft_store.errors import CredentialsUnavailable
 from humanize import naturalsize
 from tabulate import tabulate
 
@@ -227,7 +227,7 @@ class LogoutCommand(BaseCommand):
         try:
             store.logout()
             emit.message("Charmhub token cleared.")
-        except NotLoggedIn:
+        except CredentialsUnavailable:
             emit.message("You are not logged in to Charmhub.")
 
 
@@ -249,7 +249,7 @@ class WhoamiCommand(BaseCommand):
         store = Store(self.config.charmhub)
         try:
             macaroon_info = store.whoami()
-        except NotLoggedIn:
+        except CredentialsUnavailable:
             emit.message("You are not logged in to Charmhub.")
             return
 

--- a/charmcraft/commands/store/client.py
+++ b/charmcraft/commands/store/client.py
@@ -56,6 +56,7 @@ class Client(craft_store.StoreClient):
 
         super().__init__(
             base_url=api_base_url,
+            storage_base_url=storage_base_url,
             endpoints=endpoints.CHARMHUB,
             application_name="charmcraft",
             user_agent=build_user_agent(),

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,7 @@ coverage==6.3.1
 craft-cli==0.2.0
 craft-parts==1.1.1
 craft-providers==1.0.3
-craft-store==1.2.0
+craft-store==2.0.0
 cryptography==3.4
 flake8==4.0.1
 humanize==3.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ charset-normalizer==2.0.11
 craft-cli==0.2.0
 craft-parts==1.1.1
 craft-providers==1.0.3
-craft-store==1.2.0
+craft-store==2.0.0
 cryptography==3.4
 humanize==3.14.0
 idna==3.3

--- a/tests/commands/test_store_commands.py
+++ b/tests/commands/test_store_commands.py
@@ -28,7 +28,7 @@ import dateutil.parser
 import pytest
 import yaml
 from craft_cli import CraftError
-from craft_store.errors import NotLoggedIn
+from craft_store.errors import CredentialsUnavailable
 
 from charmcraft.config import CharmhubConfig
 from charmcraft.commands.store import (
@@ -166,7 +166,6 @@ def test_get_name_from_metadata_bad_content_no_name(tmp_path, monkeypatch):
 
 
 # -- tests for auth commands
-
 
 LOGIN_OPTIONS = dict.fromkeys(["export", "charm", "bundle", "permission", "channel", "ttl"])
 
@@ -343,7 +342,9 @@ def test_logout(emitter, store_mock, config):
 
 def test_logout_but_not_logged_in(emitter, store_mock, config):
     """Simple logout case."""
-    store_mock.logout.side_effect = NotLoggedIn()
+    store_mock.logout.side_effect = CredentialsUnavailable(
+        application="charmcraft", host="api.charmcraft.io"
+    )
 
     LogoutCommand(config).run(noargs)
 
@@ -381,7 +382,9 @@ def test_whoami(emitter, store_mock, config):
 
 def test_whoami_but_not_logged_in(emitter, store_mock, config):
     """Whoami when not logged."""
-    store_mock.whoami.side_effect = NotLoggedIn()
+    store_mock.whoami.side_effect = CredentialsUnavailable(
+        application="charmcraft", host="api.charmcraft.io"
+    )
 
     WhoamiCommand(config).run(noargs)
 


### PR DESCRIPTION
- updated StoreClient init to use new parameters (without making use of them
  yet)
- s/NotLoggedIn/CredentialsUnavailable/
- better support for missing Keyring scenarios
- adapted the relogin scenario to consider CredentialsAlreadyAvailable

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>