### PR TITLE
Do not modify the charm's project when packing using the reactive plugin (CRAFT-928).

### DIFF
--- a/charmcraft/reactive_plugin.py
+++ b/charmcraft/reactive_plugin.py
@@ -133,9 +133,6 @@ def build(*, charm_name: str, build_dir: Path, install_dir: Path) -> int:
     The charm tool is used to build reactive charms, the build process
     is as follows:
 
-    - Remove any charmcraft.yaml from the build directory (occurs for
-      local in-tree builds)
-
     - Run charm proof to ensure the charm
       would build with no errors (warnings are allowed)
 
@@ -143,12 +140,11 @@ def build(*, charm_name: str, build_dir: Path, install_dir: Path) -> int:
       install_dir
 
     - Run "charm build"
-    """
-    # Remove the charmcraft.yaml so it is not primed for in-tree builds.
-    charmcraft_yaml = build_dir / "charmcraft.yaml"
-    if charmcraft_yaml.exists():
-        charmcraft_yaml.unlink()
 
+    Note that no files/dirs in the original project are modified nor removed
+    because in that case the VCS will detect something changed and the version
+    string produced by `charm` would be misleading.
+    """
     # Verify the charm is ok from a charm tool point of view.
     try:
         subprocess.run(["charm", "proof"], check=True)

--- a/tests/test_reactive_plugin.py
+++ b/tests/test_reactive_plugin.py
@@ -180,23 +180,6 @@ def test_build(build_dir, install_dir, fake_run):
     ]
 
 
-def test_build_removes_charmcraft_yaml(build_dir, install_dir, fake_run):
-    charmcraft_yaml = build_dir / "charmcraft.yaml"
-    charmcraft_yaml.touch()
-
-    returncode = reactive_plugin.build(
-        charm_name="test-charm", build_dir=build_dir, install_dir=install_dir
-    )
-
-    assert returncode == 0
-    assert not charmcraft_yaml.exists()
-    assert not (build_dir / "test-charm").exists()
-    assert fake_run.mock_calls == [
-        call(["charm", "proof"], check=True),
-        call(["charm", "build", "-o", build_dir], check=True),
-    ]
-
-
 def test_build_charm_proof_raises_error_messages(build_dir, install_dir, fake_run):
     fake_run.side_effect = CalledProcessError(200, "E: name missing")
 


### PR DESCRIPTION
Fixes #693.