### PR TITLE
tests: bootstrap spread

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tools/external"]
+	path = tools/external
+	url = https://github.com/snapcore/snapd-testing-tools.git

--- a/spread.yaml
+++ b/spread.yaml
@@ -1,0 +1,67 @@
+project: charmcraft
+
+path: /charmcraft
+environment:
+  PROJECT_PATH: /charmcraft
+  PATH: /snap/bin:$PATH:$PROJECT_PATH/tools/external/tools
+
+backends:
+  google:
+    key: '$(HOST: echo "$SPREAD_GOOGLE_KEY")'
+    location: snapd-spread/us-east1-b
+    halt-timeout: 2h
+    systems:
+      - ubuntu-18.04-64:
+          workers: 1
+          storage: 40G
+      - ubuntu-20.04-64:
+          workers: 1
+          storage: 40G
+      - ubuntu-22.04-64:
+          workers: 1
+          storage: 40G
+      - fedora-35-64:
+          workers: 1
+          storage: 40G
+
+prepare: |
+  set -e
+  if os.query is-ubuntu; then
+    tempfile="$(mktemp)"
+    if ! apt-get update > "$tempfile" 2>&1; then
+        cat "$tempfile"
+        exit 1
+    fi
+  fi
+
+  tests.pkgs install snapd
+
+  snap wait system seed.loaded
+
+  # The /snap directory does not exist in some environments
+  [ ! -d /snap ] && ln -s /var/lib/snapd/snap /snap
+
+  snap install lxd
+
+  # Hold snap refreshes for 24h.
+  snap set system refresh.hold="$(date --date=tomorrow +%Y-%m-%dT%H:%M:%S%:z)"
+  if ! snap watch --last=auto-refresh?; then
+      journalctl -xe
+  fi
+  if ! snap watch --last=install?; then
+      journalctl -xe
+  fi
+
+  lxd waitready --timeout=30
+  lxd init --auto
+
+  if stat /charmcraft/charmcraft_*.snap 2>/dev/null; then
+    snap install --classic --dangerous /charmcraft/charmcraft_*.snap
+  else
+    echo "Expected a snap to exist in /charmcraft/"
+    exit 1
+  fi
+
+suites:
+  tests/spread/commands/:
+    summary: simple charmcraft commands

--- a/tests/spread/commands/version/task.yaml
+++ b/tests/spread/commands/version/task.yaml
@@ -1,0 +1,7 @@
+summary: simple version command probe
+
+execute: |
+  if ! charmcraft version; then
+      echo charmcraft version command is not working
+      exit 1
+  fi


### PR DESCRIPTION
This is "just enough" spread to run locally considering one has google credentials to run with.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

---
CRAFT-1367

```
$ spread google:
2022-09-13 19:22:51 Project content is packed for delivery (100.22MB).
2022-09-13 19:22:51 If killed, discard servers with: spread -reuse-pid=662378 -discard
2022-09-13 19:22:51 Allocating google:fedora-35-64...
2022-09-13 19:22:51 Allocating google:ubuntu-22.04-64...
2022-09-13 19:22:51 Allocating google:ubuntu-20.04-64...
2022-09-13 19:22:51 Allocating google:ubuntu-18.04-64...
2022-09-13 19:23:00 Waiting for google:fedora-35-64 (sep132222-895658) to boot at 34.139.76.162...
2022-09-13 19:23:01 Waiting for google:ubuntu-22.04-64 (sep132222-895807) to boot at 34.148.61.82...
2022-09-13 19:23:02 Waiting for google:ubuntu-20.04-64 (sep132222-895898) to boot at 35.237.46.168...
2022-09-13 19:23:04 Waiting for google:ubuntu-18.04-64 (sep132222-895914) to boot at 35.227.120.168...
2022-09-13 19:23:38 Allocated google:fedora-35-64 (sep132222-895658).
2022-09-13 19:23:38 Connecting to google:fedora-35-64 (sep132222-895658)...
2022-09-13 19:23:39 Connected to google:fedora-35-64 (sep132222-895658) at 34.139.76.162.
2022-09-13 19:23:39 Sending project content to google:fedora-35-64 (sep132222-895658)...
2022-09-13 19:23:43 Allocated google:ubuntu-22.04-64 (sep132222-895807).
2022-09-13 19:23:43 Connecting to google:ubuntu-22.04-64 (sep132222-895807)...
2022-09-13 19:23:45 Connected to google:ubuntu-22.04-64 (sep132222-895807) at 34.148.61.82.
2022-09-13 19:23:45 Sending project content to google:ubuntu-22.04-64 (sep132222-895807)...
2022-09-13 19:23:50 Preparing google:fedora-35-64 (sep132222-895658)...
2022-09-13 19:23:50 Allocated google:ubuntu-20.04-64 (sep132222-895898).
2022-09-13 19:23:50 Connecting to google:ubuntu-20.04-64 (sep132222-895898)...
2022-09-13 19:23:51 Allocated google:ubuntu-18.04-64 (sep132222-895914).
2022-09-13 19:23:51 Connecting to google:ubuntu-18.04-64 (sep132222-895914)...
2022-09-13 19:23:51 Connected to google:ubuntu-20.04-64 (sep132222-895898) at 35.237.46.168.
2022-09-13 19:23:51 Sending project content to google:ubuntu-20.04-64 (sep132222-895898)...
2022-09-13 19:23:52 Connected to google:ubuntu-18.04-64 (sep132222-895914) at 35.227.120.168.
2022-09-13 19:23:52 Sending project content to google:ubuntu-18.04-64 (sep132222-895914)...
2022-09-13 19:24:03 Preparing google:ubuntu-20.04-64 (sep132222-895898)...
2022-09-13 19:24:05 Preparing google:ubuntu-18.04-64 (sep132222-895914)...
2022-09-13 19:24:47 Executing google:ubuntu-20.04-64:tests/spread/commands/version (sep132222-895898) (1/4)...
2022-09-13 19:24:50 Executing google:ubuntu-18.04-64:tests/spread/commands/version (sep132222-895914) (2/4)...
2022-09-13 19:24:50 Discarding google:ubuntu-20.04-64 (sep132222-895898)...
2022-09-13 19:24:52 Discarding google:ubuntu-18.04-64 (sep132222-895914)...
2022-09-13 19:25:52 Preparing google:ubuntu-22.04-64 (sep132222-895807)...
2022-09-13 19:25:57 Executing google:fedora-35-64:tests/spread/commands/version (sep132222-895658) (3/4)...
2022-09-13 19:26:00 Discarding google:fedora-35-64 (sep132222-895658)...
2022-09-13 19:26:33 Executing google:ubuntu-22.04-64:tests/spread/commands/version (sep132222-895807) (4/4)...
2022-09-13 19:26:36 Discarding google:ubuntu-22.04-64 (sep132222-895807)...
2022-09-13 19:26:37 Successful tasks: 4
2022-09-13 19:26:37 Aborted tasks: 0
```