### PR TITLE
fix "charmcraft pack" on macOS

### DIFF
--- a/charmcraft/templates/init/charmcraft.yaml.j2
+++ b/charmcraft/templates/init/charmcraft.yaml.j2
@@ -1,6 +1,10 @@
 # Learn more about charmcraft.yaml configuration at:
 # https://juju.is/docs/sdk/charmcraft-config
 type: "charm"
+parts:
+  charm:
+    build-packages:
+      - build-essential
 bases:
   - build-on:
     - name: "ubuntu"


### PR DESCRIPTION
Hi Team,

running on macOS 12.2.1 (Intel CPU) the charmcraft 1.4.0 and multipass 1.8.1
```
charmcraft init
charmcraft pack
```
see the following errors
```
2022-03-10 15:54:04.722 :: 2022-03-10 15:53:45.348    :: Collecting PyYAML
2022-03-10 15:54:04.722 :: 2022-03-10 15:53:45.389    ::   Downloading PyYAML-6.0.tar.gz (124 kB)
2022-03-10 15:54:04.722 :: 2022-03-10 15:53:45.657    ::   Installing build dependencies: started
2022-03-10 15:54:04.722 :: 2022-03-10 15:54:03.286    ::   Installing build dependencies: finished with status 'error'
2022-03-10 15:54:04.722 :: 2022-03-10 15:54:03.286    ::   ERROR: Command errored out with exit status 1:
2022-03-10 15:54:04.722 :: 2022-03-10 15:54:03.286    ::    command: /root/parts/charm/build/staging-venv/bin/python3 /root/parts/charm/build/staging-venv/lib/python3.8/site-packages/pip install --ignore-installed --no-user --prefix /tmp/pip-build-env-nedyydq_/overlay --no-warn-script-location --no-binary :all: --only-binary :none: -i https://pypi.org/simple -- setuptools wheel Cython
...
2022-03-10 15:54:04.724 :: 2022-03-10 15:54:03.342    ::       x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC -I/root/parts/charm/build/staging-venv/include -I/usr/include/python3.8 -c /tmp/pip-install-q6ivu611/Cython/Cython/Plex/Scanners.c -o build/temp.linux-x86_64-3.8/tmp/pip-install-q6ivu611/Cython/Cython/Plex/Scanners.o
2022-03-10 15:54:04.724 :: 2022-03-10 15:54:03.342    ::       unable to execute 'x86_64-linux-gnu-gcc': No such file or directory
2022-03-10 15:54:04.724 :: 2022-03-10 15:54:03.342    ::       error: command 'x86_64-linux-gnu-gcc' failed with exit status 1
```
