### PR TITLE
docs(README): Replace obsoleted build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,11 +88,11 @@ With a correct `metadata.yaml` and with `ops` in `requirements.txt` you can
 build a charmed operator with:
 
 ```text
-$ charmcraft build
+$ charmcraft pack
 Created 'test-charm.charm'.
 ```
 
-`charmcraft build` will fetch additional files into the tree from PyPI based
+`charmcraft pack` will fetch additional files into the tree from PyPI based
 on `requirements.txt` and will compile modules using a virtualenv.
 
 The charmed operator is just a zipfile with metadata and the operator code


### PR DESCRIPTION
The README refers to the process of building a charm by invoking
`charmcraft build`, but that command is (no longer) available.
Looking at the code, a transition is being made from build.py to pack.py
and the command to build the charm is also `pack`.
I've renamed it to reflect this for the current version (2.0.0).