### PR TITLE
feat: replace flake8 + plugins and isort with ruff

### DIFF
--- a/charmcraft/templates/init-kubernetes/tests/unit/test_charm.py.j2
+++ b/charmcraft/templates/init-kubernetes/tests/unit/test_charm.py.j2
@@ -4,10 +4,10 @@
 import unittest
 
 import ops.testing
+from charm import {{ class_name }}
 from ops.model import ActiveStatus
 from ops.testing import Harness
 
-from charm import {{ class_name }}
 
 
 class TestCharm(unittest.TestCase):

--- a/charmcraft/templates/init-kubernetes/tests/unit/test_charm.py.j2
+++ b/charmcraft/templates/init-kubernetes/tests/unit/test_charm.py.j2
@@ -9,7 +9,6 @@ from ops.model import ActiveStatus
 from ops.testing import Harness
 
 
-
 class TestCharm(unittest.TestCase):
     def setUp(self):
         # Enable more accurate simulation of container networking.

--- a/charmcraft/templates/init-machine/tests/unit/test_charm.py.j2
+++ b/charmcraft/templates/init-machine/tests/unit/test_charm.py.j2
@@ -4,10 +4,10 @@
 import unittest
 
 import ops.testing
+from charm import {{ class_name }}
 from ops.model import ActiveStatus
 from ops.testing import Harness
 
-from charm import {{ class_name }}
 
 
 class TestCharm(unittest.TestCase):

--- a/charmcraft/templates/init-machine/tests/unit/test_charm.py.j2
+++ b/charmcraft/templates/init-machine/tests/unit/test_charm.py.j2
@@ -9,7 +9,6 @@ from ops.model import ActiveStatus
 from ops.testing import Harness
 
 
-
 class TestCharm(unittest.TestCase):
     def setUp(self):
         # Enable more accurate simulation of container networking.

--- a/charmcraft/templates/init-simple/pyproject.toml.j2
+++ b/charmcraft/templates/init-simple/pyproject.toml.j2
@@ -14,20 +14,26 @@ log_cli_level = "INFO"
 line-length = 99
 target-version = ["py38"]
 
-[tool.isort]
-line_length = 99
-profile = "black"
-
 # Linting tools configuration
-[tool.flake8]
-max-line-length = 99
-max-doc-length = 99
+[tool.ruff]
+line-length = 99
+select = ["E", "W", "F", "C", "N", "D", "I001"]
+extend-ignore = [
+    "D203",
+    "D204",
+    "D213",
+    "D215",
+    "D400",
+    "D404",
+    "D406",
+    "D407",
+    "D408",
+    "D409",
+    "D413",
+]
+ignore = ["E501", "D107"]
+extend-exclude = ["__pycache__", "*.egg_info"]
+per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
+
+[tool.ruff.mccabe]
 max-complexity = 10
-exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv"]
-select = ["E", "W", "F", "C", "N", "R", "D", "H"]
-# Ignore W503, E501 because using black creates errors with this
-# Ignore D107 Missing docstring in __init__
-ignore = ["W503", "E501", "D107"]
-# D100, D101, D102, D103: Ignore missing docstrings in tests
-per-file-ignores = ["tests/*:D100,D101,D102,D103,D104"]
-docstring-convention = "google"

--- a/charmcraft/templates/init-simple/src/charm.py.j2
+++ b/charmcraft/templates/init-simple/src/charm.py.j2
@@ -9,7 +9,7 @@
 Refer to the following post for a quick-start guide that will help you
 develop a new k8s charm using the Operator Framework:
 
