### PR TITLE
Run the charm builder with python in unbuffered mode.

### DIFF
--- a/charmcraft/parts.py
+++ b/charmcraft/parts.py
@@ -187,6 +187,7 @@ class CharmPlugin(plugins.Plugin):
             "-i",
             *env_flags,
             sys.executable,
+            "-u",
             "-I",
             charm_builder.__file__,
             "--builddir",

--- a/tests/test_parts.py
+++ b/tests/test_parts.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 Canonical Ltd.
+# Copyright 2020-2023 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -97,7 +97,7 @@ class TestCharmPlugin:
                 "SNAP_ARCH=snap_arch_value SNAP_NAME=snap_name_value "
                 "SNAP_VERSION=snap_version_value http_proxy=http_proxy_value "
                 "https_proxy=https_proxy_value no_proxy=no_proxy_value "
-                "{python} -I "
+                "{python} -u -I "
                 "{charm_builder} "
                 "--builddir {work_dir}/parts/foo/build "
                 "--installdir {work_dir}/parts/foo/install "


### PR DESCRIPTION
Currently, if you stare at the screen when the charm builder is run, at some point the plugin executes the charm builder and the last thing that is seen for a long time is

```
2023-01-17 13:36:46.136 :: + env -i LANG=C.UTF-8 LC_ALL=C.UTF-8 PATH=/snap/charmcraft/1171/libexec/charmcraft:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin SNAP=/snap/charmcraft/1171 SNAP_ARCH=amd64 SNAP_NAME=charmcraft SNAP_VERSION=2.2.0 /snap/charmcraft/1171/bin/python3 -I /snap/charmcraft/1171/lib/charmcraft/charm_builder.py --builddir /root/parts/charm/build --installdir /root/parts/charm/install --entrypoint /root/parts/charm/build/src/charm.py -r requirements.txt
```

Running this subprocess in unbuffered mode it will help to retrieve sooner its messages.