### PR TITLE
Save temp retrieved file in current directory so it's fine for the case of running inside a strict snap. (CRAFT-1069)

### DIFF
--- a/charmcraft/providers/_logs.py
+++ b/charmcraft/providers/_logs.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021-2022 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,8 +32,11 @@ def capture_logs_from_instance(instance: Executor) -> None:
 
     :returns: String of logs.
     """
-    # Get a temporary file path.
-    tmp_file = tempfile.NamedTemporaryFile(delete=False, prefix="charmcraft-")
+    # Get a temporary file path (placing it in current directory as it's the most predictible
+    # place where a strictly-snapped app could write)
+    tmp_file = tempfile.NamedTemporaryFile(
+        delete=False, prefix="charmcraft-", suffix="-temporary.log", dir="."
+    )
     tmp_file.close()
 
     local_log_path = pathlib.Path(tmp_file.name)
@@ -42,6 +45,7 @@ def capture_logs_from_instance(instance: Executor) -> None:
     try:
         instance.pull_file(source=instance_log_path, destination=local_log_path)
     except FileNotFoundError:
+        local_log_path.unlink()
         emit.trace("No logs found in instance.")
         return
 

--- a/tests/providers/test_logs.py
+++ b/tests/providers/test_logs.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021-2022 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -50,15 +50,17 @@ def test_capture_logs_from_instance(emitter, mock_instance, mock_namedtemporaryf
         ]
     )
     assert mock_namedtemporaryfile.mock_calls == [
-        mock.call(delete=False, prefix="charmcraft-"),
+        mock.call(delete=False, prefix="charmcraft-", suffix="-temporary.log", dir="."),
         mock.call().close(),
     ]
+    assert not fake_log.exists()
 
 
 def test_capture_logs_from_instance_not_found(
     emitter, mock_instance, mock_namedtemporaryfile, tmp_path
 ):
     fake_log = pathlib.Path(mock_namedtemporaryfile.return_value.name)
+    fake_log.touch()  # temp file is created when NamedTemporaryFile called
     mock_instance.pull_file.side_effect = FileNotFoundError()
 
     providers.capture_logs_from_instance(mock_instance)
@@ -67,3 +69,4 @@ def test_capture_logs_from_instance_not_found(
         mock.call.pull_file(source=pathlib.Path("/tmp/charmcraft.log"), destination=fake_log),
     ]
     emitter.assert_trace("No logs found in instance.")
+    assert not fake_log.exists()


### PR DESCRIPTION
Also fixed a small bug of not deleting the file on failure.