### PR TITLE
commands: cosmetic fixes to promote-bundle

### DIFF
--- a/charmcraft/commands/store/__init__.py
+++ b/charmcraft/commands/store/__init__.py
@@ -793,14 +793,25 @@ class PromoteBundleCommand(BaseCommand):
         """
         Promote a bundle to another channel in the Store.
 
-
-        """  # TODO (amlowe): complete this description.
+        This command must be run from the bundle project directory to be
+        promoted.
+        """
     )
 
     def fill_parser(self, parser: "ArgumentParser") -> None:
         """Add promote-bundle parameters to the general parser."""
-        parser.add_argument("from_channel", help="The channel from which to promote the bundle")
-        parser.add_argument("to_channel", help="The target channel for the promoted bundle")
+        parser.add_argument(
+            "--from-channel",
+            type=SingleOptionEnsurer(str),
+            required=True,
+            help="The channel from which to promote the bundle",
+        )
+        parser.add_argument(
+            "--to-channel",
+            type=SingleOptionEnsurer(str),
+            required=True,
+            help="The target channel for the promoted bundle",
+        )
         parser.add_argument(
             "--output-bundle",
             type=pathlib.Path,
@@ -996,7 +1007,14 @@ class PromoteBundleCommand(BaseCommand):
 
             # Upload the bundle and release it to the target channel.
             store.upload(bundle_name, zipname)
-        store.release(bundle_name, bundle_revision, [parsed_args.to_channel], [])
+        release_info = store.release(bundle_name, bundle_revision, [parsed_args.to_channel], [])
+
+        # There should only be one revision.
+        release_info = release_info["released"][0]
+        emit.message(
+            f"Created revision {release_info['revision']!r} and "
+            f"released it to the {release_info['channel']!r} channel"
+        )
 
 
 class CloseCommand(BaseCommand):

--- a/charmcraft/commands/store/store.py
+++ b/charmcraft/commands/store/store.py
@@ -347,7 +347,7 @@ class Store:
         return result
 
     @_store_client_wrapper()
-    def release(self, name: str, revision: int, channels: List[str], resources):
+    def release(self, name: str, revision: int, channels: List[str], resources) -> Dict[str, Any]:
         """Release one or more revisions for a package."""
         endpoint = "/v1/charm/{}/releases".format(name)
         resources = [{"name": res.name, "revision": res.revision} for res in resources]
@@ -355,7 +355,8 @@ class Store:
             {"revision": revision, "channel": channel, "resources": resources}
             for channel in channels
         ]
-        self._client.request_urlpath_json("POST", endpoint, json=items)
+
+        return self._client.request_urlpath_json("POST", endpoint, json=items)
 
     @_store_client_wrapper()
     def list_releases(self, name: str) -> Tuple[List[Release], List[Channel], List[Revision]]:

--- a/tests/spread/store/bundle-upload-and-release/task.yaml
+++ b/tests/spread/store/bundle-upload-and-release/task.yaml
@@ -73,7 +73,7 @@ execute: |
   if [[ $old_beta_revision != null ]]; then  # If there's no beta revision, skip this check.
     test $old_beta_revision -le $edge_revision
   fi
-  charmcraft promote-bundle latest/edge latest/beta
+  charmcraft promote-bundle --from-channel latest/edge --to-channel latest/beta
   beta_release=$(charmcraft status $BUNDLE_DEFAULT_NAME --format=json | jq -r '.[] | select(.track=="latest") | .mappings[0].releases | .[] | select(.channel=="latest/beta")')
   beta_revision=$(echo $beta_release | jq -r .revision)
   test $beta_revision -ge $edge_revision


### PR DESCRIPTION
Make channel parameters options instead of positional arguments and display what was done at the end (which also gets rid of an upload artifact left over from the last progress message).