### PR TITLE
tests: check for submodules before running spread

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -3,7 +3,8 @@ project: charmcraft
 path: /charmcraft
 environment:
   PROJECT_PATH: /charmcraft
-  PATH: /snap/bin:$PATH:$PROJECT_PATH/tools/external/tools
+  SNAPD_TESTING_TOOLS: $PROJECT_PATH/tools/external/tools
+  PATH: /snap/bin:$PATH:$SNAPD_TESTING_TOOLS
 
 backends:
   google:
@@ -86,6 +87,13 @@ backends:
 
 prepare: |
   set -e
+
+  # if the 'tools' directory inside the submodule does not exist, then assume the submodule is empty
+  if [[ ! -d "$SNAPD_TESTING_TOOLS" ]]; then
+    echo "Cannot run spread because submodule 'snapd-testing-tools' is empty. Fetch with 'git submodule update --init' and rerun spread."
+    exit 1
+  fi
+
   if os.query is-ubuntu; then
     tempfile="$(mktemp)"
     if ! apt-get update > "$tempfile" 2>&1; then


### PR DESCRIPTION
Spread tests require the `snapd-testing-tools` submodule. If the submodule has not been fetched, then a useful error is provided.

Similar to https://github.com/snapcore/snapcraft/pull/4105, but perhaps simpler (I am open to feedback).