### PR TITLE
pack: include the charm libraries dependencies (CRAFT-1559)

### DIFF
--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -28,6 +28,7 @@ from craft_cli import emit, CraftError
 
 from charmcraft import env, linters, parts, providers, instrum
 from charmcraft.charm_builder import DISPATCH_FILENAME, HOOKS_DIR
+from charmcraft.commands.store.charmlibs import collect_charmlib_pydeps
 from charmcraft.config import Base, BasesConfiguration
 from charmcraft.manifest import create_manifest
 from charmcraft.metadata import parse_metadata_yaml
@@ -223,10 +224,12 @@ class Builder:
             charm_part_prime.append(str(entrypoint.parts[0]))
 
         # add venv if there are requirements
+        charmlib_pydeps = collect_charmlib_pydeps(self.charmdir)
         if (
             self._special_charm_part.get("charm-requirements")
             or self._special_charm_part.get("charm-binary-python-packages")
             or self._special_charm_part.get("charm-python-packages")
+            or charmlib_pydeps
         ):
             charm_part_prime.append(VENV_DIRNAME)
 

--- a/charmcraft/commands/store/__init__.py
+++ b/charmcraft/commands/store/__init__.py
@@ -1123,6 +1123,9 @@ class PublishLibCommand(BaseCommand):
             local_libs_data = [lib_data]
         else:
             local_libs_data = get_libs_from_tree(charm_name)
+            found_libs = [lib_data.full_name for lib_data in local_libs_data]
+            (charmlib_path,) = {lib_data.path.parent.parent for lib_data in local_libs_data}
+            emit.debug(f"Libraries found under {str(charmlib_path)!r}: {found_libs}")
 
         # check if something needs to be done
         store = Store(self.config.charmhub)
@@ -1254,6 +1257,8 @@ class FetchLibCommand(BaseCommand):
             local_libs_data = [get_lib_info(full_name=parsed_args.library)]
         else:
             local_libs_data = get_libs_from_tree()
+            found_libs = [lib_data.full_name for lib_data in local_libs_data]
+            emit.debug(f"Libraries found under 'lib/charms': {found_libs}")
 
         # get tips from the Store
         store = Store(self.config.charmhub)

--- a/charmcraft/commands/store/charmlibs.py
+++ b/charmcraft/commands/store/charmlibs.py
@@ -75,7 +75,7 @@ def get_lib_internals(lib_path: pathlib.Path) -> LibInternals:
     There are two kind of metadata fields, simple constant fields and PYDEPS. The simple
     constant fields are also the mandatory ones: LIBAPI, LIBPATCH and LIBID.
     """
-    content = lib_path.read_text()
+    content = lib_path.read_text(encoding="utf8")
     try:
         tree = ast.parse(content)
     except Exception:

--- a/tests/commands/test_store_charmlibs.py
+++ b/tests/commands/test_store_charmlibs.py
@@ -290,7 +290,7 @@ def test_getlibinternals_success_content(tmp_path, monkeypatch):
     test_path = _create_lib(extra_content=extra_content)
 
     internals = get_lib_internals(test_path)
-    assert internals.content == test_path.read_text()
+    assert internals.content == test_path.read_text(encoding="utf8")
     assert internals.content_hash == hashlib.sha256(extra_content.encode("utf8")).hexdigest()
 
 


### PR DESCRIPTION
There are two situations where these dependencies need to be used:

- in the Builder when it decides if the `venv` directory needs to be primed

- in charm_builder when dependencies are actually handled (hashed, installed, etc.)

I created a helper to collect all the dependencies, used from those two places. Located it in the charmlibs module for convenience (initially I thought putting it in `charmcraft/utils` but hit a circular import).

Alternatively, these dependencies could have been collected where other dependencies are defined or dynamically included: in the CharmPluginProperties class. This will make "pydeps" management much more similar to standard python packages or requirements files, but there are several drawbacks of this path:

- a new `charm_libs_deps` or similar key would have need to be included, even if that key should not be exposed to the user as a real config key

- an extra validator would need to be added to collect all PYDEPS values, which would be called *twice* (when config is validated, and when the plugin is actually run), so there is no drawback in calling the collection twice in the current model

- furthermore, that validator would have been executed (and all PYDEPS collected) when the config is validated *for any command* (e.g. `charmcraft names`)

Also, I include here these needed changes in the charm libraries:

- included PYDEPS in the parsing of a library internals

- added a `root` parameter to the `get_libs_from_tree` function; notably, this function relied on being on the project's root directory, which is suspicious, so I opened #1002 to ensure everything is fine (or fix it)

- moved the `emit` usage out of `get_libs_from_tree` as it is now used also from the charm_builder.py, called from the plugin, as a standard subprocess that does not use the Craft CLI infrastructure.