### PR TITLE
Update snap install command to include --classic

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ multi-cloud application management.
 
 The recommended way to install `charmcraft` is from the stable channel with
 
-    sudo snap install charmcraft
+    sudo snap install charmcraft --classic
 
 There are multiple channels other than `stable`. See the full list with
 `snap info charmcraft`. We recommend either `latest/stable` or `latest/beta`


### PR DESCRIPTION
Very basic pull request focused on updating the `snap install ...` command for charmcraft in the main README of this repository.

### The problem

The snap install command is originally written as `sudo snap install charmcraft`, however, if you look in the Snap Store, you see that the charmcraft snap has `--classic` confinement. This means that the `--classic` flag needs to included when you install charmcraft using snap. The absence of the `--classic` flag is made evident when you go to install charmcraft as it throws an error if you use the original command:

```
$ sudo snap install charmcraft
error: This revision of snap "charmcraft" was published using classic confinement and thus may
       perform arbitrary system changes outside of the security sandbox that snaps are usually
       confined to, which may put your system at risk.

       If you understand and want to proceed repeat the command including --classic.
```

### The fix

Update the snap install command to include `--classic` so that the install is successful and does not throw an error about confinement. This will hopefully be beneficial to new charmers who are not familiar with snap confinement, and are working off of this repository to install charmcraft on their system.