### PR TITLE
bases: allow builds with ubuntu non-lts

### DIFF
--- a/charmcraft/commands/build.py
+++ b/charmcraft/commands/build.py
@@ -35,7 +35,13 @@ import charmcraft.instrum
 from charmcraft.metafiles.metadata import parse_metadata_yaml
 from charmcraft.metafiles.actions import create_actions
 from charmcraft.metafiles.manifest import create_manifest
-from charmcraft.const import BUILD_DIRNAME, CHARM_FILES, CHARM_OPTIONAL, VENV_DIRNAME
+from charmcraft.const import (
+    BUILD_DIRNAME,
+    CHARM_FILES,
+    CHARM_OPTIONAL,
+    VENV_DIRNAME,
+    UBUNTU_LTS_STABLE,
+)
 from charmcraft.commands.store.charmlibs import collect_charmlib_pydeps
 from charmcraft.models.config import Base, BasesConfiguration
 from charmcraft.parts import Step
@@ -341,13 +347,20 @@ class Builder:
             instance_name=instance_name,
         )
 
-        if build_on.name != "ubuntu":
+        if build_on.name == "ubuntu":
+            if build_on.channel in UBUNTU_LTS_STABLE:
+                allow_unstable = False
+            else:
+                allow_unstable = True
+                emit.message(
+                    f"Warning: non-LTS Ubuntu releases {build_on.channel} are "
+                    "intended for experimental use only."
+                )
+        else:
             allow_unstable = True
             emit.message(
                 f"Warning: Base {build_on.name} {build_on.channel} daily image may be unstable."
             )
-        else:
-            allow_unstable = False
 
         with self.provider.launched_environment(
             project_name=self.metadata.name,

--- a/charmcraft/const.py
+++ b/charmcraft/const.py
@@ -65,3 +65,9 @@ CHARM_OPTIONAL = [
     "README.md",
     "actions",
 ]
+
+UBUNTU_LTS_STABLE = {
+    "18.04",
+    "20.04",
+    "22.04",
+}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,7 +10,7 @@ colorama==0.4.6
 coverage==7.2.3
 craft-cli==1.2.0
 craft-parts==1.20.0
-craft-providers==1.12.0
+craft-providers==1.14.0
 craft-store==2.4.0
 cryptography==41.0.0
 Deprecated==1.2.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ cffi==1.15.1
 charset-normalizer==3.1.0
 craft-cli==1.2.0
 craft-parts==1.20.0
-craft-providers==1.12.0
+craft-providers==1.14.0
 craft-store==2.4.0
 cryptography==41.0.0
 Deprecated==1.2.13

--- a/tests/spread/smoketests/basic-non-lts/task.yaml
+++ b/tests/spread/smoketests/basic-non-lts/task.yaml
@@ -1,0 +1,23 @@
+summary: pack a simple init-created charm that use non-LTS ubuntu
+
+include: 
+  - tests/
+
+prepare: |
+  tests.pkgs install unzip
+  charmcraft init --project-dir=charm
+  sed -i 's/channel:.*$/channel: "23.04"/g' charm/charmcraft.yaml
+
+restore: |
+  pushd charm
+  charmcraft clean
+  popd
+  
+  rm -rf charm
+
+execute: |
+  cd charm
+  charmcraft pack --verbose
+  test -f charm*.charm
+  unzip -l charm*.charm | grep "venv/ops/charm.py"
+  test ! -d build


### PR DESCRIPTION
Allow user create charms with non-LTS Ubuntu versions.
User will get warning when building on those versions.

CRAFT-1759