### PR TITLE
Fix for getting image info from digest

### DIFF
--- a/charmcraft/commands/store/__init__.py
+++ b/charmcraft/commands/store/__init__.py
@@ -1745,7 +1745,9 @@ class UploadResourceCommand(BaseCommand):
         group.add_argument(
             "--image",
             type=SingleOptionEnsurer(str),
-            help="The digest (remote or local) or id (local) of the OCI image",
+            help=(
+                'The digest (remote or local) or id (local, exclude "sha256:") of the OCI image'
+            ),
         )
 
     def run(self, parsed_args):

--- a/charmcraft/commands/store/registry.py
+++ b/charmcraft/commands/store/registry.py
@@ -332,6 +332,8 @@ class LocalDockerdInterface:
             return
 
         for image_info in response.json():
+            if image_info["RepoDigests"] is None:
+                continue
             if any(digest in repo_digest for repo_digest in image_info["RepoDigests"]):
                 return image_info
 

--- a/tests/commands/test_store_registry.py
+++ b/tests/commands/test_store_registry.py
@@ -826,6 +826,22 @@ def test_localdockerinterface_get_info_by_digest_not_found(responses, emitter):
     emitter.assert_interactions(None)
 
 
+def test_localdockerinterface_get_info_by_digest_none_digest(responses, emitter):
+    """Get image info for something that is not there."""
+    test_image_info_1 = {"some": "stuff", "RepoDigests": None}
+    test_search_respoonse = [test_image_info_1]
+    responses.add(
+        responses.GET,
+        LocalDockerdInterface.dockerd_socket_baseurl + "/images/json",
+        json=test_search_respoonse,
+    )
+    ldi = LocalDockerdInterface()
+    resp = ldi.get_image_info_from_digest("sha256:test-digest")
+    assert resp is None
+
+    emitter.assert_interactions(None)
+
+
 def test_localdockerinterface_get_info_by_digest_bad_response(responses, emitter):
     """Docker answered badly when checking for the image."""
     # weird dockerd behaviour


### PR DESCRIPTION
I have consistently encountered an error when trying to upload an OCI image resource by digest,
```
2022-10-19 18:48:50.975 Checking if manifest is already uploaded
2022-10-19 18:48:54.748 Remote image not found, getting its info from local registry.
2022-10-19 18:48:54.752 charmcraft internal error: TypeError("'NoneType' object is not iterable")
2022-10-19 18:48:54.757 Traceback (most recent call last):
2022-10-19 18:48:54.757   File "/snap/charmcraft/1083/lib/charmcraft/main.py", line 180, in main
2022-10-19 18:48:54.757     retcode = dispatcher.run()
2022-10-19 18:48:54.757   File "/snap/charmcraft/1083/lib/craft_cli/dispatcher.py", line 448, in run
2022-10-19 18:48:54.757     return self._loaded_command.run(self._parsed_command_args)
2022-10-19 18:48:54.757   File "/snap/charmcraft/1083/lib/charmcraft/commands/store/__init__.py", line 1778, in run
2022-10-19 18:48:54.757     image_info = dockerd.get_image_info_from_digest(parsed_args.image)
2022-10-19 18:48:54.757   File "/snap/charmcraft/1083/lib/charmcraft/commands/store/registry.py", line 335, in get_image_info_from_digest
2022-10-19 18:48:54.757     if any(digest in repo_digest for repo_digest in image_info["RepoDigests"]):
2022-10-19 18:48:54.757 TypeError: 'NoneType' object is not iterable
```
and it seems that the request to the docker daemon returns a `None` object when the `RepoDigests` key is empty. This is often the case for any images that have been built locally.

This PR adds a simple fix and test for that.

Then with the recent [change](https://github.com/canonical/charmcraft/pull/871/files) in handling the upload of OCI image resources, I thought it would be helpful to describe exactly what should be included in the ID of an image, originally I was including the "sha26:" portion and that was what was leading me to encountering the bug above. So I've also tweaked the help text output from `charmcraft upload-resource`