### PR TITLE
providers: move `is_base_available()` to providers.py

### DIFF
--- a/charmcraft/providers/_provider.py
+++ b/charmcraft/providers/_provider.py
@@ -19,14 +19,10 @@
 import contextlib
 import pathlib
 from abc import ABC, abstractmethod
-from typing import Generator, Tuple, Union
+from typing import Generator
 
 from craft_cli import emit, CraftError
-from craft_providers import Executor, ProviderError
-
-from charmcraft.config import Base
-from charmcraft.utils import get_host_architecture
-from .providers import BASE_CHANNEL_TO_PROVIDER_BASE
+from craft_providers import Executor, ProviderError, base
 
 
 class Provider(ABC):
@@ -59,38 +55,6 @@ class Provider(ABC):
         """
 
     @classmethod
-    def is_base_available(cls, base: Base) -> Tuple[bool, Union[str, None]]:
-        """Check if provider can provide an environment matching given base.
-
-        :param base: Base to check.
-
-        :returns: Tuple of bool indicating whether it is a match, with optional
-                reason if not a match.
-        """
-        arch = get_host_architecture()
-        if arch not in base.architectures:
-            return (
-                False,
-                f"host architecture {arch!r} not in base architectures {base.architectures!r}",
-            )
-
-        if base.name != "ubuntu":
-            return (
-                False,
-                f"name {base.name!r} is not yet supported (must be 'ubuntu')",
-            )
-
-        if base.channel not in BASE_CHANNEL_TO_PROVIDER_BASE:
-            *firsts, last = sorted(BASE_CHANNEL_TO_PROVIDER_BASE)
-            allowed = f"{', '.join(map(repr, firsts))} or {last!r}"
-            return (
-                False,
-                f"channel {base.channel!r} is not yet supported (must be {allowed})",
-            )
-
-        return True, None
-
-    @classmethod
     @abstractmethod
     def is_provider_installed(cls) -> bool:
         """Check if provider is installed.
@@ -114,7 +78,7 @@ class Provider(ABC):
         *,
         charm_name: str,
         project_path: pathlib.Path,
-        base_configuration: Base,
+        base_configuration: base.Base,
         build_base: str,
         instance_name: str,
     ) -> Generator[Executor, None, None]:

--- a/tests/providers/test_lxd.py
+++ b/tests/providers/test_lxd.py
@@ -23,14 +23,13 @@ from craft_providers import bases
 from craft_providers.lxd import LXDError, LXDInstallationError
 
 from charmcraft import providers
-from charmcraft.config import Base
 from charmcraft.providers.providers import get_base_configuration
 
 
 @pytest.fixture(autouse=True)
 def mock_base_provider_get_host_architecture():
     with mock.patch(
-        "charmcraft.providers._provider.get_host_architecture", return_value="host-arch"
+        "charmcraft.providers.providers.get_host_architecture", return_value="host-arch"
     ) as mock_arch:
         yield mock_arch
 
