### PR TITLE
Add `__init__.py` files to test subdirectories in template

### DIFF
--- a/charmcraft/templates/init-kubernetes/tests/integration/__init__.py.j2
+++ b/charmcraft/templates/init-kubernetes/tests/integration/__init__.py.j2
@@ -1,0 +1,1 @@
+../../../init-simple/tests/integration/__init__.py.j2

--- a/charmcraft/templates/init-kubernetes/tests/unit/__init__.py.j2
+++ b/charmcraft/templates/init-kubernetes/tests/unit/__init__.py.j2
@@ -1,0 +1,1 @@
+../../../init-simple/tests/unit/__init__.py.j2

--- a/charmcraft/templates/init-machine/tests/integration/__init__.py.j2
+++ b/charmcraft/templates/init-machine/tests/integration/__init__.py.j2
@@ -1,0 +1,1 @@
+../../../init-simple/tests/integration/__init__.py.j2

--- a/charmcraft/templates/init-machine/tests/unit/__init__.py.j2
+++ b/charmcraft/templates/init-machine/tests/unit/__init__.py.j2
@@ -1,0 +1,1 @@
+../../../init-simple/tests/unit/__init__.py.j2

--- a/charmcraft/templates/init-simple/tests/integration/__init__.py.j2
+++ b/charmcraft/templates/init-simple/tests/integration/__init__.py.j2
@@ -1,0 +1,2 @@
+# Copyright {{ year }} {{ author }}
+# See LICENSE file for licensing details.

--- a/charmcraft/templates/init-simple/tests/unit/__init__.py.j2
+++ b/charmcraft/templates/init-simple/tests/unit/__init__.py.j2
@@ -1,0 +1,1 @@
+../integration/__init__.py.j2

--- a/tests/commands/test_init.py
+++ b/tests/commands/test_init.py
@@ -81,8 +81,10 @@ def test_all_the_files_simple(tmp_path, config):
         os.path.join("src", "charm.py"),
         "tests",
         os.path.join("tests", "integration"),
+        os.path.join("tests", "integration", "__init__.py"),
         os.path.join("tests", "integration", "test_charm.py"),
         os.path.join("tests", "unit"),
+        os.path.join("tests", "unit", "__init__.py"),
         os.path.join("tests", "unit", "test_charm.py"),
         "tox.ini",
     }
@@ -104,8 +106,10 @@ def test_all_the_files_kubernetes(tmp_path, config):
         os.path.join("src", "charm.py"),
         "tests",
         os.path.join("tests", "integration"),
+        os.path.join("tests", "integration", "__init__.py"),
         os.path.join("tests", "integration", "test_charm.py"),
         os.path.join("tests", "unit"),
+        os.path.join("tests", "unit", "__init__.py"),
         os.path.join("tests", "unit", "test_charm.py"),
         "tox.ini",
     }
@@ -127,8 +131,10 @@ def test_all_the_files_machine(tmp_path, config):
         os.path.join("src", "charm.py"),
         "tests",
         os.path.join("tests", "integration"),
+        os.path.join("tests", "integration", "__init__.py"),
         os.path.join("tests", "integration", "test_charm.py"),
         os.path.join("tests", "unit"),
+        os.path.join("tests", "unit", "__init__.py"),
         os.path.join("tests", "unit", "test_charm.py"),
         "tox.ini",
     }


### PR DESCRIPTION
Enables Python files in tests/integration/ and tests/unit/ to import other Python files in that directory

After removing the top-level directory from PYTHONPATH in 0333f4f529a0aace62a88865876e613eda01df11, Python modules in tests/ cannot import from each other without `__init__.py`

An `__init__.py` was not added to tests/ since that would cause pytest to add the top-level repository directory to PYTHONPATH. (More info: https://doc.pytest.org/en/latest/explanation/goodpractices.html#choosing-an-import-mode)