### PR TITLE
multipass: use the correct image remote

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -103,10 +103,12 @@ jobs:
         run: |
           sudo apt remove -y lxd
           sudo snap install lxd
+          snap list lxd
       - name: Refresh LXD dependency on 20.04
         if: ${{ matrix.os == 'ubuntu-20.04' }}
         run: |
           sudo snap refresh lxd || echo "Cannot refresh LXD dependency, using $(lxd --version)"
+          snap list lxd
       - name: Configured LXD
         run: |
           sudo groupadd --force --system lxd

--- a/charmcraft/providers/_multipass.py
+++ b/charmcraft/providers/_multipass.py
@@ -166,7 +166,7 @@ class MultipassProvider(Provider):
             instance = multipass.launch(
                 name=instance_name,
                 base_configuration=base_configuration,
-                image_name=base.channel,
+                image_name=f"snapcraft:{base.channel}",
                 cpus=2,
                 disk_gb=64,
                 mem_gb=2,

--- a/charmcraft/providers/_provider.py
+++ b/charmcraft/providers/_provider.py
@@ -26,11 +26,7 @@ from craft_providers import bases
 
 from charmcraft.config import Base
 from charmcraft.utils import get_host_architecture
-
-BASE_CHANNEL_TO_BUILDD_IMAGE_ALIAS = {
-    "18.04": bases.BuilddBaseAlias.BIONIC,
-    "20.04": bases.BuilddBaseAlias.FOCAL,
-}
+from ._buildd import BASE_CHANNEL_TO_BUILDD_IMAGE_ALIAS
 
 
 class Provider(ABC):

--- a/tests/providers/test_multipass.py
+++ b/tests/providers/test_multipass.py
@@ -422,7 +422,7 @@ def test_launched_environment(
             mock.call(
                 name="charmcraft-test-charm-445566-1-2-host-arch",
                 base_configuration=mock_buildd_base_configuration.return_value,
-                image_name=channel,
+                image_name=f"snapcraft:{channel}",
                 cpus=2,
                 disk_gb=64,
                 mem_gb=2,


### PR DESCRIPTION
Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>