### PR TITLE
Fixed/simplified some tests to isolate them of underlying apt.

### DIFF
--- a/tests/commands/test_build.py
+++ b/tests/commands/test_build.py
@@ -14,7 +14,6 @@
 #
 # For further info, check https://github.com/canonical/charmcraft
 
-import logging
 import pathlib
 import re
 import subprocess
@@ -30,7 +29,7 @@ import yaml
 from craft_cli import EmitterMode, emit, CraftError
 
 from charmcraft import linters
-from charmcraft.charm_builder import DISPATCH_CONTENT, relativise
+from charmcraft.charm_builder import relativise
 from charmcraft.bases import get_host_as_base
 from charmcraft.commands.build import BUILD_DIRNAME, Builder, format_charm_file_name, launch_shell
 from charmcraft.config import Base, BasesConfiguration, load
@@ -178,60 +177,6 @@ def mock_provider(mock_instance, fake_provider):
 
 
 # --- (real) build tests
-
-
-@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
-def test_build_basic_complete_structure(basic_project, caplog, monkeypatch, config, tmp_path):
-    """Integration test: a simple structure with custom lib and normal src dir."""
-    caplog.set_level(logging.WARNING, logger="charmcraft")
-    host_base = get_host_as_base()
-    host_arch = host_base.architectures[0]
-    builder = get_builder(config)
-
-    # add an optional actions dir
-    actions_dir = basic_project / "actions"
-    actions_dir.mkdir()
-    (actions_dir / "actions_script.sh").write_text("run!")
-    actions_sub_dir = actions_dir / "subd"
-    actions_sub_dir.mkdir()
-    (actions_sub_dir / "blob.bin").write_text("123")
-
-    # save original metadata and verify later
-    metadata_file = basic_project / "metadata.yaml"
-    metadata_raw = metadata_file.read_bytes()
-
-    monkeypatch.setenv("CHARMCRAFT_MANAGED_MODE", "1")
-    with patch(
-        "charmcraft.commands.build.check_if_base_matches_host",
-        return_value=(True, None),
-    ), patch("charmcraft.env.get_managed_environment_home_path", return_value=tmp_path / "root"):
-        zipnames = builder.run()
-
-    assert zipnames == [
-        f"name-from-metadata_{host_base.name}-{host_base.channel}-{host_arch}.charm"
-    ]
-
-    # check all is properly inside the zip
-    # contents!), and all relative to build dir
-    zf = zipfile.ZipFile(zipnames[0])
-    assert zf.read("metadata.yaml") == metadata_raw
-    assert zf.read("src/charm.py") == b"all the magic"
-    dispatch = DISPATCH_CONTENT.format(entrypoint_relative_path="src/charm.py").encode("ascii")
-    assert zf.read("dispatch") == dispatch
-    assert zf.read("hooks/install") == dispatch
-    assert zf.read("hooks/start") == dispatch
-    assert zf.read("hooks/upgrade-charm") == dispatch
-    assert zf.read("lib/ops/stuff.txt") == b"ops stuff"
-    assert zf.read("LICENSE") == b"license content"
-    assert zf.read("icon.svg") == b"icon content"
-    assert zf.read("README.md") == b"README content"
-    assert zf.read("actions/actions_script.sh") == b"run!"
-    assert zf.read("actions/subd/blob.bin") == b"123"
-
-    # check the manifest is present and with particular values that depend on given info
-    manifest = yaml.safe_load(zf.read("manifest.yaml"))
-    assert manifest["charmcraft-started-at"] == config.project.started_at.isoformat() + "Z"
-    assert caplog.records == []
 
 
 def test_build_error_without_metadata_yaml(basic_project):
@@ -1209,9 +1154,13 @@ def test_build_part_from_config(basic_project, monkeypatch):
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
-def test_build_using_linters_attributes(basic_project, monkeypatch, config, tmp_path):
+def test_build_using_linters_attributes(basic_project_builder, monkeypatch, tmp_path):
     """Generic use of linters, pass them ok to their proceessor and save them in the manifest."""
