### PR TITLE
requirements: update craft-parts to 1.19.3

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,7 +9,7 @@ click==8.1.3
 colorama==0.4.6
 coverage==7.2.3
 craft-cli==1.2.0
-craft-parts==1.19.2
+craft-parts==1.19.3
 craft-providers==1.11.0
 craft-store==2.4.0
 cryptography==40.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ certifi==2022.12.7
 cffi==1.15.1
 charset-normalizer==3.1.0
 craft-cli==1.2.0
-craft-parts==1.19.2
+craft-parts==1.19.3
 craft-providers==1.11.0
 craft-store==2.4.0
 cryptography==40.0.2


### PR DESCRIPTION
Craft Parts 1.19.3 fixes plugin properties state during the
planning phase.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>