### PR TITLE
Set isort line_length in the init templates to same as other tools.

### DIFF
--- a/charmcraft/templates/init-simple/pyproject.toml.j2
+++ b/charmcraft/templates/init-simple/pyproject.toml.j2
@@ -15,6 +15,7 @@ line-length = 99
 target-version = ["py38"]
 
 [tool.isort]
+line_length = 99
 profile = "black"
 
 # Linting tools configuration


### PR DESCRIPTION
Without this, isort will make a single import line with 88<n_chars<99 into a multi-line import, and black will convert it back to a single line. They will never pass at the same time.

Improvement brought from https://github.com/canonical/template-operator/pull/36 .