### PR TITLE
ci: temporarily disable externally broken spread tests

### DIFF
--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -32,7 +32,7 @@ jobs:
       matrix:
         spread:
           - "google:"
-          - "google:ubuntu-22.04-64:tests/spread/charms/k8s-operator:prometheus"
+#          - "google:ubuntu-22.04-64:tests/spread/charms/k8s-operator:prometheus"
 
     steps:
       - name: Cleanup job workspace

--- a/tests/spread/charms/bundle/task.yaml
+++ b/tests/spread/charms/bundle/task.yaml
@@ -1,4 +1,4 @@
-#summary: Recursively pack a bundle with all charms on
+summary: Recursively pack a bundle with all charms
 #systems:
 #  - ubuntu-22.04-64
 #kill-timeout: 30m

--- a/tests/spread/charms/bundle/task.yaml
+++ b/tests/spread/charms/bundle/task.yaml
@@ -1,36 +1,36 @@
-summary: Recursively pack a bundle with all charms on
-systems:
-  - ubuntu-22.04-64
-kill-timeout: 30m
-
-environment:
-  BUNDLE/notebook_operators: https://github.com/canonical/notebook-operators
-
-prepare: |
-  git clone --depth=1 "${BUNDLE}" bundle
-
-restore: |
-  pushd bundle/charms/jupyter-controller
-  charmcraft clean
-  popd
-  pushd bundle/charms/jupyter-ui
-  charmcraft clean
-  popd
-
-  rm -rf bundle
-
-execute: |
-  cd bundle
-  charmcraft pack --verbose --include-all-charms --output-bundle=output_bundle.yaml
-
-  # Ensure that the output bundle.yaml file is the same as the bundle.yaml file
-  # within the bundle itself.
-  unzip -p *.zip bundle.yaml | diff -s output_bundle.yaml -
-  # Ensure at least one charm file is referenced in the bundle.yaml
-  test $(grep "charm: ${PWD}" output_bundle.yaml | wc -l) -ge 1
-  # Ensure all local charms referenced in the bundle exist
-  grep "charm: ${PWD}" output_bundle.yaml | cut -d: -f2 | xargs file -E
-
-  # Test deploying the bundle.
-  # TODO: install juju on the runner and re-enable this.
-  # juju deploy --dry-run *.zip
+#summary: Recursively pack a bundle with all charms on
+#systems:
+#  - ubuntu-22.04-64
+#kill-timeout: 30m
+#
+#environment:
+#  BUNDLE/notebook_operators: https://github.com/canonical/notebook-operators
+#
+#prepare: |
+#  git clone --depth=1 "${BUNDLE}" bundle
+#
+#restore: |
+#  pushd bundle/charms/jupyter-controller
+#  charmcraft clean
+#  popd
+#  pushd bundle/charms/jupyter-ui
+#  charmcraft clean
+#  popd
+#
+#  rm -rf bundle
+#
+#execute: |
+#  cd bundle
+#  charmcraft pack --verbose --include-all-charms --output-bundle=output_bundle.yaml
+#
+#  # Ensure that the output bundle.yaml file is the same as the bundle.yaml file
+#  # within the bundle itself.
+#  unzip -p *.zip bundle.yaml | diff -s output_bundle.yaml -
+#  # Ensure at least one charm file is referenced in the bundle.yaml
+#  test $(grep "charm: ${PWD}" output_bundle.yaml | wc -l) -ge 1
+#  # Ensure all local charms referenced in the bundle exist
+#  grep "charm: ${PWD}" output_bundle.yaml | cut -d: -f2 | xargs file -E
+#
+#  # Test deploying the bundle.
+#  # TODO: install juju on the runner and re-enable this.
+#  # juju deploy --dry-run *.zip

--- a/tests/spread/charms/k8s-operator/task.yaml
+++ b/tests/spread/charms/k8s-operator/task.yaml
@@ -9,7 +9,7 @@ environment:
   CHARM/grafana: https://github.com/canonical/grafana-k8s-operator
   CHARM/mysql: https://github.com/canonical/mysql-k8s-operator
   CHARM/postgresql: https://github.com/canonical/postgresql-k8s-operator
-  CHARM/prometheus: https://github.com/canonical/prometheus-k8s-operator
+#  CHARM/prometheus: https://github.com/canonical/prometheus-k8s-operator
   CHARM/traefik: https://github.com/canonical/traefik-k8s-operator
   CHARM/mattermost: https://git.launchpad.net/charm-k8s-mattermost
   CHARM/discourse: https://git.launchpad.net/charm-k8s-discourse
@@ -21,7 +21,7 @@ restore: |
   pushd charm
   charmcraft clean
   popd
-  
+
   rm -rf charm
 
 execute: |

--- a/tests/spread/charms/k8s-operator/task.yaml
+++ b/tests/spread/charms/k8s-operator/task.yaml
@@ -9,7 +9,7 @@ environment:
   CHARM/grafana: https://github.com/canonical/grafana-k8s-operator
   CHARM/mysql: https://github.com/canonical/mysql-k8s-operator
   CHARM/postgresql: https://github.com/canonical/postgresql-k8s-operator
-#  CHARM/prometheus: https://github.com/canonical/prometheus-k8s-operator
+  CHARM/prometheus: https://github.com/canonical/prometheus-k8s-operator
   CHARM/traefik: https://github.com/canonical/traefik-k8s-operator
   CHARM/mattermost: https://git.launchpad.net/charm-k8s-mattermost
   CHARM/discourse: https://git.launchpad.net/charm-k8s-discourse


### PR DESCRIPTION
Related to #1193, this should make our CI succeed. We will need to re-enable these tests once the issues with those charms are resolved.