### PR TITLE
Remove a verification left over after init command refactor.

### DIFF
--- a/tests/commands/test_store_commands.py
+++ b/tests/commands/test_store_commands.py
@@ -1059,27 +1059,6 @@ def test_upload_call_error_including_release(emitter, store_mock, config, tmp_pa
     assert store_mock.mock_calls == [call.upload("mycharm", test_charm)]
 
 
-def test_upload_charm_with_init_template_todo_token(tmp_path, config):
-    """Avoid uploading a charm that is not really ready to be shown to the world."""
-    # create a charm zip file all valid but with files having the token from
-    # the templates used by 'init' command
-    test_charm = tmp_path / "mystuff.charm"
-    with zipfile.ZipFile(str(test_charm), "w") as zf:
-        zf.writestr("metadata.yaml", yaml.dump({"name": "mycharm"}).encode("ascii"))
-        zf.writestr("somefile.cfg", b"# TEMPLATE-TODO: please take a look to this.")
-        zf.writestr("file_ok.cfg", b"This is fine :).")
-        zf.writestr("othertainted.txt", b"# TEMPLATE-TODO: need to fix.")
-
-    args = Namespace(filepath=test_charm, release=[], name=None, format=False)
-    expected_msg = (
-        "Cannot upload the charm as it include the following files with a leftover "
-        "TEMPLATE-TODO token from when the project was created using the 'init' "
-        "command: somefile.cfg, othertainted.txt"
-    )
-    with pytest.raises(CraftError, match=expected_msg):
-        UploadCommand(config).run(args)
-
-
 def test_upload_with_different_name_than_in_metadata(emitter, store_mock, config, tmp_path):
     """Simple upload to a specific name different from metadata, success result."""
     store_response = Uploaded(ok=True, status=200, revision=7, errors=[])


### PR DESCRIPTION
The `TEMPLATE-TODO` was a mark used in the `init` command for places where the user should do changes, so it was validated at Upload time (way before we had linters) that everything was properly replaced. But this mark does not exist anymore after `init` was refactored and multiple templates appeared.