### PR TITLE
ci: only require CHARMCRAFT_AUTH for store spread

### DIFF
--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -35,6 +35,31 @@ jobs:
           - "google:ubuntu-22.04-64:tests/spread/charms/k8s-operator:prometheus"
 
     steps:
+      - name: Cleanup job workspace
+        run: |
+          rm -rf "${{ github.workspace }}"
+          mkdir "${{ github.workspace }}"
+
+      - name: Checkout charmcraft
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          submodules: true
+
+      - name: Download snap artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: snap
+
+      - name: Run spread
+        run: |
+          spread ${{ matrix.spread }}
+
+  snap-store-tests:
+    runs-on: self-hosted
+    needs: [snap-build]
+
+    steps:
       - name: Decision to Run
         id: decisions
         run: |
@@ -70,4 +95,5 @@ jobs:
         env:
           CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_AUTH }}
         run: |
-          spread ${{ matrix.spread }}
+          spread google:ubuntu-22.04-64:tests/spread/store/
+

--- a/spread.yaml
+++ b/spread.yaml
@@ -4,18 +4,6 @@ path: /charmcraft
 environment:
   PROJECT_PATH: /charmcraft
   PATH: /snap/bin:$PATH:$PROJECT_PATH/tools/external/tools
-    # the content for this key is the content of FILE after running
-    #     charmcraft login --export=FILE --ttl=5184000#
-    # (as the owner of CHARM_DEFAULT_NAME and BUNDLE_DEFAULT_NAME below), and it
-    # should be part of the environment (when running spread locally just define it,
-    # for GH actions set it in Settings -> Security -> Actions -> Repository secrets)
-  CHARMCRAFT_AUTH: "$(HOST: echo $CHARMCRAFT_AUTH)"
-
-  # to not flood Charmhub with names the same two are always used in the Store related
-  # tests (except in the names registration tests, of course); register them manually
-  # in staging Charmhub authenticating with the configured credentials
-  CHARM_DEFAULT_NAME: craft-spreadtests-charm-2
-  BUNDLE_DEFAULT_NAME: craft-spreadtests-bundle-2
 
 backends:
   google:
@@ -153,4 +141,20 @@ suites:
   tests/spread/store/:
     summary: sequence of commands for different store-related functionalities
     kill-timeout: 30m
+    manual: true
+    systems:
+      - ubuntu-22.04-64
+    environment:
+      # the content for this key is the content of FILE after running
+      #     charmcraft login --export=FILE --ttl=5184000#
+      # (as the owner of CHARM_DEFAULT_NAME and BUNDLE_DEFAULT_NAME below), and it
+      # should be part of the environment (when running spread locally just define it,
+      # for GH actions set it in Settings -> Security -> Actions -> Repository secrets)
+      CHARMCRAFT_AUTH: "$(HOST: echo $CHARMCRAFT_AUTH)"
+
+      # to not flood Charmhub with names the same two are always used in the Store related
+      # tests (except in the names registration tests, of course); register them manually
+      # in staging Charmhub authenticating with the configured credentials
+      CHARM_DEFAULT_NAME: craft-spreadtests-charm-2
+      BUNDLE_DEFAULT_NAME: craft-spreadtests-bundle-2
 

--- a/tests/spread/charms/k8s-operator/task.yaml
+++ b/tests/spread/charms/k8s-operator/task.yaml
@@ -2,7 +2,7 @@ summary: pack external k8s operator charms
 manual: true
 systems:
   - ubuntu-22.04-64
-kill-timeout: 30m
+kill-timeout: 60m
 
 environment:
   CHARM/alertmanager: https://github.com/canonical/alertmanager-k8s-operator


### PR DESCRIPTION
Separate the logic into two in the Github Actions Workflow to always run spread for the general tests, while limiting store tests to having CHARMCRAFT_AUTH in GHA Secrets.

The required environment has been moved to the store suite in spread. Also making it run less test repetition by limiting them to Ubuntu 22.04 and avoiding it being run in the main testing phase for spread by marking them as manual.