### PR TITLE
Removed the long time deprecated 'build' command (CRAFT-1109).

### DIFF
--- a/charmcraft/commands/pack.py
+++ b/charmcraft/commands/pack.py
@@ -19,7 +19,6 @@
 import os
 import pathlib
 import zipfile
-from argparse import Namespace
 from typing import List
 
 from craft_cli import emit, CraftError
@@ -125,28 +124,33 @@ class PackCommand(BaseCommand):
         else:
             raise CraftError("Unknown type {!r} in charmcraft.yaml".format(self.config.type))
 
+    def _validate_bases_indices(self, bases_indices):
+        """Validate that bases index is valid."""
+        msg = "Bases index '{}' is invalid (must be >= 0 and fit in configured bases)."
+        len_configured_bases = len(self.config.bases)
+        for bases_index in bases_indices:
+            if bases_index < 0:
+                raise CraftError(msg.format(bases_index))
+            if bases_index >= len_configured_bases:
+                raise CraftError(msg.format(bases_index))
+
     def _pack_charm(self, parsed_args) -> List[pathlib.Path]:
         """Pack a charm."""
-        emit.progress("Packing the charm.")
-        # adapt arguments to use the build infrastructure
-        build_args = Namespace(
-            **{
-                "debug": parsed_args.debug,
-                "destructive_mode": parsed_args.destructive_mode,
-                "from": self.config.project.dirpath,
-                "shell": parsed_args.shell,
-                "shell_after": parsed_args.shell_after,
-                "bases_indices": parsed_args.bases_index,
-                "force": parsed_args.force,
-            }
-        )
+        self._validate_bases_indices(parsed_args.bases_index)
 
-        # mimic the "build" command
-        validator = build.Validator(self.config)
-        args = validator.process(build_args)
-        emit.trace(f"Working arguments: {args}")
-        builder = build.Builder(args, self.config)
-        charms = builder.run(parsed_args.bases_index, destructive_mode=build_args.destructive_mode)
+        # build
+        emit.progress("Packing the charm.")
+        builder = build.Builder(
+            config=self.config,
+            force=parsed_args.force,
+            debug=parsed_args.debug,
+            shell=parsed_args.shell,
+            shell_after=parsed_args.shell_after,
+        )
+        charms = builder.run(
+            parsed_args.bases_index,
+            destructive_mode=parsed_args.destructive_mode,
+        )
 
         # avoid showing results when run inside a container (the outer charmcraft
         # is responsible of the final message to the user)

--- a/charmcraft/commands/pack.py
+++ b/charmcraft/commands/pack.py
@@ -126,6 +126,9 @@ class PackCommand(BaseCommand):
 
     def _validate_bases_indices(self, bases_indices):
         """Validate that bases index is valid."""
+        if bases_indices is None:
+            return
+
         msg = "Bases index '{}' is invalid (must be >= 0 and fit in configured bases)."
         len_configured_bases = len(self.config.bases)
         for bases_index in bases_indices:

--- a/charmcraft/deprecations.py
+++ b/charmcraft/deprecations.py
@@ -32,7 +32,8 @@ from charmcraft.env import is_charmcraft_running_in_managed_mode
 # the message to show for each deprecation ID (this needs to be in sync with the
 # documentation)
 _DEPRECATION_MESSAGES = {
-    "dn06": "The build command is deprecated, use 'pack' instead.",
+    # example of item in this structure when something is deprecated:
+    # "dn99": "The zircunium mogrifier is deprecated, use stellar dust instead.",
 }
 
 # the URL to point to the deprecation entry in the documentation

--- a/charmcraft/main.py
+++ b/charmcraft/main.py
@@ -34,7 +34,7 @@ from craft_cli import (
 from craft_store import errors
 
 from charmcraft import config, __version__, env, utils
-from charmcraft.commands import build, clean, init, pack, store, version, analyze
+from charmcraft.commands import clean, init, pack, store, version, analyze
 from charmcraft.commands.store.client import ALTERNATE_AUTH_ENV_VAR
 from charmcraft.parts import setup_parts
 
@@ -60,7 +60,6 @@ See https://charmhub.io/publishing for more information.
 # important when listing commands and showing help.
 _basic_commands = [
     analyze.AnalyzeCommand,
-    build.BuildCommand,
     clean.CleanCommand,
     pack.PackCommand,
     init.InitCommand,

--- a/completion.bash
+++ b/completion.bash
@@ -21,7 +21,6 @@ _charmcraft()
     local cur prev words cword cmd cmds
     cmds=(
         analyze
-        build
         clean
         close
         create-lib 
@@ -82,16 +81,6 @@ _charmcraft()
     case "$cmd" in
         analyze)
             COMPREPLY=( $(compgen -W "${globals[*]} --force --format" -- "$cur") )
-            ;;
-        build)
-            case "$prev" in
-                -f|--from)
-                    _filedir -d
-                    ;;
-                *)
-                    COMPREPLY=( $(compgen -W "${globals[*]} --from" -- "$cur") )
-                    ;;
-            esac
             ;;
         login)
             case "$prev" in

--- a/tests/commands/test_pack.py
+++ b/tests/commands/test_pack.py
@@ -770,6 +770,7 @@ def test_charm_pack_output_managed_mode(config, emitter, formatted, monkeypatch)
 @pytest.mark.parametrize(
     "bases_indices, bad_index",
     [
+        (None, None),  # not used, it's fine
         ([], None),  # empty, it's fine
         ([0], None),  # first one
         ([1], None),  # second one


### PR DESCRIPTION
The Validator, also used from `pack`, no longer makes sense:

- bases_index: moved this control to the Pack command.

- `from`: this was filled with the result of --project-dir, which already verified that the directory existed

- `destructive_mode`, `debug`, `shell`, `shell_after` and `force`: just converted an already bool to bool

Left for next PR: move the `Builder` class and helper function/constants to the `pack.py` file (which would be a huge diff, specially because of tests, but without semantic changes).