### PR TITLE
requirements: update craft-parts to 1.18.1

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,7 +9,7 @@ click==8.1.3
 colorama==0.4.6
 coverage==7.1.0
 craft-cli==1.2.0
-craft-parts==1.18.0
+craft-parts==1.18.1
 craft-providers==1.7.1
 craft-store==2.3.0
 cryptography==3.4.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ certifi==2022.12.7
 cffi==1.15.1
 charset-normalizer==3.0.1
 craft-cli==1.2.0
-craft-parts==1.18.0
+craft-parts==1.18.1
 craft-providers==1.7.1
 craft-store==2.3.0
 cryptography==3.4.8


### PR DESCRIPTION
Craft-parts 1.18.1 fixes ignored file patterns when processing local sources.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>