### PR TITLE
config: support use actions in charmcraft.yaml

### DIFF
--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -33,6 +33,7 @@ import charmcraft.parts
 import charmcraft.providers
 import charmcraft.instrum
 from charmcraft.metafiles.metadata import parse_metadata_yaml
+from charmcraft.metafiles.actions import create_actions
 from charmcraft.metafiles.manifest import create_manifest
 from charmcraft.const import BUILD_DIRNAME, CHARM_FILES, CHARM_OPTIONAL, VENV_DIRNAME
 from charmcraft.commands.store.charmlibs import collect_charmlib_pydeps
@@ -173,6 +174,7 @@ class Builder:
         linting_results = charmcraft.linters.analyze(self.config, lifecycle.prime_dir)
         self.show_linting_results(linting_results)
 
+        create_actions(lifecycle.prime_dir, self.config.actions)
         create_manifest(
             lifecycle.prime_dir,
             self.config.project.started_at,

--- a/charmcraft/commands/pack.py
+++ b/charmcraft/commands/pack.py
@@ -31,6 +31,7 @@ from charmcraft import env, parts, instrum
 from charmcraft.cmdbase import BaseCommand
 from charmcraft.commands import build
 from charmcraft.errors import DuplicateCharmsError
+from charmcraft.metafiles.actions import create_actions
 from charmcraft.metafiles.manifest import create_manifest
 from charmcraft.parts import Step
 from charmcraft.utils import (
@@ -309,6 +310,7 @@ class PackCommand(BaseCommand):
             raise
 
         # pack everything
+        create_actions(lifecycle.prime_dir, self.config.actions)
         create_manifest(lifecycle.prime_dir, project.started_at, None, [])
         zipname = project.dirpath / (bundle_name + ".zip")
         if overwrite_bundle:

--- a/charmcraft/commands/store/__init__.py
+++ b/charmcraft/commands/store/__init__.py
@@ -999,8 +999,10 @@ class PromoteBundleCommand(BaseCommand):
                 emit.debug(f"Error when running PRIME step: {error}")
                 raise
 
+            from charmcraft.metafiles.actions import create_actions
             from charmcraft.metafiles.manifest import create_manifest
 
+            create_actions(lifecycle.prime_dir, self.config.actions)
             create_manifest(lifecycle.prime_dir, self.config.project.started_at, None, [])
             zipname = bundle_dir_path / (bundle_name + ".zip")
             build_zip(zipname, lifecycle.prime_dir)

--- a/charmcraft/config.py
+++ b/charmcraft/config.py
@@ -45,6 +45,10 @@ analysis:
     attributes: [list of attribute names to ignore]
     linting: [list of linter names to ignore]
 
+actions:
+  my-action:
+    description: Action as defined at https://juju.is/docs/sdk/actions
+
 
 Object Definitions
 ==================

--- a/charmcraft/metafiles/__init__.py
+++ b/charmcraft/metafiles/__init__.py
@@ -16,4 +16,4 @@
 
 """Submodule for handling the all extra yaml files."""
 
-__all__ = ["manifest", "metadata"]
+__all__ = ["actions", "manifest", "metadata"]

--- a/charmcraft/metafiles/actions.py
+++ b/charmcraft/metafiles/actions.py
@@ -1,0 +1,44 @@
+# Copyright 2023 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For further info, check https://github.com/canonical/charmcraft
+
+"""Charmcraft project handle actions.yaml file."""
+
+import pathlib
+import logging
+from typing import Any, Dict, Optional
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+
+def create_actions(
+    basedir: pathlib.Path,
+    actions: Optional[Dict[str, Any]] = None,
+) -> Optional[pathlib.Path]:
+    """Create actions.yaml in basedir for given project configuration.
+
+    :param basedir: Directory to create Charm in.
+    :param actions: Relevant bases configuration, if any.
+
+    :returns: Path to created actions.yaml.
+    """
+    if actions is None:
+        return None
+
+    filepath = basedir / "actions.yaml"
+    filepath.write_text(yaml.dump(actions))
+    return filepath

--- a/tests/spread/smoketests/metafiles/actions/task.yaml
+++ b/tests/spread/smoketests/metafiles/actions/task.yaml
@@ -1,0 +1,50 @@
+summary: create a charm that use actions in charmcraft.yaml
+
+include: 
+  - tests/
+
+prepare: |
+  tests.pkgs install unzip
+  charmcraft init --project-dir=charm
+  cat <<- EOF >> charmcraft.yaml
+  actions:
+    pause:
+      description: Pause the database.
+    resume:
+      description: Resume a paused database.
+    snapshot:
+      description: Take a snapshot of the database.
+      params:
+        filename:
+          type: string
+          description: The name of the snapshot file.
+        compression:
+          type: object
+          description: The type of compression to use.
+          properties:
+            kind:
+              type: string
+              enum: [gzip, bzip2, xz]
+            quality:
+              description: Compression quality
+              type: integer
+              minimum: 0
+              maximum: 9
+      required: [filename]
+      additionalProperties: false
+  EOF
+
+restore: |
+  pushd charm
+  charmcraft clean
+  popd
+  
+  rm -rf charm
+
+execute: |
+  cd charm
+  charmcraft pack --verbose
+  test -f charm*.charm
+  unzip -l charm*.charm | grep "actions.yaml"
+  unzip -p actions.yaml charm*.charm | grep "Compression quality"
+  test ! -d build

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1,0 +1,62 @@
+# Copyright 2023 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For further info, check https://github.com/canonical/charmcraft
+
+import os
+
+import yaml
+
+from charmcraft.metafiles.actions import create_actions
+
+
+def test_create_actions_yaml(tmp_path):
+    """create actions.yaml."""
+    actions = {
+        "pause": {"description": "Pause the database."},
+        "resume": {"description": "Resume a paused database."},
+        "snapshot": {
+            "description": "Take a snapshot of the database.",
+            "params": {
+                "filename": {"type": "string", "description": "The name of the snapshot file."},
+                "compression": {
+                    "type": "object",
+                    "description": "The type of compression to use.",
+                    "properties": {
+                        "kind": {"type": "string", "enum": ["gzip", "bzip2", "xz"]},
+                        "quality": {
+                            "description": "Compression quality",
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 9,
+                        },
+                    },
+                },
+            },
+            "required": ["filename"],
+            "additionalProperties": False,
+        },
+    }
+
+    actions_file = create_actions(tmp_path, actions)
+
+    assert yaml.safe_load(actions_file.read_text()) == actions
+
+
+def test_create_actions_yaml_none(tmp_path):
+    """create actions.yaml with None, the file should not exist."""
+    actions_file = create_actions(tmp_path, None)
+
+    assert actions_file is None
+    assert not os.path.exists(tmp_path / "actions.yaml")


### PR DESCRIPTION
This allow we define actions in the same file rather than separated actions.yaml.

This also included some refactor to avoid circular imports.

CRAFT-1746