-    https://discourse.charmhub.io/t/4208
+https://discourse.charmhub.io/t/4208
 """
 
 import logging

--- a/charmcraft/templates/init-simple/tests/unit/test_charm.py.j2
+++ b/charmcraft/templates/init-simple/tests/unit/test_charm.py.j2
@@ -6,10 +6,10 @@
 import unittest
 
 import ops.testing
+from charm import {{ class_name }}
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 from ops.testing import Harness
 
-from charm import {{ class_name }}
 
 
 class TestCharm(unittest.TestCase):

--- a/charmcraft/templates/init-simple/tests/unit/test_charm.py.j2
+++ b/charmcraft/templates/init-simple/tests/unit/test_charm.py.j2
@@ -11,7 +11,6 @@ from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 from ops.testing import Harness
 
 
-
 class TestCharm(unittest.TestCase):
     def setUp(self):
         # Enable more accurate simulation of container networking.

--- a/charmcraft/templates/init-simple/tox.ini.j2
+++ b/charmcraft/templates/init-simple/tox.ini.j2
@@ -40,9 +40,14 @@ deps =
 commands =
     # uncomment the following line if this charm owns a lib
     # codespell {[vars]lib_path}
-    codespell {toxinidir}/. --skip {toxinidir}/.git --skip {toxinidir}/.tox \
-      --skip {toxinidir}/build --skip {toxinidir}/lib --skip {toxinidir}/venv \
-      --skip {toxinidir}/.mypy_cache --skip {toxinidir}/icon.svg
+    codespell {toxinidir}/. \
+              --skip {toxinidir}/.git \
+              --skip {toxinidir}/.tox \
+              --skip {toxinidir}/build \
+              --skip {toxinidir}/lib \
+              --skip {toxinidir}/venv \
+              --skip {toxinidir}/.mypy_cache \
+              --skip {toxinidir}/icon.svg
     
     ruff {[vars]all_path}
     black --check --diff {[vars]all_path}
@@ -55,7 +60,12 @@ deps =
     -r{toxinidir}/requirements.txt
 commands =
     coverage run --source={[vars]src_path} \
-        -m pytest --ignore={[vars]tst_path}integration -v --tb native -s {posargs}
+                 -m pytest \
+                 --ignore={[vars]tst_path}integration \
+                 --tb native \
+                 -v \
+                 -s \
+                 {posargs}
     coverage report
 
 [testenv:integration]
@@ -66,4 +76,9 @@ deps =
     pytest-operator
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
+    pytest -v \
+           -s \
+           --tb native \
+           --ignore={[vars]tst_path}unit \
+           --log-cli-level=INFO \
+           {posargs}

--- a/charmcraft/templates/init-simple/tox.ini.j2
+++ b/charmcraft/templates/init-simple/tox.ini.j2
@@ -4,7 +4,7 @@
 [tox]
 skipsdist=True
 skip_missing_interpreters = True
-envlist = lint, unit
+envlist = fmt, lint, unit
 
 [vars]
 src_path = {toxinidir}/src/
@@ -26,20 +26,16 @@ passenv =
 description = Apply coding style standards to code
 deps =
     black
-    isort
+    ruff
 commands =
-    isort {[vars]all_path}
     black {[vars]all_path}
+    ruff --fix {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards
 deps =
     black
-    flake8-docstrings
-    flake8-builtins
-    pyproject-flake8
-    pep8-naming
-    isort
+    ruff
     codespell
 commands =
     # uncomment the following line if this charm owns a lib
@@ -47,9 +43,8 @@ commands =
     codespell {toxinidir}/. --skip {toxinidir}/.git --skip {toxinidir}/.tox \
       --skip {toxinidir}/build --skip {toxinidir}/lib --skip {toxinidir}/venv \
       --skip {toxinidir}/.mypy_cache --skip {toxinidir}/icon.svg
-    # pflake8 wrapper supports config from pyproject.toml
-    pflake8 {[vars]all_path}
-    isort --check-only --diff {[vars]all_path}
+    
+    ruff {[vars]all_path}
     black --check --diff {[vars]all_path}
 
 [testenv:unit]


### PR DESCRIPTION
We have previously standardised on using `flake8` with a number of plugins, and `pyproject-flake8` to enable us to configure all of our linting tools in one place (`pyproject.toml`)

Over the past months, there have been two major releases of `flake8`, and both have caused various issues with the various plugins and their dependencies, leading to instability in CI pipelines.

I've been following [ruff](https://github.com/charliermarsh/ruff) for a while. It's a Python linter, written in Rust, that combines a lot of the rules we were using from these other plugins. It's actively maintained, and all under one project, reducing the complexity of the dependency tree a little. It's got adoption from some pretty large projects like FastAPI and pydantic.

Proposing here for discussion.