### PR TITLE
parts: update craft-parts and enable craftctl

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -162,7 +162,10 @@ jobs:
               plugin: nil
               build-packages: [hello]
               override-build: |
-                hello > "\$CHARMCRAFT_PART_INSTALL/hello.txt"
+                hello > "\$CRAFT_PART_INSTALL/hello.txt"
+              override-prime: |
+                echo "Running the prime step"
+                craftctl default
           EOF
           sg lxd -c "charmcraft -v pack"
           unzip -c build-packages-test_*.charm hello.txt | grep "^Hello, world!"

--- a/charmcraft/parts.py
+++ b/charmcraft/parts.py
@@ -319,7 +319,8 @@ class PartsLifecycle:
             with self._lcm.action_executor() as aex:
                 for action in actions:
                     emit.progress(f"Running step {action.step.name} for part {action.part_name!r}")
-                    aex.execute([action])
+                    with emit.open_stream("Execute action") as stream:
+                        aex.execute([action], stdout=stream, stderr=stream)
         except RuntimeError as err:
             raise RuntimeError(f"Parts processing internal error: {err}") from err
         except OSError as err:

--- a/libexec/craftctl
+++ b/libexec/craftctl
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec "$SNAP"/bin/python "$SNAP"/bin/craftctl "$@"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ charset-normalizer==2.0.12
 click==8.0.4
 coverage==6.3.2
 craft-cli==0.3.1
-craft-parts==1.3.0
+craft-parts==1.4.0
 craft-providers==1.1.0
 craft-store==2.0.1
 cryptography==3.4
@@ -18,7 +18,7 @@ importlib-metadata==4.11.3
 importlib-resources==5.4.0
 iniconfig==1.1.1
 jeepney==0.7.1
-Jinja2==3.0.3
+Jinja2==3.1.0
 jsonschema==4.4.0
 keyring==23.5.0
 macaroonbakery==1.3.1
@@ -56,7 +56,7 @@ responses==0.20.0
 SecretStorage==3.3.1
 semantic-version==2.9.0
 semver==2.13.0
-setuptools-rust==1.1.2
+setuptools-rust==1.2.0
 six==1.16.0
 snap-helpers==0.2.0
 snowballstemmer==2.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ certifi==2021.10.8
 cffi==1.15.0
 charset-normalizer==2.0.12
 craft-cli==0.3.1
-craft-parts==1.3.0
+craft-parts==1.4.0
 craft-providers==1.1.0
 craft-store==2.0.1
 cryptography==3.4
@@ -13,7 +13,7 @@ idna==3.3
 importlib-metadata==4.11.3
 importlib-resources==5.4.0
 jeepney==0.7.1
-Jinja2==3.0.3
+Jinja2==3.1.0
 jsonschema==4.4.0
 keyring==23.5.0
 macaroonbakery==1.3.1
@@ -40,7 +40,7 @@ requests-unixsocket==0.3.0
 SecretStorage==3.3.1
 semantic-version==2.9.0
 semver==2.13.0
-setuptools-rust==1.1.2
+setuptools-rust==1.2.0
 six==1.16.0
 snap-helpers==0.2.0
 tabulate==0.8.9

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -62,6 +62,7 @@ apps:
       # help git find its stuff
       GIT_TEMPLATE_DIR: $SNAP/git/templates
       GIT_EXEC_PATH: $SNAP/git/git-core
+      PATH: $SNAP/libexec/charmcraft:$PATH
 
 grade: stable
 confinement: classic
@@ -128,6 +129,12 @@ parts:
       usr/share/git-core/templates: git/templates
       usr/bin/git: bin/git
       lib/python3.8/site-packages: lib/
+
+  craftctl:
+    plugin: dump
+    source: libexec
+    organize:
+      craftctl: libexec/charmcraft/craftctl
 
 hooks:
   configure:

--- a/tests/test_parts.py
+++ b/tests/test_parts.py
@@ -16,7 +16,7 @@
 
 import pathlib
 import sys
-from unittest.mock import patch, call
+from unittest.mock import ANY, patch, call
 
 import craft_parts
 import pydantic
@@ -334,8 +334,8 @@ class TestPartsLifecycle:
         emitter.assert_progress("Running step STAGE for part 'charm'")
         emitter.assert_progress("Running step PRIME for part 'charm'")
         assert mock_exec.call_args_list == [
-            call([action1]),
-            call([action2]),
+            call([action1], stdout=ANY, stderr=ANY),
+            call([action2], stdout=ANY, stderr=ANY),
         ]
 
 


### PR DESCRIPTION
Use craft-parts 1.4.0 with support to craftctl. Users can now invoke
`craftctl default` from part scriptlets to run the overriden step's
built-in handler.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

---
CRAFT-944