### PR TITLE
refactor: Move charm library helper functions to their own modules (CRAFT-1557)

### DIFF
--- a/charmcraft/commands/store/charmlibs.py
+++ b/charmcraft/commands/store/charmlibs.py
@@ -1,0 +1,221 @@
+# Copyright 2023 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For further info, check https://github.com/canonical/charmcraft
+"""General purpose library functions for charmcraft."""
+import ast
+import hashlib
+import pathlib
+from collections import namedtuple
+from typing import AnyStr, Optional
+
+import yaml
+from craft_cli import CraftError, emit
+
+from charmcraft.errors import BadLibraryPathError, BadLibraryNameError
+
+LibData = namedtuple(
+    "LibData",
+    "lib_id api patch content content_hash full_name path lib_name charm_name",
+)
+
+
+def get_positive_int(raw_value: AnyStr) -> int:
+    """Convert the raw value for api/patch into a positive integer."""
+    value = int(raw_value)
+    if value < 0:
+        raise ValueError("Version numbers cannot be negative.")
+    return value
+
+
+def get_name_from_metadata() -> Optional[str]:
+    """Return the name if present and plausible in metadata.yaml."""
+    try:
+        with open("metadata.yaml", "rb") as fh:
+            metadata = yaml.safe_load(fh)
+        charm_name = metadata["name"]
+    except (yaml.error.YAMLError, OSError, KeyError):
+        return
+    return charm_name
+
+
+def create_importable_name(charm_name: str) -> str:
+    """Convert a charm name to something that is importable in python."""
+    return charm_name.replace("-", "_")
+
+
+def create_charm_name_from_importable(charm_name: str) -> str:
+    """Convert a charm name from the importable form to the real form."""
+    # _ is invalid in charm names, so we know it's intended to be '-'
+    return charm_name.replace("_", "-")
+
+
+def get_lib_info(*, full_name=None, lib_path=None):
+    """Get the whole lib info from the path/file.
+
+    This will perform mutation of the charm name to create importable paths.
+    * `charm_name` and `libdata.charm_name`: `foo-bar`
+    * `full_name` and `libdata.full_name`: `charms.foo_bar.v0.somelib`
+    * paths, including `libdata.path`: `lib/charms/foo_bar/v0/somelib`
+
+    """
+    if full_name is None:
+        # get it from the lib_path
+        try:
+            libsdir, charmsdir, importable_charm_name, v_api = lib_path.parts[:-1]
+        except ValueError:
+            raise BadLibraryPathError(lib_path)
+        if libsdir != "lib" or charmsdir != "charms" or lib_path.suffix != ".py":
+            raise BadLibraryPathError(lib_path)
+        full_name = ".".join((charmsdir, importable_charm_name, v_api, lib_path.stem))
+
+    else:
+        # build the path! convert a lib name with dots to the full path, including lib
+        # dir and Python extension.
+        #    e.g.: charms.mycharm.v4.foo -> lib/charms/mycharm/v4/foo.py
+        try:
+            charmsdir, charm_name, v_api, libfile = full_name.split(".")
+        except ValueError:
+            raise BadLibraryNameError(full_name)
+
+        # the lib full_name includes the charm_name which might not be importable (dashes)
+        importable_charm_name = create_importable_name(charm_name)
+
+        if charmsdir != "charms":
+            raise BadLibraryNameError(full_name)
+        path = pathlib.Path("lib")
+        lib_path = path / charmsdir / importable_charm_name / v_api / (libfile + ".py")
+
+    # charm names in the path can contain '_' to be importable
+    # these should be '-', so change them back
+    charm_name = create_charm_name_from_importable(importable_charm_name)
+
+    if v_api[0] != "v" or not v_api[1:].isdigit():
+        raise CraftError("The API version in the library path must be 'vN' where N is an integer.")
+    api_from_path = int(v_api[1:])
+
+    lib_name = lib_path.stem
+    if not lib_path.exists():
+        return LibData(
+            lib_id=None,
+            api=api_from_path,
+            patch=-1,
+            content_hash=None,
+            content=None,
+            full_name=full_name,
+            path=lib_path,
+            lib_name=lib_name,
+            charm_name=charm_name,
+        )
+
+    # parse the file and extract metadata from it, while hashing
+    metadata_fields = (b"LIBAPI", b"LIBPATCH", b"LIBID")
+    metadata = dict.fromkeys(metadata_fields)
+    hasher = hashlib.sha256()
+    with lib_path.open("rb") as fh:
+        for line in fh:
+            if line.startswith(metadata_fields):
+                try:
+                    field, value = [x.strip() for x in line.split(b"=")]
+                except ValueError:
+                    raise CraftError(
+                        "Bad metadata line in {!r}: {!r}".format(str(lib_path), line)
+                    ) from None
+                metadata[field] = value
+            else:
+                hasher.update(line)
+
+    missing = [k.decode("ascii") for k, v in metadata.items() if v is None]
+    if missing:
+        raise CraftError(
+            "Library {!r} is missing the mandatory metadata fields: {}.".format(
+                str(lib_path), ", ".join(sorted(missing))
+            )
+        )
+
+    bad_api_patch_msg = "Library {!r} metadata field {} is not zero or a positive integer."
+    try:
+        libapi = get_positive_int(metadata[b"LIBAPI"])
+    except ValueError:
+        raise CraftError(bad_api_patch_msg.format(str(lib_path), "LIBAPI"))
+    try:
+        libpatch = get_positive_int(metadata[b"LIBPATCH"])
+    except ValueError:
+        raise CraftError(bad_api_patch_msg.format(str(lib_path), "LIBPATCH"))
+
+    if libapi == 0 and libpatch == 0:
+        raise CraftError(
+            "Library {!r} metadata fields LIBAPI and LIBPATCH cannot both be zero.".format(
+                str(lib_path)
+            )
+        )
+
+    if libapi != api_from_path:
+        raise CraftError(
+            "Library {!r} metadata field LIBAPI is different from the version in the path.".format(
+                str(lib_path)
+            )
+        )
+
+    bad_libid_msg = "Library {!r} metadata field LIBID must be a non-empty ASCII string."
+    try:
+        libid = ast.literal_eval(metadata[b"LIBID"].decode("ascii"))
+    except (ValueError, UnicodeDecodeError):
+        raise CraftError(bad_libid_msg.format(str(lib_path)))
+    if not libid or not isinstance(libid, str):
+        raise CraftError(bad_libid_msg.format(str(lib_path)))
+
+    content_hash = hasher.hexdigest()
+    content = lib_path.read_text()
+
+    return LibData(
+        lib_id=libid,
+        api=libapi,
+        patch=libpatch,
+        content_hash=content_hash,
+        content=content,
+        full_name=full_name,
+        path=lib_path,
+        lib_name=lib_name,
+        charm_name=charm_name,
+    )
+
+
+def get_libs_from_tree(charm_name=None):
+    """Get library info from the directories tree (for a specific charm if specified).
+
+    It only follows/uses the directories/files for a correct charmlibs
+    disk structure.
+
+    This can take charm_name as both importable and normal form.
+    """
+    local_libs_data = []
+
+    if charm_name is None:
+        base_dir = pathlib.Path("lib") / "charms"
+        charm_dirs = sorted(base_dir.iterdir()) if base_dir.is_dir() else []
+    else:
+        importable_charm_name = create_importable_name(charm_name)
+        base_dir = pathlib.Path("lib") / "charms" / importable_charm_name
+        charm_dirs = [base_dir] if base_dir.is_dir() else []
+
+    for charm_dir in charm_dirs:
+        for v_dir in sorted(charm_dir.iterdir()):
+            if v_dir.is_dir() and v_dir.name[0] == "v" and v_dir.name[1:].isdigit():
+                for libfile in sorted(v_dir.glob("*.py")):
+                    local_libs_data.append(get_lib_info(lib_path=libfile))
+
+    found_libs = [lib_data.full_name for lib_data in local_libs_data]
+    emit.debug(f"Libraries found under {str(base_dir)!r}: {found_libs}")
+    return local_libs_data

