### PR TITLE
Add name argument for upload command

### DIFF
--- a/charmcraft/commands/store/__init__.py
+++ b/charmcraft/commands/store/__init__.py
@@ -473,6 +473,11 @@ class UploadCommand(BaseCommand):
             help="The channel(s) to release to (this option can be indicated multiple times)",
         )
         parser.add_argument(
+            "--name",
+            type=str,
+            help="Name of the charm or bundle on Charmhub to upload to",
+        )
+        parser.add_argument(
             "--resource",
             action="append",
             type=ResourceOption(),
@@ -507,7 +512,10 @@ class UploadCommand(BaseCommand):
 
     def run(self, parsed_args):
         """Run the command."""
-        name = get_name_from_zip(parsed_args.filepath)
+        if parsed_args.name:
+            name = parsed_args.name
+        else:
+            name = get_name_from_zip(parsed_args.filepath)
         self._validate_template_is_handled(parsed_args.filepath)
         store = Store(self.config.charmhub)
         result = store.upload(name, parsed_args.filepath)


### PR DESCRIPTION
In some cases the name of the charm a user wants to upload is not the
same as the one specified in metadata.yaml. Specifically for charms
imported into charmhub from the old charmstore this isn't true if they
formerly namespaces (e.g. cs:~foo/bar become foo-bar but charm name
remains foo in metadata.yaml).

To allow charms to be still uploaded in this case a --name option is
added to the upload command which allows a user to specify the exact
name of the charm he wants to upload to rather than letting charmcraft
automatically extract the name from the metadata.yaml file

Fixes #681