@@ -116,45 +115,6 @@ def test_ensure_provider_is_available_errors_when_lxd_not_ready(
         provider.ensure_provider_is_available()
 
     assert exc_info.value.__cause__ is error
-
-
-@pytest.mark.parametrize(
-    "name,channel,architectures,expected_valid,expected_reason",
-    [
-        ("ubuntu", "18.04", ["host-arch"], True, None),
-        ("ubuntu", "20.04", ["host-arch"], True, None),
-        ("ubuntu", "22.04", ["host-arch"], True, None),
-        ("ubuntu", "20.04", ["extra-arch", "host-arch"], True, None),
-        (
-            "not-ubuntu",
-            "20.04",
-            ["host-arch"],
-            False,
-            "name 'not-ubuntu' is not yet supported (must be 'ubuntu')",
-        ),
-        (
-            "ubuntu",
-            "10.04",
-            ["host-arch"],
-            False,
-            "channel '10.04' is not yet supported (must be '18.04', '20.04' or '22.04')",
-        ),
-        (
-            "ubuntu",
-            "20.04",
-            ["other-arch"],
-            False,
-            "host architecture 'host-arch' not in base architectures ['other-arch']",
-        ),
-    ],
-)
-def test_is_base_available(name, channel, architectures, expected_valid, expected_reason):
-    base = Base(name=name, channel=channel, architectures=architectures)
-    provider = providers.LXDProvider()
-
-    valid, reason = provider.is_base_available(base)
-
-    assert (valid, reason) == (expected_valid, expected_reason)
 
 
 @pytest.mark.parametrize("is_installed", [True, False])

--- a/tests/providers/test_multipass.py
+++ b/tests/providers/test_multipass.py
@@ -23,14 +23,13 @@ from craft_providers import bases
 from craft_providers.multipass import MultipassError, MultipassInstallationError
 
 from charmcraft import providers
-from charmcraft.config import Base
 from charmcraft.providers.providers import get_base_configuration
 
 
 @pytest.fixture(autouse=True)
 def mock_base_provider_get_host_architecture():
     with mock.patch(
-        "charmcraft.providers._provider.get_host_architecture", return_value="host-arch"
+        "charmcraft.providers.providers.get_host_architecture", return_value="host-arch"
     ) as mock_arch:
         yield mock_arch
 
@@ -113,45 +112,6 @@ def test_ensure_provider_is_available_errors_when_multipass_not_ready(
         provider.ensure_provider_is_available()
 
     assert exc_info.value.__cause__ is error
-
-
-@pytest.mark.parametrize(
-    "name,channel,architectures,expected_valid,expected_reason",
-    [
-        ("ubuntu", "18.04", ["host-arch"], True, None),
-        ("ubuntu", "20.04", ["host-arch"], True, None),
-        ("ubuntu", "22.04", ["host-arch"], True, None),
-        ("ubuntu", "20.04", ["extra-arch", "host-arch"], True, None),
-        (
-            "not-ubuntu",
-            "20.04",
-            ["host-arch"],
-            False,
-            "name 'not-ubuntu' is not yet supported (must be 'ubuntu')",
-        ),
-        (
-            "ubuntu",
-            "10.04",
-            ["host-arch"],
-            False,
-            "channel '10.04' is not yet supported (must be '18.04', '20.04' or '22.04')",
-        ),
-        (
-            "ubuntu",
-            "20.04",
-            ["other-arch"],
-            False,
-            "host architecture 'host-arch' not in base architectures ['other-arch']",
-        ),
-    ],
-)
-def test_is_base_available(name, channel, architectures, expected_valid, expected_reason):
-    base = Base(name=name, channel=channel, architectures=architectures)
-    provider = providers.MultipassProvider()
-
-    valid, reason = provider.is_base_available(base)
-
-    assert (valid, reason) == (expected_valid, expected_reason)
 
 
 @pytest.mark.parametrize("is_installed", [True, False])

--- a/tests/providers/test_provider.py
+++ b/tests/providers/test_provider.py
@@ -21,13 +21,12 @@ from craft_providers.lxd import LXDError
 import pytest
 
 from charmcraft import providers
-from charmcraft.config import Base
 
 
 @pytest.fixture(autouse=True)
 def mock_get_host_architecture():
     with patch(
-        "charmcraft.providers._provider.get_host_architecture", return_value="host-arch"
+        "charmcraft.providers.providers.get_host_architecture", return_value="host-arch"
     ) as mock_arch:
         yield mock_arch
 
@@ -54,47 +53,6 @@ def mock_lxd_is_installed():
 def mock_lxd_exists():
     with patch("craft_providers.lxd.LXDInstance.exists", return_value=True) as mock_exists:
         yield mock_exists
-
-
-@pytest.mark.parametrize(
-    "name,channel,architectures,expected_valid,expected_reason",
-    [
-        ("ubuntu", "18.04", ["host-arch"], True, None),
-        ("ubuntu", "20.04", ["host-arch"], True, None),
-        ("ubuntu", "22.04", ["host-arch"], True, None),
-        ("ubuntu", "20.04", ["extra-arch", "host-arch"], True, None),
-        (
-            "not-ubuntu",
-            "20.04",
-            ["host-arch"],
-            False,
-            "name 'not-ubuntu' is not yet supported (must be 'ubuntu')",
-        ),
-        (
-            "ubuntu",
-            "10.04",
-            ["host-arch"],
-            False,
-            "channel '10.04' is not yet supported (must be '18.04', '20.04' or '22.04')",
-        ),
-        (
-            "ubuntu",
-            "20.04",
-            ["other-arch"],
-            False,
-            "host architecture 'host-arch' not in base architectures ['other-arch']",
-        ),
-    ],
-)
-def test_is_base_available(
-    mock_get_host_architecture, name, channel, architectures, expected_valid, expected_reason
-):
-    base = Base(name=name, channel=channel, architectures=architectures)
-    provider = providers.LXDProvider()
-
-    valid, reason = provider.is_base_available(base)
-
-    assert (valid, reason) == (expected_valid, expected_reason)
 
 
 def test_clean_project_environments_provider_not_installed(


### PR DESCRIPTION
`is_base_available()` contains charmcraft-specific logic, so it is separated from the craft-providers interface