### PR TITLE
Fix the default template's tests

### DIFF
--- a/charmcraft/templates/init/tests/test_charm.py.j2
+++ b/charmcraft/templates/init/tests/test_charm.py.j2
@@ -36,6 +36,8 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(action_event.fail.call_args, [("fail this",)])
 
     def test_httpbin_pebble_ready(self):
+        # Make the container's pebble socket available
+        self.harness.set_can_connect("httpbin", True)
         # Check the initial Pebble plan is empty
         initial_plan = self.harness.get_container_pebble_plan("httpbin")
         self.assertEqual(initial_plan.to_yaml(), "{}\n")


### PR DESCRIPTION
The introduction of more realistic container networking in the test suite broke the `init` template tests. I know we're looking at updating the template anyway, but this should be considered a bug fix in the mean time. 

Perhaps we could introduce a CI test that runs `charmcraft init; pip install -r requirements-dev.txt; ./run_tests` to ensure this doesn't get broken again?