### PR TITLE
Fix digest check for uploading OCI resource

### DIFF
--- a/charmcraft/commands/store/__init__.py
+++ b/charmcraft/commands/store/__init__.py
@@ -1799,7 +1799,7 @@ class UploadResourceCommand(BaseCommand):
             dockerd = LocalDockerdInterface()
 
             server_image_digest = None
-            if ":" in parsed_args.image:
+            if "@" in parsed_args.image:
                 # the user provided a digest; check if the specific image is
                 # already in Canonical's registry
                 already_uploaded = ih.check_in_registry(parsed_args.image)


### PR DESCRIPTION
`charmcraft upload-resource` fails to upload a local OCI image if the OCI image has a tag

(e.g. `charmcraft upload-resource test-application-167531 mysql-image --image dataplatformoci/mysql-and-shell:latest`)

I believe this happens because the check for a digest (e.g. `dataplatformoci/mysql-and-shell@sha256:599fe5e5073102dbb0ee3dbb65f049dab44fa9fc251f6835c9990f8fb196a72b`) checks if `:` is in the string instead of checking `@`