### PR TITLE
deps: remove ops dependency

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -32,7 +32,7 @@ MarkupSafe==2.1.2
 mccabe==0.7.0
 more-itertools==9.1.0
 mypy-extensions==0.4.4
-ops==2.0.0
+ops==1.5.4
 overrides==7.3.1
 packaging==23.0
 pathspec==0.11.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -32,7 +32,6 @@ MarkupSafe==2.1.2
 mccabe==0.7.0
 more-itertools==9.1.0
 mypy-extensions==0.4.4
-ops==1.5.4
 overrides==7.3.1
 packaging==23.0
 pathspec==0.11.0

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ dev_requires = [
     "black",
     "coverage",
     "flake8",
-    "ops>=1.4.0",
+    "ops>=1.4.0,<2.0",  # *1
     "pydocstyle",
     "pytest",
     "pytest-cov",
@@ -59,6 +59,9 @@ dev_requires = [
     "responses",
     "tox",
 ]
+
+# *1: Ops 2.0 requires Python 3.8, so we can only upgrade once we can
+# guarantee we'll have it. Currently, spread tests on bionic use Python 3.6.
 
 extras_require = {
     "dev": dev_requires,

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,6 @@ dev_requires = [
     "black",
     "coverage",
     "flake8",
-    "ops>=1.4.0,<2.0",  # *1
     "pydocstyle",
     "pytest",
     "pytest-cov",
@@ -59,9 +58,6 @@ dev_requires = [
     "responses",
     "tox",
 ]
-
-# *1: Ops 2.0 requires Python 3.8, so we can only upgrade once we can
-# guarantee we'll have it. Currently, spread tests on bionic use Python 3.6.
 
 extras_require = {
     "dev": dev_requires,


### PR DESCRIPTION
Spread tests were failing due to this. We're going to have to keep this pre-2.0 until we can guarantee at least Python 3.8 in our spread tests, which will likely only happen when we drop support for 18.04.