### PR TITLE
snap: ensure cryptography builds correctly on all architectures

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -53,12 +53,12 @@
       // tox.ini can get updates too if we specify for each package.
       fileMatch: ["tox.ini"],
       matchStrings: [
-        "# renovate: datasource=(?<datasource>\\S+)\n\\s+(?<depName>.*?)==(?<currentValue>.*?)\\n"
+        "# renovate: datasource=(?<datasource>\\S+)\n\\s+(?<depName>.*?)(\\[[\\w]*\\])*[=><]=?(?<currentValue>.*?)\n"
       ]
     }
   ],
   timezone: "Etc/UTC",
-  automergeSchedule: "after 1 am and before 7 am",
+  automergeSchedule: "before 07:00",
   schedule: "every weekend",
   prConcurrentLimit: 5, // No more than 5 open PRs at a time.
   prCreation: "not-pending", // Wait until status checks have completed before raising the PR

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -71,26 +71,27 @@ jobs:
           name: snap
           path: ${{ steps.snapcraft.outputs.snap }}
 
-  snap-remote-build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Start installing snapcraft
-        run: echo SNAP_JOB=$(sudo snap install --classic --no-wait snapcraft) >> $GITHUB_OUTPUT
-        id: install
-      - name: Checkout code
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Remote-build snap
-        id: snapcraft
-        run: |
-          sudo snap watch ${{ steps.install.outputs.SNAP_JOB }}
-          snapcraft remote-build --launchpad-accept-public-upload
-      - name: Upload snap artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: snap
-          path: ./*.snap
+# Commented out until we can provide the necessary launchpad credentials.
+#  snap-remote-build:
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Start installing snapcraft
+#        run: echo SNAP_JOB=$(sudo snap install --classic --no-wait snapcraft) >> $GITHUB_OUTPUT
+#        id: install
+#      - name: Checkout code
+#        uses: actions/checkout@v3
+#        with:
+#          fetch-depth: 0
+#      - name: Remote-build snap
+#        id: snapcraft
+#        run: |
+#          sudo snap watch ${{ steps.install.outputs.SNAP_JOB }}
+#          snapcraft remote-build --launchpad-accept-public-upload
+#      - name: Upload snap artifacts
+#        uses: actions/upload-artifact@v3
+#        with:
+#          name: snap
+#          path: ./*.snap
 
   snap-tests:
     needs: [snap-build]

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -71,6 +71,27 @@ jobs:
           name: snap
           path: ${{ steps.snapcraft.outputs.snap }}
 
+  snap-remote-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Start installing snapcraft
+        run: echo SNAP_JOB=$(sudo snap install --classic --no-wait snapcraft) >> $GITHUB_OUTPUT
+        id: install
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Remote-build snap
+        id: snapcraft
+        run: |
+          sudo snap watch ${{ steps.install.outputs.SNAP_JOB }}
+          snapcraft remote-build --launchpad-accept-public-upload
+      - name: Upload snap artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: snap
+          path: ./*.snap
+
   snap-tests:
     needs: [snap-build]
     strategy:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -73,10 +73,10 @@ confinement: classic
 parts:
   # The cryptography library (indirect dependency via craft-store) requires rust, but only ships wheels for amd64 and arm64.
   # As of cryptography 39, it requires rust v1.48.0 or newer, which is available from focal-updates.
-  # This part contains the full set of build dependencies for cryptography.
-  # NOTE: cryptography requires at least pip version 22 for building.
+  # This part builds the wheel for cryptography.
   cryptography-deps:
-    plugin: nil
+    plugin: dump
+    source: .
     build-packages:
       - cargo
       - rustc
@@ -89,10 +89,9 @@ parts:
       - python3-pip
       - python3-setuptools-scm
     override-build: |
-      pip install 'pip>=22.0' 'setuptools>=61.0.0'
       # Dirty workaround - builds the cryptography wheel for later installation.
       # This must be exactly the version referenced in requirements.txt, so this is fragile.
-      pip wheel cryptography==40.0.2
+      pip wheel $(grep '^cryptography[<=>]' requirements.txt)
 
   # Classic core20 snaps require staged python.
   python3:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -93,7 +93,6 @@ parts:
       # Dirty workaround - builds the cryptography wheel for later installation.
       # This must be exactly the version referenced in requirements.txt, so this is fragile.
       pip wheel cryptography==40.0.2
-      snapcraftctl build
 
   # Classic core20 snaps require staged python.
   python3:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -141,6 +141,8 @@ parts:
     override-pull: |
       # do the usual pull stuff
       snapcraftctl pull
+      # Ensure we don't have a dubious ownership error from git with a remote build.
+      git config --global --add safe.directory $SNAPCRAFT_PART_SRC
       # set the version
       version="$(python3 setup.py --version)"
       snapcraftctl set-version "$version"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -71,8 +71,33 @@ grade: stable
 confinement: classic
 
 parts:
+  # The cryptography library (indirect dependency via craft-store) requires rust, but only ships wheels for amd64 and arm64.
+  # As of cryptography 39, it requires rust v1.48.0 or newer, which is available from focal-updates.
+  # This part contains the full set of build dependencies for cryptography.
+  # NOTE: cryptography requires at least pip version 22 for building.
+  cryptography-deps:
+    plugin: nil
+    build-packages:
+      - cargo
+      - rustc
+      - pkg-config
+      - python3.8-dev
+      - libpython3.8-dev
+      - libssl-dev
+      - libffi-dev
+      - python3-wheel
+      - python3-pip
+      - python3-setuptools-scm
+    override-build: |
+      pip install 'pip>=22.0' 'setuptools>=61.0.0'
+      # Dirty workaround - builds the cryptography wheel for later installation.
+      # This must be exactly the version referenced in requirements.txt, so this is fragile.
+      pip wheel cryptography==40.0.2
+      snapcraftctl build
+
   # Classic core20 snaps require staged python.
   python3:
+    after: [cryptography-deps]
     plugin: nil
     build-packages:
       - python3-dev
@@ -92,16 +117,8 @@ parts:
       snapcraftctl build
       install -D -m 0755 $SNAPCRAFT_PROJECT_DIR/snap/local/sitecustomize.py $SNAPCRAFT_PART_INSTALL/usr/lib/python3.8/sitecustomize.py
 
-  # The cryptography library (indirect dependency via craft-store) requires rust, but only ships wheels for amd64 and arm64.
-  # As of cryptography 39, it requires rust v1.48.0 or newer, which is available from focal-updates.
-  rust-deps:
-    plugin: nil
-    build-packages:
-      - cargo
-      - rustc
-
   charmcraft:
-    after: [python3, rust-deps]
+    after: [python3, cryptography-deps]
     source: .
     plugin: python
     requirements:


### PR DESCRIPTION
This is a quick and dirty workaround to make cryptography build properly.

I'll follow up with a more robust fix, but this should at least get the snap building on all architectures.

Remote build: https://launchpad.net/~lengau/+snap/snapcraft-charmcraft-1bebeb44e32b4aa985026c6f977fd0b8