### PR TITLE
templates: remove duplicate "await"

### DIFF
--- a/charmcraft/templates/init-kubernetes/tests/integration/test_charm.py.j2
+++ b/charmcraft/templates/init-kubernetes/tests/integration/test_charm.py.j2
@@ -30,7 +30,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
 
     # Deploy the charm and wait for active/idle status
     await asyncio.gather(
-        ops_test.model.deploy(await charm, resources=resources, application_name=APP_NAME),
+        ops_test.model.deploy(charm, resources=resources, application_name=APP_NAME),
         ops_test.model.wait_for_idle(
             apps=[APP_NAME], status="active", raise_on_blocked=True, timeout=1000
         ),

--- a/charmcraft/templates/init-machine/tests/integration/test_charm.py.j2
+++ b/charmcraft/templates/init-machine/tests/integration/test_charm.py.j2
@@ -27,7 +27,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
 
     # Deploy the charm and wait for active/idle status
     await asyncio.gather(
-        ops_test.model.deploy(await charm, application_name=APP_NAME),
+        ops_test.model.deploy(charm, application_name=APP_NAME),
         ops_test.model.wait_for_idle(
             apps=[APP_NAME], status="active", raise_on_blocked=True, timeout=1000
         ),

--- a/charmcraft/templates/init-simple/tests/integration/test_charm.py.j2
+++ b/charmcraft/templates/init-simple/tests/integration/test_charm.py.j2
@@ -28,7 +28,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
 
     # Deploy the charm and wait for active/idle status
     await asyncio.gather(
-        ops_test.model.deploy(await charm, resources=resources, application_name=APP_NAME),
+        ops_test.model.deploy(charm, resources=resources, application_name=APP_NAME),
         ops_test.model.wait_for_idle(
             apps=[APP_NAME], status="active", raise_on_blocked=True, timeout=1000
         ),


### PR DESCRIPTION
The integration tests already do `charm = await
ops_test.build_charm(".")` earlier, so it doesn't make sense to await again on the result of that.

Fixes #910.