### PR TITLE
Show better timestamps in commands outputs (CRAFT-873).

### DIFF
--- a/charmcraft/commands/store/__init__.py
+++ b/charmcraft/commands/store/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 Canonical Ltd.
+# Copyright 2020-2022 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -38,6 +38,7 @@ from charmcraft.cmdbase import BaseCommand
 from charmcraft.utils import (
     ResourceOption,
     SingleOptionEnsurer,
+    format_timestamp,
     get_templates_environment,
     useful_filepath,
 )
@@ -553,8 +554,8 @@ class ListRevisionsCommand(BaseCommand):
         For example:
 
            $ charmcraft revisions mycharm
-           Revision    Version    Created at    Status
-           1           1          2020-11-15    released
+           Revision    Version    Created at              Status
+           1           1          2020-11-15T11:13:15Z    released
 
         Listing revisions will take you through login if needed.
     """
@@ -587,7 +588,7 @@ class ListRevisionsCommand(BaseCommand):
                 [
                     item.revision,
                     item.version,
-                    item.created_at.strftime("%Y-%m-%d"),
+                    format_timestamp(item.created_at),
                     status,
                 ]
             )
@@ -858,7 +859,7 @@ class StatusCommand(BaseCommand):
                         # not for this base!
                         continue
                     description = "/".join((branch.risk, branch.branch))
-                    expiration = release.expires_at.isoformat()
+                    expiration = format_timestamp(release.expires_at)
                     revision = revisions_by_revno[release.revision]
                     datum = ["", "", description, revision.version, release.revision]
                     if resources_present:
@@ -1605,8 +1606,8 @@ class ListResourceRevisionsCommand(BaseCommand):
         For example:
 
            $ charmcraft resource-revisions my-charm my-resource
-           Revision    Created at     Size
-           1           2020-11-15   183151
+           Revision    Created at               Size
+           1           2020-11-15 T11:13:15Z  183151
 
         Listing revisions will take you through login if needed.
     """
@@ -1630,12 +1631,12 @@ class ListResourceRevisionsCommand(BaseCommand):
             return
 
         headers = ["Revision", "Created at", "Size"]