--- a/charmcraft/errors.py
+++ b/charmcraft/errors.py
@@ -1,0 +1,37 @@
+# Copyright 2023 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For further info, check https://github.com/canonical/charmcraft
+"""Charmcraft error classes."""
+
+from craft_cli import CraftError
+
+
+class BadLibraryPathError(CraftError):
+    """Subclass to provide a specific error for a bad library path."""
+
+    def __init__(self, path):
+        super().__init__(
+            "Charm library path {} must conform to lib/charms/<charm>/vN/<libname>.py"
+            "".format(path)
+        )
+
+
+class BadLibraryNameError(CraftError):
+    """Subclass to provide a specific error for a bad library name."""
+
+    def __init__(self, name):
+        super().__init__(
+            "Charm library name {!r} must conform to charms.<charm>.vN.<libname>".format(name)
+        )

--- a/snap/local/sitecustomize.py
+++ b/snap/local/sitecustomize.py
@@ -3,6 +3,6 @@ import os
 
 snap_dir = os.getenv("SNAP")
 if snap_dir:
-  site.ENABLE_USER_SITE = False
-  site.addsitedir(os.path.join(snap_dir, "lib"))
-  site.addsitedir(os.path.join(snap_dir, "usr/lib/python3/dist-packages"))
+    site.ENABLE_USER_SITE = False
+    site.addsitedir(os.path.join(snap_dir, "lib"))
+    site.addsitedir(os.path.join(snap_dir, "usr/lib/python3/dist-packages"))

