### PR TITLE
store: ensure promote-bundle succeeds if there are no applications

### DIFF
--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -94,6 +94,8 @@ jobs:
         name: Run spread
         env:
           CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_AUTH }}
+          CHARM_DEFAULT_NAME: charmcraft-ci-test-charm
+          BUNDLE_DEFAULT_NAME: charmcraft-ci-test-bundle
         run: |
           spread google:ubuntu-22.04-64:tests/spread/store/
 

--- a/charmcraft/commands/store/__init__.py
+++ b/charmcraft/commands/store/__init__.py
@@ -845,7 +845,7 @@ class PromoteBundleCommand(BaseCommand):
                 f"file {str(bundle_path)!r}."
             )
         emit.progress("Determining charms to promote")
-        charms = [c["charm"] for c in bundle_config["applications"].values()]
+        charms = [c["charm"] for c in bundle_config.get("applications", {}).values()]
         errant_excludes = []
         for excluded in parsed_args.exclude:
             try:
@@ -916,7 +916,7 @@ class PromoteBundleCommand(BaseCommand):
             charm_list = humanize_list(error_charms, "and")
             raise CraftError(f"Not found in channel {from_channel.name}: {charm_list}")
 
-        for application in bundle_config["applications"].values():
+        for application in bundle_config.get("applications", {}).values():
             application["channel"] = to_channel.name
 
         if parsed_args.output_bundle:

--- a/spread.yaml
+++ b/spread.yaml
@@ -155,6 +155,6 @@ suites:
       # to not flood Charmhub with names the same two are always used in the Store related
       # tests (except in the names registration tests, of course); register them manually
       # in staging Charmhub authenticating with the configured credentials
-      CHARM_DEFAULT_NAME: craft-spreadtests-charm-2
-      BUNDLE_DEFAULT_NAME: craft-spreadtests-bundle-2
+      CHARM_DEFAULT_NAME: "$(HOST: echo ${SPREAD_CHARM_NAME:-$USER-test-charm})"
+      BUNDLE_DEFAULT_NAME: "$(HOST: echo ${SPREAD_BUNDLE_NAME:-$USER-test-bundle})"
 

--- a/tests/spread/store/bundle-upload-and-release/task.yaml
+++ b/tests/spread/store/bundle-upload-and-release/task.yaml
@@ -23,6 +23,13 @@ prepare: |
   series: focal
   EOF
 
+  # If necessary, try to register the bundle.
+  if ! charmcraft status $BUNDLE_DEFAULT_NAME; then
+    if ! charmcraft register $BUNDLE_DEFAULT_NAME; then
+      ERROR Charm $BUNDLE_DEFAULT_NAME cannot be registered to this account.
+    fi
+  fi
+
 restore: |
   rm -rf bundle
 

--- a/tests/spread/store/bundle-upload-and-release/task.yaml
+++ b/tests/spread/store/bundle-upload-and-release/task.yaml
@@ -23,6 +23,11 @@ prepare: |
   series: focal
   EOF
 
+  cat <<- EOF > metadata.yaml
+  name: $BUNDLE_DEFAULT_NAME
+  summary: Test bundle for charmcraft
+  EOF
+
   # If necessary, try to register the bundle.
   if ! charmcraft status $BUNDLE_DEFAULT_NAME; then
     if ! charmcraft register $BUNDLE_DEFAULT_NAME; then

--- a/tests/spread/store/charm-upload-and-release/task.yaml
+++ b/tests/spread/store/charm-upload-and-release/task.yaml
@@ -1,6 +1,6 @@
 summary: full charm cycle -- pack, upload, check revisions, release, check channel map
 
-include: 
+include:
   - tests/
 
 prepare: |
@@ -14,11 +14,18 @@ prepare: |
     storage-url: https://storage.staging.snapcraftcontent.com
   EOF
 
+  # If necessary, try to register the charm.
+  if ! charmcraft status $CHARM_DEFAULT_NAME; then
+    if ! charmcraft register $CHARM_DEFAULT_NAME; then
+      ERROR Charm $CHARM_DEFAULT_NAME cannot be registered to this account.
+    fi
+  fi
+
 restore: |
   pushd charm
   charmcraft clean
   popd
-  
+
   rm -rf charm
 
 execute: |
@@ -33,7 +40,7 @@ execute: |
   # upload and get uploaded revision
   uploaded_revno=$(charmcraft upload $charm_filepath --format=json | jq .revision)
 
-  # check the uploaded revision is newer than start datetime (note we're not using latest, as 
+  # check the uploaded revision is newer than start datetime (note we're not using latest, as
   # it may not be the one we uploaded here, because multiple tests running concurrently)
   up_revision=$(charmcraft revisions $CHARM_DEFAULT_NAME --format=json | jq -r --arg revno $uploaded_revno '.[] | select(.revision|tostring==$revno)')
   up_revision_created=$(echo $up_revision | jq -r .created_at)
@@ -45,7 +52,7 @@ execute: |
   # validate the channel map
   edge_release=$(charmcraft status $CHARM_DEFAULT_NAME --format=json | jq -r '.[] | select(.track=="latest") | .mappings[0].releases | .[] | select(.channel=="latest/edge")')
   edge_revision=$(echo $edge_release | jq -r .revision)
-  # check that the current release greater or equal than what was 
+  # check that the current release greater or equal than what was
   # uploaded, because other tests running concurrently may have
   # also released (but for sure cannot be a previous revision)
-  test $edge_revision -ge $uploaded_revno  
+  test $edge_revision -ge $uploaded_revno

--- a/tests/spread/store/libraries/task.yaml
+++ b/tests/spread/store/libraries/task.yaml
@@ -4,7 +4,7 @@ environment:
   LIB_NAME: lib_$(uuidgen | sed -e 's/-//g')
   CHARM_UNDERSCORE_NAME: $(echo $CHARM_DEFAULT_NAME | sed -e 's/-/_/g')
 
-include: 
+include:
   - tests/
 
 prepare: |
@@ -21,6 +21,13 @@ prepare: |
     api-url: https://api.staging.charmhub.io
     storage-url: https://storage.staging.snapcraftcontent.com
   EOF
+
+  # If necessary, try to register the charm.
+  if ! charmcraft status $CHARM_DEFAULT_NAME; then
+    if ! charmcraft register $CHARM_DEFAULT_NAME; then
+      ERROR Charm $CHARM_DEFAULT_NAME cannot be registered to this account.
+    fi
+  fi
 
 restore: |
   rm -rf charm

--- a/tests/spread/store/resources/task.yaml
+++ b/tests/spread/store/resources/task.yaml
@@ -1,6 +1,6 @@
 summary: upload resources, list their revisions, release them
 
-include: 
+include:
   - tests/
 
 prepare: |
@@ -37,11 +37,18 @@ prepare: |
   # an oci image resource
   docker pull hello-world@sha256:18a657d0cc1c7d0678a3fbea8b7eb4918bba25968d3e1b0adebfa71caddbc346
 
+  # If necessary, try to register the charm.
+  if ! charmcraft status $CHARM_DEFAULT_NAME; then
+    if ! charmcraft register $CHARM_DEFAULT_NAME; then
+      ERROR Charm $CHARM_DEFAULT_NAME cannot be registered to this account.
+    fi
+  fi
+
 restore: |
   pushd charm
   charmcraft clean
   popd
-  
+
   rm -rf charm
 
 execute: |


### PR DESCRIPTION
Depends on #1075. Once that's merged this will be a whole lot cleaner

The actual changes for this PR: https://github.com/canonical/charmcraft/pull/1081/files/82d83e4a1292c5619e66fe4a5045cd04cc828732..HEAD