### PR TITLE
store: check the credentials validity before upload

### DIFF
--- a/charmcraft/commands/store/store.py
+++ b/charmcraft/commands/store/store.py
@@ -251,6 +251,10 @@ class Store:
         )
         return result
 
+    def _check_authorized(self) -> None:
+        """Check if current credentials authenticated."""
+        self._client.whoami()
+
     @_store_client_wrapper()
     def register_name(self, name, entity_type):
         """Register the specified name for the authenticated user."""
@@ -280,6 +284,8 @@ class Store:
 
     def _upload(self, endpoint, filepath, *, extra_fields=None):
         """Upload for all charms, bundles and resources (generic process)."""
+        self._check_authorized()
+
         upload_id = self._client.push_file(filepath)
         payload = {"upload-id": upload_id}
         if extra_fields is not None:

--- a/tests/commands/test_store_api.py
+++ b/tests/commands/test_store_api.py
@@ -658,6 +658,7 @@ def test_upload_straightforward(client_mock, emitter, config):
 
     # check all client calls
     assert client_mock.mock_calls == [
+        call.whoami(),
         call.push_file(test_filepath),
         call.request_urlpath_json("POST", test_endpoint, json={"upload-id": test_upload_id}),
         call.request_urlpath_json("GET", test_status_url),
@@ -715,7 +716,7 @@ def test_upload_polls_status_ok(client_mock, emitter, config):
             result = store._upload("/test/endpoint/", "some-filepath")
 
     # check the status-checking client calls (kept going until third one)
-    assert client_mock.mock_calls[2:] == [
+    assert client_mock.mock_calls[3:] == [
         call.request_urlpath_json("GET", test_status_url),
         call.request_urlpath_json("GET", test_status_url),
         call.request_urlpath_json("GET", test_status_url),
@@ -885,6 +886,7 @@ def test_upload_including_extra_parameters(client_mock, emitter, config):
 
     # check all client calls
     assert client_mock.mock_calls == [
+        call.whoami(),
         call.push_file(test_filepath),
         call.request_urlpath_json(
             "POST",


### PR DESCRIPTION
Avoid wasting time uploading when credentials expire.