### PR TITLE
bases: support creating charms use CentOS 7 as base

### DIFF
--- a/charmcraft/parts.py
+++ b/charmcraft/parts.py
@@ -20,7 +20,7 @@ import os
 import pathlib
 import shlex
 import sys
-from typing import Any, Dict, List, Set, Optional, cast
+from typing import Any, Dict, List, Optional, Set, cast
 from contextlib import suppress
 
 import pydantic

--- a/charmcraft/parts.py
+++ b/charmcraft/parts.py
@@ -166,6 +166,13 @@ class CharmPlugin(plugins.Plugin):
                 if (os_release.id(), os_release.version_id()) in (("centos", "7"), ("rhel", "7")):
                     # CentOS 7 Python 3.8 from SCL repo
                     return {
+                        "autoconf",
+                        "automake",
+                        "gcc",
+                        "gcc-c++",
+                        "git",
+                        "make",
+                        "patch",
                         "rh-python38-python-devel",
                         "rh-python38-python-pip",
                         "rh-python38-python-setuptools",
@@ -175,6 +182,13 @@ class CharmPlugin(plugins.Plugin):
                 pass
 
             return {
+                "autoconf",
+                "automake",
+                "gcc",
+                "gcc-c++",
+                "git",
+                "make",
+                "patch",
                 "python3-devel",
                 "python3-pip",
                 "python3-setuptools",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,7 +10,7 @@ colorama==0.4.6
 coverage==7.2.3
 craft-cli==1.2.0
 craft-parts==1.19.1
-craft-providers==1.10.0
+craft-providers==1.11.0
 craft-store==2.4.0
 cryptography==40.0.2
 Deprecated==1.2.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ cffi==1.15.1
 charset-normalizer==3.1.0
 craft-cli==1.2.0
 craft-parts==1.19.1
-craft-providers==1.10.0
+craft-providers==1.11.0
 craft-store==2.4.0
 cryptography==40.0.2
 Deprecated==1.2.13

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -167,8 +167,8 @@ def fake_provider(mock_instance):
             project_name: str,
             project_path: pathlib.Path,
             base_configuration: Base,
-            build_base: str,
             instance_name: str,
+            allow_unstable: bool = False,
         ):
             yield mock_instance
 

--- a/tests/spread/smoketests/basic-centos-7/task.yaml
+++ b/tests/spread/smoketests/basic-centos-7/task.yaml
@@ -1,0 +1,33 @@
+summary: pack a simple init-created charm for CentOS 7
+systems:
+  # CentOS 7 only works in 18.04 because it needs cgroup v1
+  - ubuntu-18.04-64
+kill-timeout: 30m
+
+prepare: |
+  charmcraft init --project-dir=charm
+  pushd charm
+
+  cat <<- EOF >> charmcraft.yaml
+  type: charm
+  bases:
+    - build-on:
+      - name: centos
+        channel: "7"
+      run-on:
+      - name: centos
+        channel: "7"
+  EOF
+
+  popd
+
+restore: |
+  pushd charm
+  charmcraft clean
+  popd
+  
+  rm -rf charm
+
+execute: |
+  cd charm
+  charmcraft pack --verbose

--- a/tests/test_parts.py
+++ b/tests/test_parts.py
@@ -81,6 +81,13 @@ def test_charmplugin_get_build_package_yum_based(charm_plugin):
         mock_id.return_value = "centos"
 
         assert charm_plugin.get_build_packages() == {
+            "autoconf",
+            "automake",
+            "gcc",
+            "gcc-c++",
+            "git",
+            "make",
+            "patch",
             "python3-devel",
             "python3-pip",
             "python3-setuptools",
@@ -95,6 +102,13 @@ def test_charmplugin_get_build_package_centos7(charm_plugin):
             mock_version.return_value = "7"
 
             assert charm_plugin.get_build_packages() == {
+                "autoconf",
+                "automake",
+                "gcc",
+                "gcc-c++",
+                "git",
+                "make",
+                "patch",
                 "rh-python38-python-devel",
                 "rh-python38-python-pip",
                 "rh-python38-python-setuptools",


### PR DESCRIPTION
needs Ubuntu 18.04 for cgroup v1

needs craft-providers unreleased version.

CRAFT-1697