### PR TITLE
deps: update cryptography to v39.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,7 +12,7 @@ craft-cli==1.2.0
 craft-parts==1.18.1
 craft-providers==1.7.2
 craft-store==2.3.0
-cryptography==3.4.8
+cryptography==39.0.1
 Deprecated==1.2.13
 distlib==0.3.6
 exceptiongroup==1.1.0
@@ -61,9 +61,7 @@ requests-toolbelt==0.10.1
 requests-unixsocket==0.3.0
 responses==0.22.0
 SecretStorage==3.3.3
-semantic-version==2.10.0
 semver==2.13.0
-setuptools-rust==1.5.2
 six==1.16.0
 snap-helpers==0.3.2
 snowballstemmer==2.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ craft-cli==1.2.0
 craft-parts==1.18.1
 craft-providers==1.7.2
 craft-store==2.3.0
-cryptography==3.4.8
+cryptography==39.0.1
 Deprecated==1.2.13
 humanize==4.5.0
 idna==3.4
@@ -38,9 +38,7 @@ requests==2.28.2
 requests-toolbelt==0.10.1
 requests-unixsocket==0.3.0
 SecretStorage==3.3.3
-semantic-version==2.10.0
 semver==2.13.0
-setuptools-rust==1.5.2
 six==1.16.0
 snap-helpers==0.3.2
 tabulate==0.9.0

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ install_requires = [
     "craft-parts",
     "craft-providers",
     "craft-store",
-    "cryptography==3.4.8",  # *1
+    "cryptography==39.0",
     "humanize>=2.6.0",
     "jsonschema",
     "jinja2",
@@ -46,9 +46,6 @@ install_requires = [
     "snap-helpers",
     "tabulate",
 ]
-# *1: cryptography is not needed as a direct dependency, but it will be brought in
-# newer versions from other dependencies, and the new ones need a Rust compiler
-# which is not present in armhf, ppc64el and s390x architectures.
 
 dev_requires = [
     "black",

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ install_requires = [
     "craft-parts",
     "craft-providers",
     "craft-store",
-    "cryptography==39.0",
     "humanize>=2.6.0",
     "jsonschema",
     "jinja2",

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -92,9 +92,8 @@ parts:
       snapcraftctl build
       install -D -m 0755 $SNAPCRAFT_PROJECT_DIR/snap/local/sitecustomize.py $SNAPCRAFT_PART_INSTALL/usr/lib/python3.8/sitecustomize.py
 
-  # The cryptography library requires rust, but only ships wheels for amd64 and arm64.
-  # As of cryptography 39, it requires rust v1.48.0 or newer, which is available
-  # from focal-updates.
+  # The cryptography library (indirect dependency via craft-store) requires rust, but only ships wheels for amd64 and arm64.
+  # As of cryptography 39, it requires rust v1.48.0 or newer, which is available from focal-updates.
   rust-deps:
     plugin: nil
     build-packages:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -92,8 +92,17 @@ parts:
       snapcraftctl build
       install -D -m 0755 $SNAPCRAFT_PROJECT_DIR/snap/local/sitecustomize.py $SNAPCRAFT_PART_INSTALL/usr/lib/python3.8/sitecustomize.py
 
+  # The cryptography library requires rust, but only ships wheels for amd64 and arm64.
+  # As of cryptography 39, it requires rust v1.48.0 or newer, which is available
+  # from the focal-updates pocket.
+  rust-deps:
+    plugin: nil
+    build-packages:
+      - cargo
+      - rustc
+
   charmcraft:
-    after: [python3]
+    after: [python3, rust-deps]
     source: .
     plugin: python
     requirements:
@@ -114,7 +123,6 @@ parts:
     build-environment:
       - LDFLAGS: -L/usr/lib/python3.8
       - CPPFLAGS: -I/usr/include/python3.8
-      - CRYPTOGRAPHY_DONT_BUILD_RUST: "1"  # for cryptography to not use a Rust compiler (fails on some archs)
     override-pull: |
       # do the usual pull stuff
       snapcraftctl pull


### PR DESCRIPTION
Since older versions of cryptography now have known security issues, it's more necessary to update. This not only makes that change but also updates the snapcraft.yaml to include the appropriate rust dependencies.

Should fix #991 