--- a/tests/commands/test_store_charmlibs.py
+++ b/tests/commands/test_store_charmlibs.py
@@ -1,0 +1,380 @@
+# Copyright 2023 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For further info, check https://github.com/canonical/charmcraft
+
+"""Tests for store helpers commands (code in store/charmlibs.py)."""
+import hashlib
+import pathlib
+import sys
+
+import pytest
+from craft_cli import CraftError
+
+from charmcraft.commands.store.charmlibs import get_lib_info, get_name_from_metadata
+
+
+# region Name-related tests
+def test_get_name_from_metadata_ok(tmp_path, monkeypatch):
+    """The metadata file is valid yaml, but there is no name."""
+    monkeypatch.chdir(tmp_path)
+
+    # put a valid metadata
+    metadata_file = tmp_path / "metadata.yaml"
+    with metadata_file.open("wb") as fh:
+        fh.write(b"name: test-name")
+
+    result = get_name_from_metadata()
+    assert result == "test-name"
+
+
+def test_get_name_from_metadata_no_file(tmp_path, monkeypatch):
+    """No metadata file to get info."""
+    monkeypatch.chdir(tmp_path)
+    result = get_name_from_metadata()
+    assert result is None
+
+
+def test_get_name_from_metadata_bad_content_garbage(tmp_path, monkeypatch):
+    """The metadata file is broken."""
+    monkeypatch.chdir(tmp_path)
+
+    # put a broken metadata
+    metadata_file = tmp_path / "metadata.yaml"
+    with metadata_file.open("wb") as fh:
+        fh.write(b"\b00\bff -- not a really yaml stuff")
+
+    result = get_name_from_metadata()
+    assert result is None
+
+
+def test_get_name_from_metadata_bad_content_no_name(tmp_path, monkeypatch):
+    """The metadata file is valid yaml, but there is no name."""
+    monkeypatch.chdir(tmp_path)
+
+    # put a broken metadata
+    metadata_file = tmp_path / "metadata.yaml"
+    with metadata_file.open("wb") as fh:
+        fh.write(b"{}")
+
+    result = get_name_from_metadata()
+    assert result is None
+
+
+# endregion
+# region getlibinfo tests
+
+
+def _create_lib(extra_content=None, metadata_id=None, metadata_api=None, metadata_patch=None):
+    """Helper to create the structures on disk for a given lib.
+    WARNING: this function has the capability of creating INCORRECT structures on disk.
+    This is specific for the _get_lib_info tests below, other tests should use the
+    functionality provided by the factory.
+    """
+    base_dir = pathlib.Path("lib")
+    lib_file = base_dir / "charms" / "testcharm" / "v3" / "testlib.py"
+    lib_file.parent.mkdir(parents=True, exist_ok=True)
+
+    # save the content to that specific file under custom structure
+    if metadata_id is None:
+        metadata_id = "LIBID = 'test-lib-id'"
+    if metadata_api is None:
+        metadata_api = "LIBAPI = 3"
+    if metadata_patch is None:
+        metadata_patch = "LIBPATCH = 14"
+
+    fields = [metadata_id, metadata_api, metadata_patch]
+    with lib_file.open("wt", encoding="utf8") as fh:
+        for f in fields:
+            if f:
+                fh.write(f + "\n")
+        if extra_content:
+            fh.write(extra_content)
+
+    return lib_file
+
+
+def test_getlibinfo_success_simple(tmp_path, monkeypatch):
+    """Simple basic case of success getting info from the library."""
+    monkeypatch.chdir(tmp_path)
+    test_path = _create_lib()
+
+    lib_data = get_lib_info(lib_path=test_path)
+    assert lib_data.lib_id == "test-lib-id"
+    assert lib_data.api == 3
+    assert lib_data.patch == 14
+    assert lib_data.content_hash is not None
+    assert lib_data.content is not None
+    assert lib_data.full_name == "charms.testcharm.v3.testlib"
+    assert lib_data.path == test_path
+    assert lib_data.lib_name == "testlib"
+    assert lib_data.charm_name == "testcharm"
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
+def test_getlibinfo_success_content(tmp_path, monkeypatch):
+    """Check that content and its hash are ok."""
+    monkeypatch.chdir(tmp_path)
+    extra_content = """
+        extra lines for the file
+        extra non-ascii: ñáéíóú
+        the content is everything, this plus metadata
+        the hash should be of this, excluding metadata
+    """
+    test_path = _create_lib(extra_content=extra_content)
+
+    lib_data = get_lib_info(lib_path=test_path)
+    assert lib_data.content == test_path.read_text()
+    assert lib_data.content_hash == hashlib.sha256(extra_content.encode("utf8")).hexdigest()
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "charms.testcharm.v3.testlib.py",
+        "charms.testcharm.testlib",
+        "testcharm.v2.testlib",
+        "mycharms.testcharm.v2.testlib",
+    ],
+)
+def test_getlibinfo_bad_name(name):
+    """Different combinations of a bad library name."""
+    with pytest.raises(CraftError) as err:
+        get_lib_info(full_name=name)
+    assert str(err.value) == (
+        "Charm library name {!r} must conform to charms.<charm>.vN.<libname>".format(name)
+    )
+
+
+def test_getlibinfo_not_importable_charm_name():
+    """Libraries should be save under importable paths."""
+    lib_data = get_lib_info(full_name="charms.operator-libs-linux.v0.apt")
+    assert lib_data.charm_name == "operator-libs-linux"
+    assert lib_data.path == pathlib.Path("lib/charms/operator_libs_linux/v0/apt.py")
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
+@pytest.mark.parametrize(
+    "path",
+    [
+        "charms/testcharm/v3/testlib",
+        "charms/testcharm/v3/testlib.html",
+        "charms/testcharm/v3/testlib.",
+        "charms/testcharm/testlib.py",
+        "testcharm/v2/testlib.py",
+        "mycharms/testcharm/v2/testlib.py",
+    ],
+)
+def test_getlibinfo_bad_path(path):
+    """Different combinations of a bad library path."""
+    with pytest.raises(CraftError) as err:
+        get_lib_info(lib_path=pathlib.Path(path))
+    assert str(err.value) == (
+        "Charm library path {} must conform to lib/charms/<charm>/vN/<libname>.py".format(path)
+    )
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "charms.testcharm.v-three.testlib",
+        "charms.testcharm.v-3.testlib",
+        "charms.testcharm.3.testlib",
+        "charms.testcharm.vX.testlib",
+    ],
+)
+def test_getlibinfo_bad_api(name):
+    """Different combinations of a bad api in the path/name."""
+    with pytest.raises(CraftError) as err:
+        get_lib_info(full_name=name)
+    assert str(err.value) == (
+        "The API version in the library path must be 'vN' where N is an integer."
+    )
+
+
+def test_getlibinfo_missing_library_from_name():
+    """Partial case for when the library is not found in disk, starting from the name."""
+    test_name = "charms.testcharm.v3.testlib"
+    # no create lib!
+    lib_data = get_lib_info(full_name=test_name)
+    assert lib_data.lib_id is None
+    assert lib_data.api == 3
+    assert lib_data.patch == -1
+    assert lib_data.content_hash is None
+    assert lib_data.content is None
+    assert lib_data.full_name == test_name
+    assert lib_data.path == pathlib.Path("lib") / "charms" / "testcharm" / "v3" / "testlib.py"
+    assert lib_data.lib_name == "testlib"
+    assert lib_data.charm_name == "testcharm"
+
+
+def test_getlibinfo_missing_library_from_path():
+    """Partial case for when the library is not found in disk, starting from the path."""
+    test_path = pathlib.Path("lib") / "charms" / "testcharm" / "v3" / "testlib.py"
+    # no create lib!
+    lib_data = get_lib_info(lib_path=test_path)
+    assert lib_data.lib_id is None
+    assert lib_data.api == 3
+    assert lib_data.patch == -1
+    assert lib_data.content_hash is None
+    assert lib_data.content is None
+    assert lib_data.full_name == "charms.testcharm.v3.testlib"
+    assert lib_data.path == test_path
+    assert lib_data.lib_name == "testlib"
+    assert lib_data.charm_name == "testcharm"
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
+def test_getlibinfo_malformed_metadata_field(tmp_path, monkeypatch):
+    """Some metadata field is not really valid."""
+    monkeypatch.chdir(tmp_path)
+    test_path = _create_lib(metadata_id="LIBID = foo = 23")
+    with pytest.raises(CraftError) as err:
+        get_lib_info(lib_path=test_path)
+    assert str(err.value) == r"Bad metadata line in {!r}: b'LIBID = foo = 23\n'".format(
+        str(test_path)
+    )
+
+
+def test_getlibinfo_missing_metadata_field(tmp_path, monkeypatch):
+    """Some metadata field is not present."""
+    monkeypatch.chdir(tmp_path)
+    test_path = _create_lib(metadata_patch="", metadata_api="")
+    with pytest.raises(CraftError) as err:
+        get_lib_info(lib_path=test_path)
+    assert str(err.value) == (
+        "Library {!r} is missing the mandatory metadata fields: LIBAPI, LIBPATCH.".format(
+            str(test_path)
+        )
+    )
+
+
+def test_getlibinfo_api_not_int(tmp_path, monkeypatch):
+    """The API is not an integer."""
+    monkeypatch.chdir(tmp_path)
+    test_path = _create_lib(metadata_api="LIBAPI = v3")
+    with pytest.raises(CraftError) as err:
+        get_lib_info(lib_path=test_path)
+    assert str(err.value) == (
+        "Library {!r} metadata field LIBAPI is not zero or a positive integer.".format(
+            str(test_path)
+        )
+    )
+
+
+def test_getlibinfo_api_negative(tmp_path, monkeypatch):
+    """The API is not negative."""
+    monkeypatch.chdir(tmp_path)
+    test_path = _create_lib(metadata_api="LIBAPI = -3")
+    with pytest.raises(CraftError) as err:
+        get_lib_info(lib_path=test_path)
+    assert str(err.value) == (
+        "Library {!r} metadata field LIBAPI is not zero or a positive integer.".format(
+            str(test_path)
+        )
+    )
+
+
+def test_getlibinfo_patch_not_int(tmp_path, monkeypatch):
+    """The PATCH is not an integer."""
+    monkeypatch.chdir(tmp_path)
+    test_path = _create_lib(metadata_patch="LIBPATCH = beta3")
+    with pytest.raises(CraftError) as err:
+        get_lib_info(lib_path=test_path)
+    assert str(err.value) == (
+        "Library {!r} metadata field LIBPATCH is not zero or a positive integer.".format(
+            str(test_path)
+        )
+    )
+
+
+def test_getlibinfo_patch_negative(tmp_path, monkeypatch):
+    """The PATCH is not negative."""
+    monkeypatch.chdir(tmp_path)
+    test_path = _create_lib(metadata_patch="LIBPATCH = -1")
+    with pytest.raises(CraftError) as err:
+        get_lib_info(lib_path=test_path)
+    assert str(err.value) == (
+        "Library {!r} metadata field LIBPATCH is not zero or a positive integer.".format(
+            str(test_path)
+        )
+    )
+
+
+def test_getlibinfo_api_patch_both_zero(tmp_path, monkeypatch):
+    """Invalid combination of both API and PATCH being 0."""
+    monkeypatch.chdir(tmp_path)
+    test_path = _create_lib(metadata_patch="LIBPATCH = 0", metadata_api="LIBAPI = 0")
+    with pytest.raises(CraftError) as err:
+        get_lib_info(lib_path=test_path)
+    assert str(err.value) == (
+        "Library {!r} metadata fields LIBAPI and LIBPATCH cannot both be zero.".format(
+            str(test_path)
+        )
+    )
+
+
+def test_getlibinfo_metadata_api_different_path_api(tmp_path, monkeypatch):
+    """The API value included in the file is different than the one in the path."""
+    monkeypatch.chdir(tmp_path)
+    test_path = _create_lib(metadata_api="LIBAPI = 99")
+    with pytest.raises(CraftError) as err:
+        get_lib_info(lib_path=test_path)
+    assert str(err.value) == (
+        "Library {!r} metadata field LIBAPI is different from the version in the path.".format(
+            str(test_path)
+        )
+    )
+
+
+def test_getlibinfo_libid_non_string(tmp_path, monkeypatch):
+    """The ID is not really a string."""
+    monkeypatch.chdir(tmp_path)
+    test_path = _create_lib(metadata_id="LIBID = 99")
+    with pytest.raises(CraftError) as err:
+        get_lib_info(lib_path=test_path)
+    assert str(err.value) == (
+        "Library {!r} metadata field LIBID must be a non-empty ASCII string.".format(
+            str(test_path)
+        )
+    )
+
+
+def test_getlibinfo_libid_non_ascii(tmp_path, monkeypatch):
+    """The ID is not ASCII."""
+    monkeypatch.chdir(tmp_path)
+    test_path = _create_lib(metadata_id="LIBID = 'moño'")
+    with pytest.raises(CraftError) as err:
+        get_lib_info(lib_path=test_path)
+    assert str(err.value) == (
+        "Library {!r} metadata field LIBID must be a non-empty ASCII string.".format(
+            str(test_path)
+        )
+    )
+
+
+def test_getlibinfo_libid_empty(tmp_path, monkeypatch):
+    """The ID is empty."""
+    monkeypatch.chdir(tmp_path)
+    test_path = _create_lib(metadata_id="LIBID = ''")
+    with pytest.raises(CraftError) as err:
+        get_lib_info(lib_path=test_path)
+    assert str(err.value) == (
+        "Library {!r} metadata field LIBID must be a non-empty ASCII string.".format(
+            str(test_path)
+        )
+    )
+
+
+# endregion

