### PR TITLE
Manifest Linter

### DIFF
--- a/charmcraft/metadata.py
+++ b/charmcraft/metadata.py
@@ -17,7 +17,7 @@
 """Logic related to metadata.yaml."""
 
 import pathlib
-from typing import Any, Dict
+from typing import Any, Dict, List, Optional
 
 import pydantic
 import yaml
@@ -34,6 +34,7 @@ class CharmMetadata(pydantic.BaseModel, frozen=True, validate_all=True):
     name: pydantic.StrictStr
     summary: pydantic.StrictStr = ""
     description: pydantic.StrictStr = ""
+    series: List[pydantic.StrictStr] = []
 
     @classmethod
     def unmarshal(cls, obj: Dict[str, Any]):

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -22,6 +22,30 @@ import yaml
 from charmcraft import __version__, config, linters
 from charmcraft.manifest import create_manifest
 from charmcraft.utils import OSPlatform
+from charmcraft.manifest import parse_manifest_yaml
+
+
+def test_parse_manifest_yaml_complete(tmp_path):
+    """Example of parsing with all the optional attributes."""
+    manifest_file = tmp_path / "manifest.yaml"
+    manifest_file.write_text(
+        """
+        bases:
+          - name: test-name
+            channel: test-channel
+            architectures:
+              - arch1
+              - arch2
+    """
+    )
+
+    manifest = parse_manifest_yaml(tmp_path)
+
+    assert manifest.bases == [config.Base(
+                    name="test-name",
+                    channel="test-channel",
+                    architectures=["arch1", "arch2"],
+                )]
 
 
 def test_manifest_simple_ok(tmp_path):


### PR DESCRIPTION
The following implements a manifest linter that ensures that you don't
have both a metadata series and a manifest base. By doing this, we
can make the Juju side of the code simpler in the future. If all within
the charmhub store and locally deployed charms with Juju only have one
source of truth for the series information it makes determination easy.

Additionally, Juju wants to move away from series terminology and this
will help with that, as in the future we would want to deprecate
metadata.series field.

Fixes https://github.com/canonical/charmcraft/issues/732