### PR TITLE
Dependencies handling related bug fixes and improvements

### DIFF
--- a/charmcraft/charm_builder.py
+++ b/charmcraft/charm_builder.py
@@ -308,44 +308,38 @@ def _parse_arguments() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--entrypoint",
-        metavar="filename",
         default="src/charm.py",
+        type=pathlib.Path,
         help="The charm entry point. Default is 'src/charm.py'.",
     )
     parser.add_argument(
         "--charmdir",
-        metavar="dirname",
         default=".",
+        type=pathlib.Path,
         help="The charm source directory. Default is current.",
     )
     parser.add_argument(
         "--builddir",
-        metavar="dirname",
         required=True,
+        type=pathlib.Path,
         help="The build destination directory",
     )
     parser.add_argument(
         "-b",
         "--binary-package",
-        metavar="pkg",
         action="append",
-        default=None,
         help="Binary Python package to install before requirements.",
     )
     parser.add_argument(
         "-p",
         "--package",
-        metavar="pkg",
         action="append",
-        default=None,
         help="Python package to install before requirements.",
     )
     parser.add_argument(
         "-r",
         "--requirement",
-        metavar="reqfile",
         action="append",
-        default=None,
         type=pathlib.Path,
         help="Requirements file to install dependencies from.",
     )

--- a/charmcraft/charm_builder.py
+++ b/charmcraft/charm_builder.py
@@ -355,12 +355,12 @@ def main():
     emit.init(EmitterMode.TRACE, "charm-builder", "Starting charm builder", log_filepath=logpath)
 
     builder = CharmBuilder(
-        charmdir=pathlib.Path(options.charmdir),
-        builddir=pathlib.Path(options.builddir),
-        entrypoint=pathlib.Path(options.entrypoint),
-        binary_python_packages=options.binary_package,
-        python_packages=options.package,
-        requirements=options.requirement,
+        charmdir=options.charmdir,
+        builddir=options.builddir,
+        entrypoint=options.entrypoint,
+        binary_python_packages=options.binary_package or [],
+        python_packages=options.package or [],
+        requirements=options.requirement or [],
     )
     builder.build_charm()
 

--- a/charmcraft/charm_builder.py
+++ b/charmcraft/charm_builder.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 Canonical Ltd.
+# Copyright 2020-2022 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -70,7 +70,7 @@ class CharmBuilder:
         allow_pip_binary: bool = None,
         binary_python_packages: List[str] = None,
         python_packages: List[str] = None,
-        requirements: List[str] = None,
+        requirements: List[pathlib.Path] = None,
     ):
         self.charmdir = charmdir
         self.buildpath = builddir
@@ -346,6 +346,7 @@ def _parse_arguments() -> argparse.Namespace:
         metavar="reqfile",
         action="append",
         default=None,
+        type=pathlib.Path,
         help="Requirements file to install dependencies from.",
     )
 

--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 Canonical Ltd.
+# Copyright 2020-2022 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -269,7 +269,11 @@ class Builder:
             charm_part_prime.append(str(entrypoint.parts[0]))
 
         # add venv if there are requirements
-        if self._special_charm_part["charm-requirements"]:
+        if (
+            self._special_charm_part.get("charm-requirements")
+            or self._special_charm_part.get("charm-binary-python-packages")
+            or self._special_charm_part.get("charm-python-packages")
+        ):
             charm_part_prime.append(VENV_DIRNAME)
 
         # add mandatory and optional charm files

--- a/tests/test_charm_builder.py
+++ b/tests/test_charm_builder.py
@@ -838,7 +838,7 @@ def test_builder_arguments_defaults(tmp_path):
         assert self.charmdir == pathlib.Path("charmdir")
         assert self.buildpath == pathlib.Path("builddir")
         assert self.entrypoint == pathlib.Path("src/charm.py")
-        assert self.requirement_paths is None
+        assert self.requirement_paths == []
         sys.exit(42)
 
     with patch.object(sys, "argv", ["cmd", "--charmdir", "charmdir", "--builddir", "builddir"]):


### PR DESCRIPTION
Specifically...

In `charm_builder.py`:

- Fixed the type for requirement files: all paths should be pathlib.Path, not strings

- Stopped CharmBuilder receiving `python_packages` and `binary_python_packages` that could be lists or None; now they are always lists (that may be empty, it's fine)

- Improved argument parsing:

    - removed the `default=None` in arguments definitions, as it is... well.. the default

    - removed the `metavar` in arguments definitions, it's only used for help text (this is not a user exposed script) and they were being used wrong anyway (the correct use is to better identify the option, and the metavar strings were repeated)

    - for file/dir paths, the argument parsing now returns pathlib.Paths directly


In `commands/build.py`:

- The "venv" directory were added to the prime filter if requirements existed; that was missing the possibility that maybe requirement files didn't exist, but python packages (binary or not) did