--- a/tests/commands/test_store_commands.py
+++ b/tests/commands/test_store_commands.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 Canonical Ltd.
+# Copyright 2020-2023 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,8 +17,6 @@
 """Tests for the Store commands (code in store/__init__.py)."""
 
 import datetime
-import hashlib
-import pathlib
 import sys
 import zipfile
 from argparse import Namespace, ArgumentParser
@@ -52,8 +50,6 @@ from charmcraft.commands.store import (
     UploadCommand,
     UploadResourceCommand,
     WhoamiCommand,
-    _get_lib_info,
-    get_name_from_metadata,
     get_name_from_zip,
 )
 from charmcraft.commands.store.store import (
@@ -116,55 +112,6 @@ def add_cleanup():
 
     for func, args, kwargs in to_cleanup:
         func(*args, **kwargs)
-
-
-# -- tests for helpers
-
-
-def test_get_name_from_metadata_ok(tmp_path, monkeypatch):
-    """The metadata file is valid yaml, but there is no name."""
-    monkeypatch.chdir(tmp_path)
-
-    # put a valid metadata
-    metadata_file = tmp_path / "metadata.yaml"
-    with metadata_file.open("wb") as fh:
-        fh.write(b"name: test-name")
-
-    result = get_name_from_metadata()
-    assert result == "test-name"
-
-
-def test_get_name_from_metadata_no_file(tmp_path, monkeypatch):
-    """No metadata file to get info."""
-    monkeypatch.chdir(tmp_path)
-    result = get_name_from_metadata()
-    assert result is None
-
-
-def test_get_name_from_metadata_bad_content_garbage(tmp_path, monkeypatch):
-    """The metadata file is broken."""
-    monkeypatch.chdir(tmp_path)
-
-    # put a broken metadata
-    metadata_file = tmp_path / "metadata.yaml"
-    with metadata_file.open("wb") as fh:
-        fh.write(b"\b00\bff -- not a really yaml stuff")
-
-    result = get_name_from_metadata()
-    assert result is None
-
-
-def test_get_name_from_metadata_bad_content_no_name(tmp_path, monkeypatch):
-    """The metadata file is valid yaml, but there is no name."""
-    monkeypatch.chdir(tmp_path)
-
-    # put a broken metadata
-    metadata_file = tmp_path / "metadata.yaml"
-    with metadata_file.open("wb") as fh:
-        fh.write(b"{}")
-
-    result = get_name_from_metadata()
-    assert result is None
 
 
 # -- tests for auth commands
@@ -932,7 +879,7 @@ def test_get_name_bundle_bad_data(tmp_path, yaml_content):
 @pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
 def test_get_name_nor_charm_nor_bundle(tmp_path):
     """Get the name from a zip that has no metadata.yaml nor bundle.yaml."""
-    bad_zip = tmp_path / "badstuff.zip"
+    bad_zip = tmp_path / "bad-stuff.zip"
     _build_zip_with_yaml(bad_zip, "whatever.yaml", content={})
 
     with pytest.raises(CraftError) as cm:
@@ -3397,312 +3344,6 @@ def test_publishlib_store_has_same_revision_other_hash(
         emitter.assert_json_output(expected)
     else:
         emitter.assert_messages([error_message])
-
-
-# -- tests for _get_lib_info helper
-
-
-def _create_lib(extra_content=None, metadata_id=None, metadata_api=None, metadata_patch=None):
-    """Helper to create the structures on disk for a given lib.
-
-    WARNING: this function has the capability of creating INCORRECT structures on disk.
-
-    This is specific for the _get_lib_info tests below, other tests should use the
-    functionality provided by the factory.
-    """
-    base_dir = pathlib.Path("lib")
-    lib_file = base_dir / "charms" / "testcharm" / "v3" / "testlib.py"
-    lib_file.parent.mkdir(parents=True, exist_ok=True)
-
-    # save the content to that specific file under custom structure
-    if metadata_id is None:
-        metadata_id = "LIBID = 'test-lib-id'"
-    if metadata_api is None:
-        metadata_api = "LIBAPI = 3"
-    if metadata_patch is None:
-        metadata_patch = "LIBPATCH = 14"
-
-    fields = [metadata_id, metadata_api, metadata_patch]
-    with lib_file.open("wt", encoding="utf8") as fh:
-        for f in fields:
-            if f:
-                fh.write(f + "\n")
-        if extra_content:
-            fh.write(extra_content)
-
-    return lib_file
-
-
-def test_getlibinfo_success_simple(tmp_path, monkeypatch):
-    """Simple basic case of success getting info from the library."""
-    monkeypatch.chdir(tmp_path)
-    test_path = _create_lib()
-
-    lib_data = _get_lib_info(lib_path=test_path)
-    assert lib_data.lib_id == "test-lib-id"
-    assert lib_data.api == 3
-    assert lib_data.patch == 14
-    assert lib_data.content_hash is not None
-    assert lib_data.content is not None
-    assert lib_data.full_name == "charms.testcharm.v3.testlib"
-    assert lib_data.path == test_path
-    assert lib_data.lib_name == "testlib"
-    assert lib_data.charm_name == "testcharm"
-
-
-@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
-def test_getlibinfo_success_content(tmp_path, monkeypatch):
-    """Check that content and its hash are ok."""
-    monkeypatch.chdir(tmp_path)
-    extra_content = """
-        extra lines for the file
-        extra non-ascii: ñáéíóú
-        the content is everything, this plus metadata
-        the hash should be of this, excluding metadata
-    """
-    test_path = _create_lib(extra_content=extra_content)
-
-    lib_data = _get_lib_info(lib_path=test_path)
-    assert lib_data.content == test_path.read_text()
-    assert lib_data.content_hash == hashlib.sha256(extra_content.encode("utf8")).hexdigest()
-
-
-@pytest.mark.parametrize(
-    "name",
-    [
-        "charms.testcharm.v3.testlib.py",
-        "charms.testcharm.testlib",
-        "testcharm.v2.testlib",
-        "mycharms.testcharm.v2.testlib",
-    ],
-)
-def test_getlibinfo_bad_name(name):
-    """Different combinations of a bad library name."""
-    with pytest.raises(CraftError) as err:
-        _get_lib_info(full_name=name)
-    assert str(err.value) == (
-        "Charm library name {!r} must conform to charms.<charm>.vN.<libname>".format(name)
-    )
-
-
-def test_getlibinfo_not_importable_charm_name():
-    """Libraries should be save under importable paths."""
-    lib_data = _get_lib_info(full_name="charms.operator-libs-linux.v0.apt")
-    assert lib_data.charm_name == "operator-libs-linux"
-    assert lib_data.path == pathlib.Path("lib/charms/operator_libs_linux/v0/apt.py")
-
-
-@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
-@pytest.mark.parametrize(
-    "path",
-    [
-        "charms/testcharm/v3/testlib",
-        "charms/testcharm/v3/testlib.html",
-        "charms/testcharm/v3/testlib.",
-        "charms/testcharm/testlib.py",
-        "testcharm/v2/testlib.py",
-        "mycharms/testcharm/v2/testlib.py",
-    ],
-)
-def test_getlibinfo_bad_path(path):
-    """Different combinations of a bad library path."""
-    with pytest.raises(CraftError) as err:
-        _get_lib_info(lib_path=pathlib.Path(path))
-    assert str(err.value) == (
-        "Charm library path {} must conform to lib/charms/<charm>/vN/<libname>.py".format(path)
-    )
-
-
-@pytest.mark.parametrize(
-    "name",
-    [
-        "charms.testcharm.v-three.testlib",
-        "charms.testcharm.v-3.testlib",
-        "charms.testcharm.3.testlib",
-        "charms.testcharm.vX.testlib",
-    ],
-)
-def test_getlibinfo_bad_api(name):
-    """Different combinations of a bad api in the path/name."""
-    with pytest.raises(CraftError) as err:
-        _get_lib_info(full_name=name)
-    assert str(err.value) == (
-        "The API version in the library path must be 'vN' where N is an integer."
-    )
-
-
-def test_getlibinfo_missing_library_from_name():
-    """Partial case for when the library is not found in disk, starting from the name."""
-    test_name = "charms.testcharm.v3.testlib"
-    # no create lib!
-    lib_data = _get_lib_info(full_name=test_name)
-    assert lib_data.lib_id is None
-    assert lib_data.api == 3
-    assert lib_data.patch == -1
-    assert lib_data.content_hash is None
-    assert lib_data.content is None
-    assert lib_data.full_name == test_name
-    assert lib_data.path == pathlib.Path("lib") / "charms" / "testcharm" / "v3" / "testlib.py"
-    assert lib_data.lib_name == "testlib"
-    assert lib_data.charm_name == "testcharm"
-
-
-def test_getlibinfo_missing_library_from_path():
-    """Partial case for when the library is not found in disk, starting from the path."""
-    test_path = pathlib.Path("lib") / "charms" / "testcharm" / "v3" / "testlib.py"
-    # no create lib!
-    lib_data = _get_lib_info(lib_path=test_path)
-    assert lib_data.lib_id is None
-    assert lib_data.api == 3
-    assert lib_data.patch == -1
-    assert lib_data.content_hash is None
-    assert lib_data.content is None
-    assert lib_data.full_name == "charms.testcharm.v3.testlib"
-    assert lib_data.path == test_path
-    assert lib_data.lib_name == "testlib"
-    assert lib_data.charm_name == "testcharm"
-
-
-@pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")
-def test_getlibinfo_malformed_metadata_field(tmp_path, monkeypatch):
-    """Some metadata field is not really valid."""
-    monkeypatch.chdir(tmp_path)
-    test_path = _create_lib(metadata_id="LIBID = foo = 23")
-    with pytest.raises(CraftError) as err:
-        _get_lib_info(lib_path=test_path)
-    assert str(err.value) == r"Bad metadata line in {!r}: b'LIBID = foo = 23\n'".format(
-        str(test_path)
-    )
-
-
-def test_getlibinfo_missing_metadata_field(tmp_path, monkeypatch):
-    """Some metadata field is not present."""
-    monkeypatch.chdir(tmp_path)
-    test_path = _create_lib(metadata_patch="", metadata_api="")
-    with pytest.raises(CraftError) as err:
-        _get_lib_info(lib_path=test_path)
-    assert str(err.value) == (
-        "Library {!r} is missing the mandatory metadata fields: LIBAPI, LIBPATCH.".format(
-            str(test_path)
-        )
-    )
-
-
-def test_getlibinfo_api_not_int(tmp_path, monkeypatch):
-    """The API is not an integer."""
-    monkeypatch.chdir(tmp_path)
-    test_path = _create_lib(metadata_api="LIBAPI = v3")
-    with pytest.raises(CraftError) as err:
-        _get_lib_info(lib_path=test_path)
-    assert str(err.value) == (
-        "Library {!r} metadata field LIBAPI is not zero or a positive integer.".format(
-            str(test_path)
-        )
-    )
-
-
-def test_getlibinfo_api_negative(tmp_path, monkeypatch):
-    """The API is not negative."""
-    monkeypatch.chdir(tmp_path)
-    test_path = _create_lib(metadata_api="LIBAPI = -3")
-    with pytest.raises(CraftError) as err:
-        _get_lib_info(lib_path=test_path)
-    assert str(err.value) == (
-        "Library {!r} metadata field LIBAPI is not zero or a positive integer.".format(
-            str(test_path)
-        )
-    )
-
-
-def test_getlibinfo_patch_not_int(tmp_path, monkeypatch):
-    """The PATCH is not an integer."""
-    monkeypatch.chdir(tmp_path)
-    test_path = _create_lib(metadata_patch="LIBPATCH = beta3")
-    with pytest.raises(CraftError) as err:
-        _get_lib_info(lib_path=test_path)
-    assert str(err.value) == (
-        "Library {!r} metadata field LIBPATCH is not zero or a positive integer.".format(
-            str(test_path)
-        )
-    )
-
-
-def test_getlibinfo_patch_negative(tmp_path, monkeypatch):
-    """The PATCH is not negative."""
-    monkeypatch.chdir(tmp_path)
-    test_path = _create_lib(metadata_patch="LIBPATCH = -1")
-    with pytest.raises(CraftError) as err:
-        _get_lib_info(lib_path=test_path)
-    assert str(err.value) == (
-        "Library {!r} metadata field LIBPATCH is not zero or a positive integer.".format(
-            str(test_path)
-        )
-    )
-
-
-def test_getlibinfo_api_patch_both_zero(tmp_path, monkeypatch):
-    """Invalid combination of both API and PATCH being 0."""
-    monkeypatch.chdir(tmp_path)
-    test_path = _create_lib(metadata_patch="LIBPATCH = 0", metadata_api="LIBAPI = 0")
-    with pytest.raises(CraftError) as err:
-        _get_lib_info(lib_path=test_path)
-    assert str(err.value) == (
-        "Library {!r} metadata fields LIBAPI and LIBPATCH cannot both be zero.".format(
-            str(test_path)
-        )
-    )
-
-
-def test_getlibinfo_metadata_api_different_path_api(tmp_path, monkeypatch):
-    """The API value included in the file is different than the one in the path."""
-    monkeypatch.chdir(tmp_path)
-    test_path = _create_lib(metadata_api="LIBAPI = 99")
-    with pytest.raises(CraftError) as err:
-        _get_lib_info(lib_path=test_path)
-    assert str(err.value) == (
-        "Library {!r} metadata field LIBAPI is different from the version in the path.".format(
-            str(test_path)
-        )
-    )
-
-
-def test_getlibinfo_libid_non_string(tmp_path, monkeypatch):
-    """The ID is not really a string."""
-    monkeypatch.chdir(tmp_path)
-    test_path = _create_lib(metadata_id="LIBID = 99")
-    with pytest.raises(CraftError) as err:
-        _get_lib_info(lib_path=test_path)
-    assert str(err.value) == (
-        "Library {!r} metadata field LIBID must be a non-empty ASCII string.".format(
-            str(test_path)
-        )
-    )
-
-
-def test_getlibinfo_libid_non_ascii(tmp_path, monkeypatch):
-    """The ID is not ASCII."""
-    monkeypatch.chdir(tmp_path)
-    test_path = _create_lib(metadata_id="LIBID = 'moño'")
-    with pytest.raises(CraftError) as err:
-        _get_lib_info(lib_path=test_path)
-    assert str(err.value) == (
-        "Library {!r} metadata field LIBID must be a non-empty ASCII string.".format(
-            str(test_path)
-        )
-    )
-
-
-def test_getlibinfo_libid_empty(tmp_path, monkeypatch):
-    """The ID is empty."""
-    monkeypatch.chdir(tmp_path)
-    test_path = _create_lib(metadata_id="LIBID = ''")
-    with pytest.raises(CraftError) as err:
-        _get_lib_info(lib_path=test_path)
-    assert str(err.value) == (
-        "Library {!r} metadata field LIBID must be a non-empty ASCII string.".format(
-            str(test_path)
-        )
-    )
 
 
 # -- tests for fetch libraries command

--- a/tests/factory.py
+++ b/tests/factory.py
@@ -19,7 +19,7 @@
 import pathlib
 import textwrap
 
-from charmcraft.commands.store import _get_lib_info, create_importable_name
+from charmcraft.commands.store import create_importable_name, get_lib_info
 
 
 def create_lib_filepath(charm_name, lib_name, api=0, patch=1, lib_id="test-lib-id"):
@@ -43,7 +43,7 @@ def create_lib_filepath(charm_name, lib_name, api=0, patch=1, lib_id="test-lib-i
     content = template.format(lib_id=lib_id, api=api, patch=patch)
     lib_file.write_text(content)
 
-    # use _get_lib_info to get the hash of the file, as the used hash is WITHOUT the metadata
+    # use get_lib_info to get the hash of the file, as the used hash is WITHOUT the metadata
     # files (no point in duplicating that logic here)
-    libdata = _get_lib_info(lib_path=lib_file)
+    libdata = get_lib_info(lib_path=lib_file)
     return content, libdata.content_hash


### PR DESCRIPTION
Fixes CRAFT-1557

(Side note: I've got an upcoming PR that implements many of the test changes I made in #990 and takes into account the feedback. It'll be based on this one though.)