### PR TITLE
Fix the tests in the init template

### DIFF
--- a/charmcraft/templates/init/tests/test_charm.py.j2
+++ b/charmcraft/templates/init/tests/test_charm.py.j2
@@ -36,6 +36,8 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(action_event.fail.call_args, [("fail this",)])
 
     def test_httpbin_pebble_ready(self):
+        # Simulate making the Pebble socket available
+        self.harness.set_can_connect("httpbin", True)
         # Check the initial Pebble plan is empty
         initial_plan = self.harness.get_container_pebble_plan("httpbin")
         self.assertEqual(initial_plan.to_yaml(), "{}\n")

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -25,7 +25,7 @@ macaroonbakery==1.3.1
 MarkupSafe==2.1.1
 mccabe==0.6.1
 mypy-extensions==0.4.3
-ops==1.3.0
+ops==1.4.0
 overrides==6.1.0
 packaging==21.3
 pathspec==0.9.0

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ dev_requires = [
     "black",
     "coverage",
     "flake8",
-    "ops>=0.8.0",
+    "ops>=1.4.0",
     "pydocstyle",
     "pytest",
     "responses",


### PR DESCRIPTION
The introduction of more realistic container networking in the test suite broke the init template tests. I know we're looking at updating the template anyway, but this should be considered a bug fix in the mean time.

In order for the `charmcraft` tests to pass, the `ops` version in `requirements-dev.txt` also needed bumping.

Perhaps we could introduce a CI test that runs charmcraft init; pip install -r requirements-dev.txt; ./run_tests to ensure this doesn't get broken again?