### PR TITLE
Use incremental delays (with very small first ones) during the polling of upload status (CRAFT-894).

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@
 import contextlib
 import datetime
 import json
-import imp
+import importlib
 import pathlib
 import tempfile
 import types
@@ -116,7 +116,7 @@ def intertests_cleanups():
 
     - unregister all Craft Parts plugins callbacks
     """
-    imp.reload(instrum)
+    importlib.reload(instrum)
     yield
     deprecations._ALREADY_NOTIFIED.clear()
     callbacks.unregister_all()


### PR DESCRIPTION
Fixes #79.

Also sneaked in a change of `imp` to `importlib` library (as the former is deprecated).