### PR TITLE
Update the charmcraft status --format

### DIFF
--- a/charmcraft/cmdbase.py
+++ b/charmcraft/cmdbase.py
@@ -21,6 +21,7 @@ import json
 import craft_cli
 
 JSON_FORMAT = "json"
+FORMAT_HELP_STR = "Produce the result in the specified format (currently only 'json')"
 
 
 class BaseCommand(craft_cli.BaseCommand):
@@ -50,5 +51,5 @@ class BaseCommand(craft_cli.BaseCommand):
         parser.add_argument(
             "--format",
             choices=[JSON_FORMAT],
-            help="Produce the result formatted as a JSON string",
+            help=FORMAT_HELP_STR,
         )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -34,7 +34,7 @@ from craft_cli import (
 from craft_store.errors import CraftStoreError
 
 from charmcraft import __version__, env, utils
-from charmcraft.cmdbase import BaseCommand, JSON_FORMAT
+from charmcraft.cmdbase import BaseCommand, JSON_FORMAT, FORMAT_HELP_STR
 from charmcraft.commands.store.client import ALTERNATE_AUTH_ENV_VAR
 from charmcraft.main import COMMAND_GROUPS, main, _get_system_details
 
@@ -484,7 +484,7 @@ def test_basecommand_include_format_option(config):
     assert action.dest == "format"
     assert action.default is None
     assert action.choices == [JSON_FORMAT]
-    assert action.help == "Produce the result formatted as a JSON string"
+    assert action.help == FORMAT_HELP_STR
 
 
 def test_basecommand_format_content_json(config):


### PR DESCRIPTION
This commit add the option to format the output data in yaml format and also updates the text for charmcraft status --help for --format option.

Fixes #794 