### PR TITLE
create_build_plan: refactor

### DIFF
--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -22,18 +22,18 @@ import os
 import pathlib
 import subprocess
 import zipfile
-from typing import List, Optional, Tuple
+from typing import List, Optional
 
 from craft_cli import emit, CraftError
 
 from charmcraft import env, linters, parts
-from charmcraft.bases import check_if_base_matches_host
 from charmcraft.charm_builder import DISPATCH_FILENAME, HOOKS_DIR
 from charmcraft.config import Base, BasesConfiguration
 from charmcraft.manifest import create_manifest
 from charmcraft.metadata import parse_metadata_yaml
 from charmcraft.parts import Step
 from charmcraft.providers import capture_logs_from_instance, get_provider
+from charmcraft.providers.providers import create_build_plan
 
 # Some constants that are used through the code.
 BUILD_DIRNAME = "build"
@@ -259,51 +259,6 @@ class Builder:
             if path.exists():
                 charm_part_prime.append(fn)
 
-    def plan(
-        self, *, bases_indices: Optional[List[int]], destructive_mode: bool, managed_mode: bool
-    ) -> List[Tuple[BasesConfiguration, Base, int, int]]:
-        """Determine the build plan based on user inputs and host environment.
-
-        Provide a list of bases that are buildable and scoped according to user
-        configuration. Provide all relevant details including the applicable
-        bases configuration and the indices of the entries to build for.
-
-        :returns: List of Tuples (bases_config, build_on, bases_index, build_on_index).
-        """
-        build_plan: List[Tuple[BasesConfiguration, Base, int, int]] = []
-
-        for bases_index, bases_config in enumerate(self.config.bases):
-            if bases_indices and bases_index not in bases_indices:
-                emit.debug(f"Skipping 'bases[{bases_index:d}]' due to --base-index usage.")
-                continue
-
-            for build_on_index, build_on in enumerate(bases_config.build_on):
-                if managed_mode or destructive_mode:
-                    matches, reason = check_if_base_matches_host(build_on)
-                else:
-                    matches, reason = self.provider.is_base_available(build_on)
-
-                if matches:
-                    emit.debug(
-                        f"Building for 'bases[{bases_index:d}]' "
-                        f"as host matches 'build-on[{build_on_index:d}]'.",
-                    )
-                    build_plan.append((bases_config, build_on, bases_index, build_on_index))
-                    break
-                else:
-                    emit.progress(
-                        f"Skipping 'bases[{bases_index:d}].build-on[{build_on_index:d}]': "
-                        f"{reason}.",
-                    )
-            else:
-                emit.progress(
-                    "No suitable 'build-on' environment found "
-                    f"in 'bases[{bases_index:d}]' configuration.",
-                    permanent=True,
-                )
-
-        return build_plan
-
     def run(
         self, bases_indices: Optional[List[int]] = None, destructive_mode: bool = False
     ) -> List[str]:
@@ -322,10 +277,12 @@ class Builder:
         if not managed_mode and not destructive_mode:
             self.provider.ensure_provider_is_available()
 
