### PR TITLE
charmlibs: skip non top-level name assignments

### DIFF
--- a/charmcraft/commands/store/charmlibs.py
+++ b/charmcraft/commands/store/charmlibs.py
@@ -105,7 +105,7 @@ def get_lib_internals(lib_path: pathlib.Path) -> LibInternals:
     metadata = {}
     for node in ast.iter_child_nodes(tree):
         if isinstance(node, ast.Assign):
-            for target in node.targets:
+            for target in (n for n in node.targets if isinstance(n, ast.Name)):
                 if target.id in simple_fields:
                     validator, error_msg = simple_fields[target.id]
                     if not isinstance(node.value, ast.Constant):

--- a/tests/commands/test_store_charmlibs.py
+++ b/tests/commands/test_store_charmlibs.py
@@ -294,6 +294,20 @@ def test_getlibinternals_success_content(tmp_path, monkeypatch):
     assert internals.content_hash == hashlib.sha256(extra_content.encode("utf8")).hexdigest()
 
 
+def test_getlibinternals_non_toplevel_names(tmp_path, monkeypatch):
+    """Test non direct assignments."""
+    monkeypatch.chdir(tmp_path)
+    test_path = _create_lib(extra_content="logging.getLogger('kazoo.client').disabled = True")
+    internals = get_lib_internals(test_path)
+
+    assert internals.lib_id == "test-lib-id"
+    assert internals.api == 3
+    assert internals.patch == 14
+    assert internals.pydeps == []
+    assert internals.content is not None
+    assert internals.content_hash is not None
+
+
 def test_getlibinternals_malformed_content(tmp_path, monkeypatch):
     """Some internals field is not really valid."""
     monkeypatch.chdir(tmp_path)


### PR DESCRIPTION
Without filtering for ast.Names when looking for ast.Assign, we also falled into looking for assignments of the form
`module_name.method_call().attribute = assignment`