-    builder = get_builder(config)
+    host_base = get_host_as_base()
+    builder = basic_project_builder(
+        [BasesConfiguration(**{"build-on": [host_base], "run-on": [host_base]})],
+        force=True,  # to ignore any linter issue
+    )
 
     # the results from the analyzer
     linting_results = [
@@ -1232,17 +1181,14 @@ def test_build_using_linters_attributes(basic_project, monkeypatch, config, tmp_
     ]
 
     monkeypatch.setenv("CHARMCRAFT_MANAGED_MODE", "1")
-    with patch(
-        "charmcraft.commands.build.check_if_base_matches_host",
-        return_value=(True, None),
-    ), patch("charmcraft.env.get_managed_environment_home_path", return_value=tmp_path / "root"):
+    with patch("charmcraft.env.get_managed_environment_home_path", return_value=tmp_path / "root"):
         with patch("charmcraft.linters.analyze") as mock_analyze:
             with patch.object(Builder, "show_linting_results") as mock_show_lint:
                 mock_analyze.return_value = linting_results
                 zipnames = builder.run()
 
     # check the analyze and processing functions were called properly
-    mock_analyze.assert_called_with(config, tmp_path / "root" / "prime")
+    mock_analyze.assert_called_with(builder.config, tmp_path / "root" / "prime")
     mock_show_lint.assert_called_with(linting_results)
 
     # the manifest should have all the results (including the ignored one)

--- a/tests/test_parts.py
+++ b/tests/test_parts.py
@@ -390,34 +390,32 @@ class TestPartsLifecycle:
 
     def test_run_actions_progress(self, tmp_path, monkeypatch, emitter):
         data = {
-            "plugin": "charm",
+            "plugin": "nil",
             "source": ".",
-            "charm-entrypoint": "my-entrypoint",
         }
 
         lifecycle = parts.PartsLifecycle(
-            all_parts={"charm": data},
+            all_parts={"testpart": data},
             work_dir=tmp_path,
             project_dir=tmp_path,
             project_name="test",
-            ignore_local_sources=["*.charm"],
+            ignore_local_sources=[],
         )
 
         action1 = Action(
-            part_name="charm", step=Step.STAGE, action_type=ActionType.RUN, reason=None
+            part_name="testpart", step=Step.STAGE, action_type=ActionType.RUN, reason=None
         )
         action2 = Action(
-            part_name="charm", step=Step.PRIME, action_type=ActionType.RUN, reason=None
+            part_name="testpart", step=Step.PRIME, action_type=ActionType.RUN, reason=None
         )
 
-        with patch("craft_parts.LifecycleManager.clean"):
-            with patch("craft_parts.LifecycleManager.plan") as mock_plan:
-                mock_plan.return_value = [action1, action2]
-                with patch("craft_parts.executor.executor.ExecutionContext.execute") as mock_exec:
-                    lifecycle.run(Step.PRIME)
+        with patch("craft_parts.LifecycleManager.plan") as mock_plan:
+            mock_plan.return_value = [action1, action2]
+            with patch("craft_parts.executor.executor.ExecutionContext.execute") as mock_exec:
+                lifecycle.run(Step.PRIME)
 
-        emitter.assert_progress("Running step STAGE for part 'charm'")
-        emitter.assert_progress("Running step PRIME for part 'charm'")
+        emitter.assert_progress("Running step STAGE for part 'testpart'")
+        emitter.assert_progress("Running step PRIME for part 'testpart'")
         assert mock_exec.call_args_list == [
             call([action1], stdout=ANY, stderr=ANY),
             call([action2], stdout=ANY, stderr=ANY),


### PR DESCRIPTION
I started running the test suite in a different way and found that some tests failed because "couldn't run `apt`". That was totally a leak, and tests running apt scare me.

So I fixed/simplified them. In detail:

- `test_parts.TestPartsLifecycle.test_run_actions_progress`: used a "null plugin"; using the charm one was irrelevant for what is being tested (that progress was informed for the different actions).

- `test_build.test_build_basic_complete_structure`: this was more like an "integration test" from the very first days, it doesn't make much sense since the real charm building is responsibility of the `charm_builder.py` script, and it was patched more and more in the last months, and this was the final nail in the coffin. Its conceptual flaw is that it uses the external machinery and then check that the charm built ok, which of course needs *a real underlying execution*, which of course is not 100% possible in a test.

- `test_build.test_build_using_linters_attributes`: improved the test to use a better project setup (copied from other tests), which even lead to a minor simplification.