-        custom_alignment = ["left", None, "right"]
+        custom_alignment = ["left", "left", "right"]
         result.sort(key=attrgetter("revision"), reverse=True)
         data = [
             (
                 item.revision,
-                item.created_at.strftime("%Y-%m-%d"),
+                format_timestamp(item.created_at),
                 naturalsize(item.size, gnu=True),
             )
             for item in result

--- a/charmcraft/utils.py
+++ b/charmcraft/utils.py
@@ -240,6 +240,6 @@ def format_timestamp(dt: datetime.datetime) -> str:
 
     Always in UTC.
     """
-    # convert to UTC no matter the timezone `dt` has
+    # convert to UTC from whatever timezone `dt` has
     dtz = datetime.datetime.fromtimestamp(time.mktime(dt.utctimetuple()))
     return dtz.strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/charmcraft/utils.py
+++ b/charmcraft/utils.py
@@ -16,10 +16,12 @@
 
 """Collection of utilities for charmcraft."""
 
+import datetime
 import os
 import pathlib
 import platform
 import sys
+import time
 from collections import namedtuple
 from dataclasses import dataclass
 from stat import S_IRGRP, S_IROTH, S_IRUSR, S_IXGRP, S_IXOTH, S_IXUSR
@@ -227,3 +229,17 @@ def confirm_with_user(prompt, default=False) -> bool:
         return False
     else:
         return default
+
+
+def format_timestamp(dt: datetime.datetime) -> str:
+    """Convert a datetime object (with or without timezone) to a string.
+
+    The format is
+
+        <DATE>T<TIME>Z
+
+    Always in UTC.
+    """
+    # convert to UTC no matter the timezone `dt` has
+    dtz = datetime.datetime.fromtimestamp(time.mktime(dt.utctimetuple()))
+    return dtz.strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/tests/commands/test_store_commands.py
+++ b/tests/commands/test_store_commands.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 Canonical Ltd.
+# Copyright 2020-2022 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -934,8 +934,8 @@ def test_revisions_simple(emitter, store_mock, config):
         call.list_revisions("testcharm"),
     ]
     expected = [
-        "Revision    Version    Created at    Status",
-        "1           v1         2020-07-03    accepted",
+        "Revision    Version    Created at            Status",
+        "1           v1         2020-07-03T20:30:40Z  accepted",
     ]
     emitter.assert_messages(expected)
 
@@ -992,10 +992,10 @@ def test_revisions_ordered_by_revision(emitter, store_mock, config):
     ListRevisionsCommand(config).run(args)
 
     expected = [
-        "Revision    Version    Created at    Status",
-        "3           v1         2020-07-03    accepted",
-        "2           v1         2020-07-03    accepted",
-        "1           v1         2020-07-03    accepted",
+        "Revision    Version    Created at            Status",
+        "3           v1         2020-07-03T20:30:40Z  accepted",
+        "2           v1         2020-07-03T20:30:40Z  accepted",
+        "1           v1         2020-07-03T20:30:40Z  accepted",
     ]
     emitter.assert_messages(expected)
 
@@ -1019,8 +1019,8 @@ def test_revisions_version_null(emitter, store_mock, config):
     ListRevisionsCommand(config).run(args)
 
     expected = [
-        "Revision    Version    Created at    Status",
-        "1                      2020-07-03    accepted",
+        "Revision    Version    Created at            Status",
+        "1                      2020-07-03T20:30:40Z  accepted",
     ]
     emitter.assert_messages(expected)
 
@@ -1044,8 +1044,8 @@ def test_revisions_errors_simple(emitter, store_mock, config):
     ListRevisionsCommand(config).run(args)
 
     expected = [
-        "Revision    Version    Created at    Status",
-        "1                      2020-07-03    rejected: error text [broken]",
+        "Revision    Version    Created at            Status",
+        "1                      2020-07-03T20:30:40Z  rejected: error text [broken]",
     ]
     emitter.assert_messages(expected)
 
@@ -1072,8 +1072,8 @@ def test_revisions_errors_multiple(emitter, store_mock, config):
     ListRevisionsCommand(config).run(args)
 
     expected = [
-        "Revision    Version    Created at    Status",
-        "1                      2020-07-03    rejected: text 1 [missing-stuff]; other long error text [broken]",  # NOQA
+        "Revision    Version    Created at            Status",
+        "1                      2020-07-03T20:30:40Z  rejected: text 1 [missing-stuff]; other long error text [broken]",  # NOQA
     ]
     emitter.assert_messages(expected)
 
@@ -1498,7 +1498,7 @@ def test_status_with_one_branch(emitter, store_mock, config):
         "                               candidate      -          -",
         "                               beta           5.1        5",
         "                               edge           ↑          ↑",
-        "                               beta/mybranch  ver.12     12          2020-07-03T20:30:40+00:00",  # NOQA
+        "                               beta/mybranch  ver.12     12          2020-07-03T20:30:40Z",  # NOQA
     ]
     emitter.assert_messages(expected)
 
@@ -1550,8 +1550,8 @@ def test_status_with_multiple_branches(emitter, store_mock, config):
         "                               candidate      -          -",
         "                               beta           5.1        5",
         "                               edge           ↑          ↑",
-        "                               beta/branch-1  ver.12     12          2020-07-03T20:30:40+00:00",  # NOQA
-        "                               beta/branch-2  15.0.0     15          2020-07-03T20:30:40+00:00",  # NOQA
+        "                               beta/branch-1  ver.12     12          2020-07-03T20:30:40Z",  # NOQA
+        "                               beta/branch-2  15.0.0     15          2020-07-03T20:30:40Z",  # NOQA
     ]
     emitter.assert_messages(expected)
 
@@ -1649,7 +1649,7 @@ def test_status_with_resources_and_branches(emitter, store_mock, config):
         "                               candidate      -          -           -",
         "                               beta           7.0.0      23          testres (r14)",
         "                               edge           ↑          ↑           ↑",
-        "                               edge/mybranch  5.1        5           testres (r1)   2020-07-03T20:30:40+00:00",  # NOQA
+        "                               edge/mybranch  5.1        5           testres (r1)   2020-07-03T20:30:40Z",  # NOQA
     ]
     emitter.assert_messages(expected)
 
@@ -1818,12 +1818,12 @@ def test_status_multiplebases_everything_combined(emitter, store_mock, config):
         "                               candidate      v7            7           -",
         "                               beta           ↑             ↑           ↑",
         "                               edge           git-0db35ea1  156         -",
-        "                               candidate/br1  v7            7           -             2020-07-03T20:30:40+00:00",  # NOQA
+        "                               candidate/br1  v7            7           -             2020-07-03T20:30:40Z",  # NOQA
         "         xz 1 (16b)            stable         v7            7           -",
         "                               candidate      ↑             ↑           ↑",
         "                               beta           2.0           80          -",
         "                               edge           ↑             ↑           ↑",
-        "                               beta/br2       weird         99          testres (r1)  2020-07-03T20:30:40+00:00",  # NOQA
+        "                               beta/br2       weird         99          testres (r1)  2020-07-03T20:30:40Z",  # NOQA
         "2.0      ubuntu 20.04 (amd64)  stable         -             -           -",
         "                               candidate      v7            7           -",
         "                               beta           2.0           80          -",
@@ -1832,7 +1832,7 @@ def test_status_multiplebases_everything_combined(emitter, store_mock, config):
         "                               candidate      ↑             ↑           ↑",
         "                               beta           ↑             ↑           ↑",
         "                               edge           2.0           80          -",
-        "                               edge/foobar    2.0           80          -             2020-07-03T20:30:40+00:00",  # NOQA
+        "                               edge/foobar    2.0           80          -             2020-07-03T20:30:40Z",  # NOQA
     ]
     emitter.assert_messages(expected)
 
@@ -3555,8 +3555,8 @@ def test_resourcerevisions_simple(emitter, store_mock, config):
         call.list_resource_revisions("testcharm", "testresource"),
     ]
     expected = [
-        "Revision    Created at    Size",
-        "1           2020-07-03     50B",
+        "Revision    Created at              Size",
+        "1           2020-07-03T02:30:40Z     50B",
     ]
     emitter.assert_messages(expected)
 
@@ -3589,10 +3589,10 @@ def test_resourcerevisions_ordered_by_revision(emitter, store_mock, config):
     ListResourceRevisionsCommand(config).run(args)
 
     expected = [
-        "Revision    Created at    Size",
-        "4           2020-07-03  856.0K",
-        "3           2020-07-03   32.9M",
-        "2           2020-07-03     50B",
-        "1           2020-07-03    4.9K",
+        "Revision    Created at              Size",
+        "4           2020-07-03T20:30:40Z  856.0K",
+        "3           2020-07-03T20:30:40Z   32.9M",
+        "2           2020-07-03T20:30:40Z     50B",
+        "1           2020-07-03T20:30:40Z    4.9K",
     ]
     emitter.assert_messages(expected)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -239,14 +239,15 @@ class RecordingEmitter:
         """
         if expected_call_list is None:
             if self.interactions:
-                raise AssertionError(f"Expected no call but really got {self.interactions}")
+                show_interactions = "\n".join(map(str, self.interactions))
+                raise AssertionError("Expected no call but really got:\n" + show_interactions)
             return
 
         for pos, stored_call in enumerate(self.interactions):
             if stored_call == expected_call_list[0]:
                 break
         else:
-            raise AssertionError(f"Initial expected call not found in {self.interactions}")
+            pos = 0
 
         stored = self.interactions[pos : pos + len(expected_call_list)]
         assert stored == expected_call_list

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 Canonical Ltd.
+# Copyright 2020-2022 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,12 +14,14 @@
 #
 # For further info, check https://github.com/canonical/charmcraft
 
+import datetime
 import os
 import pathlib
 import sys
 from textwrap import dedent
 from unittest.mock import call, patch
 
+import dateutil.parser
 import pytest
 from craft_cli import CraftError
 
@@ -27,6 +29,7 @@ from charmcraft.utils import (
     ResourceOption,
     SingleOptionEnsurer,
     confirm_with_user,
+    format_timestamp,
     get_host_architecture,
     get_os_platform,
     load_yaml,
@@ -414,3 +417,24 @@ def test_confirm_with_user_pause_emitter(mock_isatty, emitter):
 
     with patch("charmcraft.utils.input", fake_input):
         confirm_with_user("prompt")
+
+
+def test_timestampstr_simple():
+    """Converts a timestamp without timezone."""
+    source = datetime.datetime(2020, 7, 3, 20, 30, 40)
+    result = format_timestamp(source)
+    assert result == "2020-07-03T20:30:40Z"
+
+
+def test_timestampstr_utc():
+    """Converts a timestamp with UTC timezone."""
+    source = dateutil.parser.parse("2020-07-03T20:30:40Z")
+    result = format_timestamp(source)
+    assert result == "2020-07-03T20:30:40Z"
+
+
+def test_timestampstr_nonutc():
+    """Converts a timestamp with other timezone."""
+    source = dateutil.parser.parse("2020-07-03T20:30:40+03:00")
+    result = format_timestamp(source)
+    assert result == "2020-07-03T17:30:40Z"


### PR DESCRIPTION
Also improved how errors are shown in the Emitter fixture.

Fixes #643 .