### PR TITLE
Made pack & upload tests more robust.

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -27,9 +27,11 @@ backends:
       - ubuntu-22.04-64:
           workers: 4
           storage: 40G
-      - fedora-35-64:
-          workers: 2
-          storage: 40G
+      # Fedora is disabled until it runs kernel 6.0.7 due to squashfs bug
+      # (https://forum.snapcraft.io/t/unsupported-version-0-of-verneed-record-linux-6-0/32160/14)
+      #- fedora-35-64:
+      #    workers: 2
+      #    storage: 40G
 
   multipass:
     type: adhoc

--- a/tests/spread/store/bundle-upload-and-release/task.yaml
+++ b/tests/spread/store/bundle-upload-and-release/task.yaml
@@ -50,4 +50,8 @@ execute: |
   # validate the channel map
   edge_release=$(charmcraft status $BUNDLE_DEFAULT_NAME --format=json | jq -r '.[] | select(.track=="latest") | .mappings[0].releases | .[] | select(.channel=="latest/edge")')
   edge_revision=$(echo $edge_release | jq -r .revision)
-  test $edge_revision == $uploaded_revno
+  # check that the current release greater or equal than what was 
+  # uploaded, because other tests running concurrently may have
+  # also released (but for sure cannot be a previous revision)
+  test $edge_revision -ge $uploaded_revno  
+

--- a/tests/spread/store/bundle-upload-and-release/task.yaml
+++ b/tests/spread/store/bundle-upload-and-release/task.yaml
@@ -35,18 +35,19 @@ execute: |
   test -f $BUNDLE_DEFAULT_NAME.zip
 
   # upload
-  charmcraft upload $BUNDLE_DEFAULT_NAME.zip
+  uploaded_revno=$(charmcraft upload $BUNDLE_DEFAULT_NAME.zip --format=json | jq .revision)
 
-  # check that latest revision is newer than start datetime
-  last_revision=$(charmcraft revisions $BUNDLE_DEFAULT_NAME --format=json | jq -r .[0])
-  last_revision_created=$(echo $last_revision | jq -r .created_at)
-  [[ $start_datetime < $last_revision_created ]]
+  # check the uploaded revision is newer than start datetime (note we're 
+  # not using latest, as it may not be the one we uploaded here, because 
+  # multiple tests running concurrently)
+  up_revision=$(charmcraft revisions $BUNDLE_DEFAULT_NAME --format=json | jq -r --arg revno $uploaded_revno '.[] | select(.revision|tostring==$revno)')
+  up_revision_created=$(echo $up_revision | jq -r .created_at)
+  [[ $start_datetime < $up_revision_created ]]
 
   # release that last revision to edge
-  last_revision_revno=$(echo $last_revision | jq -r .revision)
-  charmcraft release $BUNDLE_DEFAULT_NAME -r $last_revision_revno -c edge
+  charmcraft release $BUNDLE_DEFAULT_NAME -r $uploaded_revno -c edge
 
   # validate the channel map
   edge_release=$(charmcraft status $BUNDLE_DEFAULT_NAME --format=json | jq -r '.[] | select(.track=="latest") | .mappings[0].releases | .[] | select(.channel=="latest/edge")')
   edge_revision=$(echo $edge_release | jq -r .revision)
-  test $edge_revision == $last_revision_revno
+  test $edge_revision == $uploaded_revno

--- a/tests/spread/store/bundle-upload-and-release/task.yaml
+++ b/tests/spread/store/bundle-upload-and-release/task.yaml
@@ -34,7 +34,7 @@ execute: |
   charmcraft pack --verbose
   test -f $BUNDLE_DEFAULT_NAME.zip
 
-  # upload
+  # upload and get uploaded revision
   uploaded_revno=$(charmcraft upload $BUNDLE_DEFAULT_NAME.zip --format=json | jq .revision)
 
   # check the uploaded revision is newer than start datetime (note we're 

--- a/tests/spread/store/charm-upload-and-release/task.yaml
+++ b/tests/spread/store/charm-upload-and-release/task.yaml
@@ -30,19 +30,19 @@ execute: |
   test -f $CHARM_DEFAULT_NAME*.charm
   charm_filepath=$(ls $CHARM_DEFAULT_NAME*.charm)
 
-  # upload
-  charmcraft upload $charm_filepath
+  # upload and get uploaded revision
+  uploaded_revno=$(charmcraft upload $charm_filepath --format=json | jq .revision)
 
-  # check that latest revision is newer than start datetime
-  last_revision=$(charmcraft revisions $CHARM_DEFAULT_NAME --format=json | jq -r .[0])
-  last_revision_created=$(echo $last_revision | jq -r .created_at)
-  [[ $start_datetime < $last_revision_created ]]
+  # check the uploaded revision is newer than start datetime (note we're not using latest, as 
+  # it may not be the one we uploaded here, because multiple tests running concurrently)
+  up_revision=$(charmcraft revisions $CHARM_DEFAULT_NAME --format=json | jq -r --arg revno $uploaded_revno '.[] | select(.revision|tostring==$revno)')
+  up_revision_created=$(echo $up_revision | jq -r .created_at)
+  [[ $start_datetime < $up_revision_created ]]
 
   # release that last revision to edge
-  last_revision_revno=$(echo $last_revision | jq -r .revision)
-  charmcraft release $CHARM_DEFAULT_NAME -r $last_revision_revno -c edge
+  charmcraft release $CHARM_DEFAULT_NAME -r $uploaded_revno -c edge
 
   # validate the channel map
   edge_release=$(charmcraft status $CHARM_DEFAULT_NAME --format=json | jq -r '.[] | select(.track=="latest") | .mappings[0].releases | .[] | select(.channel=="latest/edge")')
   edge_revision=$(echo $edge_release | jq -r .revision)
-  test $edge_revision == $last_revision_revno
+  test $edge_revision == $uploaded_revno

--- a/tests/spread/store/charm-upload-and-release/task.yaml
+++ b/tests/spread/store/charm-upload-and-release/task.yaml
@@ -45,4 +45,7 @@ execute: |
   # validate the channel map
   edge_release=$(charmcraft status $CHARM_DEFAULT_NAME --format=json | jq -r '.[] | select(.track=="latest") | .mappings[0].releases | .[] | select(.channel=="latest/edge")')
   edge_revision=$(echo $edge_release | jq -r .revision)
-  test $edge_revision == $uploaded_revno
+  # check that the current release greater or equal than what was 
+  # uploaded, because other tests running concurrently may have
+  # also released (but for sure cannot be a previous revision)
+  test $edge_revision -ge $uploaded_revno  


### PR DESCRIPTION
Avoided to get "last" revision because the uploaded one may not be the latest one (because other concurrently running test may have uploaded other one).