### PR TITLE
Update Renovate config to match all requirements-*.txt files.

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,6 +2,9 @@
   // Configuration file for RenovateBot: https://docs.renovatebot.com/configuration-options
   extends: ["config:base"],
   labels: ["dependencies"],  // For convenient searching in GitHub
+  pip_requirements: {
+    fileMatch: ["(^|/)requirements([\\w-]*)\\.txt$"]
+  },
   packageRules: [
     {
       // Automerge patches, pin changes and digest changes.


### PR DESCRIPTION
Based on [this comment](https://github.com/canonical/charmcraft/pull/948#pullrequestreview-1213392441)

If we later need to ignore specific requirements files we can add an `ignorePaths` array to the base config.