-        build_plan = self.plan(
+        build_plan = create_build_plan(
+            bases=self.config.bases,
             bases_indices=bases_indices,
             destructive_mode=destructive_mode,
             managed_mode=managed_mode,
+            provider=self.provider,
         )
         if not build_plan:
             raise CraftError(

--- a/charmcraft/providers/providers.py
+++ b/charmcraft/providers/providers.py
@@ -1,0 +1,104 @@
+# Copyright 2022 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For further info, check https://github.com/canonical/charmcraft
+
+"""Charmcraft-specific code to interface with craft-providers."""
+
+from typing import NamedTuple, List, Optional
+
+from craft_cli import emit, CraftError
+
+from charmcraft.bases import check_if_base_matches_host
+from charmcraft.config import Base, BasesConfiguration
+from charmcraft.providers import Provider
+
+
+class Plan(NamedTuple):
+    """A build plan for a particular base.
+
+    :param bases_config: The BasesConfiguration object, which contains a list of Bases to
+      build on and a list of Bases to run on.
+    :param build_on: The Base to build on.
+    :param bases_index: Index of the BasesConfiguration in bases_config containing the
+      Base to build on.
+    :param build_on_index: Index of the Base to build on in the BasesConfiguration's build_on list.
+    """
+
+    bases_config: BasesConfiguration
+    build_on: Base
+    bases_index: int
+    build_on_index: int
+
+
+def create_build_plan(
+    *,
+    bases: Optional[List[BasesConfiguration]],
+    bases_indices: Optional[List[int]],
+    destructive_mode: bool,
+    managed_mode: bool,
+    provider: Provider,
+) -> List[Plan]:
+    """Determine the build plan based on user inputs and host environment.
+
+    Provide a list of bases that are buildable and scoped according to user
+    configuration. Provide all relevant details including the applicable
+    bases configuration and the indices of the entries to build for.
+
+    :param bases: List of BaseConfigurations
+    :param bases_indices: List of indices of which BaseConfigurations to consider when creating
+      the build plan. If None, then all BaseConfigurations are considered
+    :param destructive_mode: True is charmcraft is running in destructive mode
+    :param managed_mode: True is charmcraft is running in managed mode
+    :param provider: Provider object to check for base availability
+
+    :returns: List of Plans
+    :raises CraftError: if no bases are provided.
+    """
+    build_plan: List[Plan] = []
+
+    if not bases:
+        raise CraftError("Cannot create build plan because no bases were provided.")
+
+    for bases_index, bases_config in enumerate(bases):
+        if bases_indices and bases_index not in bases_indices:
+            emit.debug(f"Skipping 'bases[{bases_index:d}]' due to --base-index usage.")
+            continue
+
+        for build_on_index, build_on in enumerate(bases_config.build_on):
+            if managed_mode or destructive_mode:
+                matches, reason = check_if_base_matches_host(build_on)
+            else:
+                matches, reason = provider.is_base_available(build_on)
+
+            if matches:
+                emit.debug(
+                    f"Building for 'bases[{bases_index:d}]' "
+                    f"as host matches 'build-on[{build_on_index:d}]'.",
+                )
+                build_plan.append(Plan(bases_config, build_on, bases_index, build_on_index))
+                break
+            else:
+                emit.progress(
+                    f"Skipping 'bases[{bases_index:d}].build-on[{build_on_index:d}]': "
+                    f"{reason}.",
+                )
+        else:
+            emit.progress(
+                "No suitable 'build-on' environment found "
+                f"in 'bases[{bases_index:d}]' configuration.",
+                permanent=True,
+            )
+
+    return build_plan

--- a/tests/providers/test_providers.py
+++ b/tests/providers/test_providers.py
@@ -1,0 +1,422 @@
+# Copyright 2022 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For further info, check https://github.com/canonical/charmcraft
+
+from unittest.mock import Mock, patch, call
+
+import pytest
+
+from charmcraft.config import Base, BasesConfiguration
+from charmcraft.providers.providers import Plan, create_build_plan
+from craft_cli import CraftError
+
+
+@pytest.fixture()
+def mock_provider(mock_instance, fake_provider):
+    mock_provider = Mock(wraps=fake_provider)
+    with patch("charmcraft.commands.build.get_provider", return_value=mock_provider):
+        yield mock_provider
+
+
+@pytest.fixture()
+def mock_is_base_available():
+    with patch(
+        "charmcraft.providers._provider.Provider.is_base_available", return_value=(True, None)
+    ) as mock_is_base_available:
+        yield mock_is_base_available
+
+
+@pytest.fixture()
+def mock_check_if_base_matches_host():
+    with patch(
+        "charmcraft.providers.providers.check_if_base_matches_host", return_value=(True, None)
+    ) as mock_check_if_base_matches_host:
+        yield mock_check_if_base_matches_host
+
+
+@pytest.fixture()
+def simple_base_config():
+    """Yields a simple BaseConfiguration object."""
+    yield [
+        BasesConfiguration(
+            **{
+                "build-on": [
+                    Base(name="x1name", channel="x1channel", architectures=["x1arch"]),
+                ],
+                "run-on": [
+                    Base(name="x2name", channel="x2channel", architectures=["x2arch"]),
+                ],
+            }
+        ),
+    ]
+
+
+@pytest.fixture()
+def complex_base_config():
+    """Yields a complex list of BaseConfiguration objects."""
+    yield [
+        # 1 build-on and 1 run-on
+        BasesConfiguration(
+            **{
+                "build-on": [
+                    Base(name="x1name", channel="x1channel", architectures=["x1arch"]),
+                ],
+                "run-on": [
+                    Base(name="x2name", channel="x2channel", architectures=["x2arch"]),
+                ],
+            }
+        ),
+        # 2 build-on and 1 run-on
+        BasesConfiguration(
+            **{
+                "build-on": [
+                    Base(name="x3name", channel="x3channel", architectures=["x3arch"]),
+                    Base(name="x4name", channel="x4channel", architectures=["x4arch"]),
+                ],
+                "run-on": [
+                    Base(name="x5name", channel="x5channel", architectures=["x5arch"]),
+                ],
+            }
+        ),
+        # 1 build-on and 2 run-on with multiple architectures
+        BasesConfiguration(
+            **{
+                "build-on": [
+                    Base(name="x6name", channel="x6channel", architectures=["x6arch"]),
+                ],
+                "run-on": [
+                    Base(name="x7name", channel="x7channel", architectures=["x7arch"]),
+                    Base(
+                        name="x8name",
+                        channel="x8channel",
+                        architectures=["x8arch1", "x8arch2"],
+                    ),
+                ],
+            }
+        ),
+    ]
+
+
+def test_create_build_plan_simple(
+    emitter, mock_provider, mock_is_base_available, simple_base_config
+):
+    """Verify creation of a simple build plan."""
+    build_plan = create_build_plan(
+        bases=simple_base_config,
+        bases_indices=None,
+        destructive_mode=False,
+        managed_mode=False,
+        provider=mock_provider,
+    )
+
+    assert build_plan == [
+        Plan(
+            bases_config=BasesConfiguration(
+                **{
+                    "build-on": [
+                        Base(name="x1name", channel="x1channel", architectures=["x1arch"]),
+                    ],
+                    "run-on": [
+                        Base(name="x2name", channel="x2channel", architectures=["x2arch"]),
+                    ],
+                }
+            ),
+            build_on=Base(name="x1name", channel="x1channel", architectures=["x1arch"]),
+            bases_index=0,
+            build_on_index=0,
+        ),
+    ]
+    emitter.assert_interactions(
+        [
+            call("debug", "Building for 'bases[0]' as host matches 'build-on[0]'."),
+        ]
+    )
+
+
+def test_create_build_plan_complex(
+    emitter, complex_base_config, mock_provider, mock_is_base_available
+):
+    """Verify creation of a complex build plan."""
+
+    build_plan = create_build_plan(
+        bases=complex_base_config,
+        bases_indices=None,
+        destructive_mode=False,
+        managed_mode=False,
+        provider=mock_provider,
+    )
+
+    assert build_plan == [
+        Plan(
+            bases_config=BasesConfiguration(
+                **{
+                    "build-on": [
+                        Base(name="x1name", channel="x1channel", architectures=["x1arch"]),
+                    ],
+                    "run-on": [
+                        Base(name="x2name", channel="x2channel", architectures=["x2arch"]),
+                    ],
+                }
+            ),
+            build_on=Base(name="x1name", channel="x1channel", architectures=["x1arch"]),
+            bases_index=0,
+            build_on_index=0,
+        ),
+        Plan(
+            bases_config=BasesConfiguration(
+                **{
+                    "build-on": [
+                        Base(name="x3name", channel="x3channel", architectures=["x3arch"]),
+                        Base(name="x4name", channel="x4channel", architectures=["x4arch"]),
+                    ],
+                    "run-on": [
+                        Base(name="x5name", channel="x5channel", architectures=["x5arch"]),
+                    ],
+                }
+            ),
+            build_on=Base(name="x3name", channel="x3channel", architectures=["x3arch"]),
+            bases_index=1,
+            build_on_index=0,
+        ),
+        Plan(
+            bases_config=BasesConfiguration(
+                **{
+                    "build-on": [
+                        Base(name="x6name", channel="x6channel", architectures=["x6arch"]),
+                    ],
+                    "run-on": [
+                        Base(name="x7name", channel="x7channel", architectures=["x7arch"]),
+                        Base(
+                            name="x8name",
+                            channel="x8channel",
+                            architectures=["x8arch1", "x8arch2"],
+                        ),
+                    ],
+                }
+            ),
+            build_on=Base(name="x6name", channel="x6channel", architectures=["x6arch"]),
+            bases_index=2,
+            build_on_index=0,
+        ),
+    ]
+    emitter.assert_interactions(
+        [
+            call("debug", "Building for 'bases[0]' as host matches 'build-on[0]'."),
+            call("debug", "Building for 'bases[1]' as host matches 'build-on[0]'."),
+            call("debug", "Building for 'bases[2]' as host matches 'build-on[0]'."),
+        ]
+    )
+
+
+@pytest.mark.parametrize("destructive_mode, managed_mode", [(True, False), (False, True)])
+def test_create_build_plan_base_matches_host(
+    emitter,
+    destructive_mode,
+    managed_mode,
+    mock_check_if_base_matches_host,
+    mock_provider,
+    simple_base_config,
+):
+    """Verify the first `build_on` Base that matches the host is used for the build plan
+    when building in managed mode or destructive mode."""
+    build_plan = create_build_plan(
+        bases=simple_base_config,
+        bases_indices=None,
+        destructive_mode=destructive_mode,
+        managed_mode=managed_mode,
+        provider=mock_provider,
+    )
+
+    assert build_plan == [
+        Plan(
+            bases_config=BasesConfiguration(
+                **{
+                    "build-on": [
+                        Base(name="x1name", channel="x1channel", architectures=["x1arch"]),
+                    ],
+                    "run-on": [
+                        Base(name="x2name", channel="x2channel", architectures=["x2arch"]),
+                    ],
+                }
+            ),
+            build_on=Base(name="x1name", channel="x1channel", architectures=["x1arch"]),
+            bases_index=0,
+            build_on_index=0,
+        ),
+    ]
+    emitter.assert_interactions(
+        [
+            call("debug", "Building for 'bases[0]' as host matches 'build-on[0]'."),
+        ]
+    )
+
+
+def test_create_build_plan_is_base_available(emitter, mock_is_base_available, mock_provider):
+    """Verify the first available `build_on` Base that is used for the build plan."""
+    base = [
+        BasesConfiguration(
+            **{
+                "build-on": [
+                    Base(name="x1name", channel="x1channel", architectures=["x1arch"]),
+                    Base(name="x2name", channel="x2channel", architectures=["x2arch"]),
+                ],
+                "run-on": [
+                    Base(name="x3name", channel="x3channel", architectures=["x3arch"]),
+                ],
+            }
+        )
+    ]
+
+    # the first Base is not available, but the second Base is available
+    mock_is_base_available.side_effect = [(False, "test error message"), (True, None)]
+
+    build_plan = create_build_plan(
+        bases=base,
+        bases_indices=None,
+        destructive_mode=False,
+        managed_mode=False,
+        provider=mock_provider,
+    )
+
+    # verify charmcraft will build on the second Base
+    assert build_plan[0].build_on == Base(
+        name="x2name", channel="x2channel", architectures=["x2arch"]
+    )
+    assert build_plan[0].build_on_index == 1
+
+    emitter.assert_interactions(
+        [
+            call("progress", "Skipping 'bases[0].build-on[0]': test error message."),
+            call("debug", "Building for 'bases[0]' as host matches 'build-on[1]'."),
+        ]
+    )
+
+
+def test_create_build_plan_base_index_usage(
+    complex_base_config,
+    emitter,
+    mock_is_base_available,
+    mock_provider,
+):
+    """Verify `bases_indices` argument causes build plan to only contain matching bases."""
+    build_plan = create_build_plan(
+        bases=complex_base_config,
+        bases_indices=[1, 2],
+        destructive_mode=False,
+        managed_mode=False,
+        provider=mock_provider,
+    )
+
+    assert build_plan == [
+        Plan(
+            bases_config=BasesConfiguration(
+                **{
+                    "build-on": [
+                        Base(name="x3name", channel="x3channel", architectures=["x3arch"]),
+                        Base(name="x4name", channel="x4channel", architectures=["x4arch"]),
+                    ],
+                    "run-on": [
+                        Base(name="x5name", channel="x5channel", architectures=["x5arch"]),
+                    ],
+                }
+            ),
+            build_on=Base(name="x3name", channel="x3channel", architectures=["x3arch"]),
+            bases_index=1,
+            build_on_index=0,
+        ),
+        Plan(
+            bases_config=BasesConfiguration(
+                **{
+                    "build-on": [
+                        Base(name="x6name", channel="x6channel", architectures=["x6arch"]),
+                    ],
+                    "run-on": [
+                        Base(name="x7name", channel="x7channel", architectures=["x7arch"]),
+                        Base(
+                            name="x8name",
+                            channel="x8channel",
+                            architectures=["x8arch1", "x8arch2"],
+                        ),
+                    ],
+                }
+            ),
+            build_on=Base(name="x6name", channel="x6channel", architectures=["x6arch"]),
+            bases_index=2,
+            build_on_index=0,
+        ),
+    ]
+
+    emitter.assert_interactions(
+        [
+            call("debug", "Skipping 'bases[0]' due to --base-index usage."),
+            call("debug", "Building for 'bases[1]' as host matches 'build-on[0]'."),
+            call("debug", "Building for 'bases[2]' as host matches 'build-on[0]'."),
+        ]
+    )
+
+
+def test_create_build_plan_no_suitable_bases(
+    emitter, complex_base_config, mock_is_base_available, mock_provider
+):
+    """Verify an empty build plan is returned when no bases are available."""
+    mock_is_base_available.return_value = (False, "test error message")
+
+    build_plan = create_build_plan(
+        bases=complex_base_config,
+        bases_indices=None,
+        destructive_mode=False,
+        managed_mode=False,
+        provider=mock_provider,
+    )
+
+    assert build_plan == []
+
+    emitter.assert_interactions(
+        [
+            call("progress", "Skipping 'bases[0].build-on[0]': test error message."),
+            call(
+                "progress",
+                "No suitable 'build-on' environment found in 'bases[0]' configuration.",
+                permanent=True,
+            ),
+            call("progress", "Skipping 'bases[1].build-on[0]': test error message."),
+            call("progress", "Skipping 'bases[1].build-on[1]': test error message."),
+            call(
+                "progress",
+                "No suitable 'build-on' environment found in 'bases[1]' configuration.",
+                permanent=True,
+            ),
+            call("progress", "Skipping 'bases[2].build-on[0]': test error message."),
+            call(
+                "progress",
+                "No suitable 'build-on' environment found in 'bases[2]' configuration.",
+                permanent=True,
+            ),
+        ]
+    )
+
+
+def test_create_build_plan_no_bases_error(mock_provider):
+    """Verify an error is raised when no bases are passed."""
+    with pytest.raises(CraftError) as error:
+        create_build_plan(
+            bases=None,
+            bases_indices=None,
+            destructive_mode=False,
+            managed_mode=False,
+            provider=mock_provider,
+        )
+
+    assert str(error.value) == "Cannot create build plan because no bases were provided."


### PR DESCRIPTION
### Overview
- `create_build_plan` is now in a common location so other commands can access it
- `create_build_plan` returns a list of named tuples
- Added a comprehensive set of unit tests.  Previously, this function was only being tested indirectly.

### Rationale for the new file `charmcraft/providers/providers.py`
As the new `craft-providers` interface is built out, the directory `charmcraft/providers/` will be split into 2 places:
1. `charmcraft/providers.py` for charmcraft-specific code
2. The `craft-providers` library

The code in the `charmcraft/providers/` directory will be split piece-by-piece, in a series of small PRs.

Once all the code is finally split, the file `charmcraft/providers/providers.py` will be moved to `charmcraft/providers.py`. Then, the directory will be removed. Finally, all references to the intermediate file`charmcraft/providers/providers.py` will be replaced with `charmcraft/providers.py`.

(CRAFT-1272)