### PR TITLE
requirements: update craft-providers to 1.4.1

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,7 @@ click==8.1.3
 coverage==6.4.3
 craft-cli==1.2.0
 craft-parts==1.10.2
-craft-providers==1.4.0
+craft-providers==1.4.1
 craft-store==2.1.1
 cryptography==3.4
 Deprecated==1.2.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ cffi==1.15.1
 charset-normalizer==2.1.0
 craft-cli==1.2.0
 craft-parts==1.10.2
-craft-providers==1.4.0
+craft-providers==1.4.1
 craft-store==2.1.1
 cryptography==3.4
 Deprecated==1.2.13


### PR DESCRIPTION
Bump `craft-providers` to `1.4.1` to fix a bug in the truncation of long hostnames when creating an instance.