### PR TITLE
models: do not enforce pydantic models on legacy files

### DIFF
--- a/charmcraft/models/actions.py
+++ b/charmcraft/models/actions.py
@@ -34,7 +34,6 @@ class JujuActions(ModelConfigDefaults):
 
     _action_name_regex = re.compile(r"^[a-zA-Z_][a-zA-Z0-9-_]*$")
     actions: Optional[Dict[str, Dict]]
-    legacy: bool = False
 
     @pydantic.validator("actions")
     def validate_actions(cls, actions, values):

--- a/charmcraft/models/config.py
+++ b/charmcraft/models/config.py
@@ -30,7 +30,6 @@ class JujuConfig(ModelConfigDefaults):
     """
 
     options: Optional[Dict[str, Dict]]
-    legacy: bool = False
 
     @pydantic.validator("options", pre=True)
     def validate_actions(cls, options, values):

--- a/charmcraft/models/metadata.py
+++ b/charmcraft/models/metadata.py
@@ -21,7 +21,6 @@ from typing import Any, Dict, Optional, List, Union
 import pydantic
 
 from craft_cli import CraftError
-from charmcraft.format import format_pydantic_errors
 from charmcraft.const import METADATA_FILENAME
 
 
@@ -43,7 +42,7 @@ class CharmMetadataLegacy(
     name: pydantic.StrictStr
     summary: pydantic.StrictStr
     description: pydantic.StrictStr
-    assumes: Optional[List[Union[str, Dict[str, List[str]]]]]
+    assumes: Optional[List[Union[str, Dict[str, Union[List, Dict]]]]]
     containers: Optional[Dict[str, Any]]
     devices: Optional[Dict[str, Any]]
     display_name: Optional[pydantic.StrictStr]
@@ -79,10 +78,7 @@ class CharmMetadataLegacy(
             obj["maintainers"] = [obj["maintainer"]]
             del obj["maintainer"]
 
-        try:
-            return cls.parse_obj(obj)
-        except pydantic.error_wrappers.ValidationError as error:
-            raise CraftError(format_pydantic_errors(error.errors(), file_name=METADATA_FILENAME))
+        return cls.parse_obj(obj)
 
 
 class BundleMetadataLegacy(
@@ -110,7 +106,4 @@ class BundleMetadataLegacy(
 
         :raises CraftError: On failure to unmarshal object.
         """
-        try:
-            return cls.parse_obj(obj)
-        except pydantic.error_wrappers.ValidationError as error:
-            raise CraftError(format_pydantic_errors(error.errors(), file_name=METADATA_FILENAME))
+        return cls.parse_obj(obj)

--- a/tests/spread/smoketests/metafiles-bad-yaml-unenforced/task.yaml
+++ b/tests/spread/smoketests/metafiles-bad-yaml-unenforced/task.yaml
@@ -1,0 +1,98 @@
+summary: >
+  create a charm that use charmcraft.yaml, but bad
+  metadata.yaml, config.yaml, actions.yaml
+
+include: 
+  - tests/
+
+prepare: |
+  tests.pkgs install unzip
+  charmcraft init --project-dir=charm
+  rm -f charm/metadata.yaml
+  rm -f charm/config.yaml
+
+  cat <<- EOF > charm/charmcraft.yaml
+  type: charm
+
+  bases:
+    - build-on:
+      - name: ubuntu
+        channel: "22.04"
+      run-on:
+      - name: ubuntu
+        channel: "22.04"
+
+  EOF
+
+  cat <<- EOF > charm/metadata.yaml
+  name: charmcraft-test
+  summary: test-summary
+  description: test-description
+
+  title: test-title
+
+  links:
+    issues: https://example.com/issues
+    contact:
+      - https://example.com/contact
+      - contact@example.com
+      - "IRC #example"
+    documentation: https://example.com/docs
+    source:
+      - https://example.com/source
+      - https://example.com/source2
+      - https://example.com/source3
+    website:
+      - https://example.com/
+
+  meow: meow
+
+  #### TEST-COPY ####
+  EOF
+
+  cat <<- EOF > charm/actions.yaml
+  pause
+  #### TEST-COPY ####
+
+  EOF
+
+  cat <<- EOF > charm/config.yaml
+  options:
+    max-body-size:
+      default: 20
+      description: Max allowed body-size (for file uploads) in megabytes,
+        set to 0 to disable limits.
+      source: default
+      type: int
+      value: 20
+  #### TEST-COPY ####
+
+  EOF
+
+restore: |
+  pushd charm
+  charmcraft clean
+  popd
+  
+  rm -rf charm
+
+execute: |
+  cd charm
+  charmcraft pack --verbose
+  test -f charm*.charm
+
+  unzip -l charm*.charm | MATCH "actions.yaml"
+  unzip -l charm*.charm | MATCH "config.yaml"
+  unzip -l charm*.charm | MATCH "metadata.yaml"
+
+  unzip -p charm*.charm actions.yaml | MATCH "pause"
+  unzip -p charm*.charm actions.yaml | MATCH "#### TEST-COPY ####"
+
+  unzip -p charm*.charm config.yaml | MATCH "max-body-size"
+  unzip -p charm*.charm config.yaml | MATCH "#### TEST-COPY ####"
+
+  unzip -p charm*.charm metadata.yaml | MATCH "meow"
+  unzip -p charm*.charm metadata.yaml | MATCH "#### TEST-COPY ####"
+
+  test ! -d build
+

--- a/tests/spread/smoketests/metafiles-multiple-yaml/task.yaml
+++ b/tests/spread/smoketests/metafiles-multiple-yaml/task.yaml
@@ -18,14 +18,14 @@ prepare: |
     - build-on:
       - name: ubuntu
         channel: "22.04"
-    run-on:
+      run-on:
       - name: ubuntu
         channel: "22.04"
 
   EOF
 
   cat <<- EOF > charm/metadata.yaml
-  name: test-charm-name
+  name: charmcraft-test
   summary: test-summary
   description: test-description
 
@@ -112,14 +112,14 @@ execute: |
   unzip -l charm*.charm | MATCH "config.yaml"
   unzip -l charm*.charm | MATCH "metadata.yaml"
 
-  unzip -p actions.yaml charm*.charm | MATCH "description: The type of compression to use."
-  unzip -p actions.yaml charm*.charm | MATCH "#### TEST-COPY ####"
+  unzip -p charm*.charm actions.yaml | MATCH "description: The type of compression to use."
+  unzip -p charm*.charm actions.yaml | MATCH "#### TEST-COPY ####"
 
-  unzip -p config.yaml charm*.charm | MATCH "description: test-2"
-  unzip -p config.yaml charm*.charm | MATCH "#### TEST-COPY ####"
+  unzip -p charm*.charm config.yaml | MATCH "description: test-2"
+  unzip -p charm*.charm config.yaml | MATCH "#### TEST-COPY ####"
 
-  unzip -p metadata.yaml charm*.charm | MATCH "issues: https://example.com/issues"
-  unzip -p metadata.yaml charm*.charm | MATCH "#### TEST-COPY ####"
+  unzip -p charm*.charm metadata.yaml | MATCH "issues: https://example.com/issues"
+  unzip -p charm*.charm metadata.yaml | MATCH "#### TEST-COPY ####"
 
   test ! -d build
 

--- a/tests/spread/smoketests/metafiles-unified-charmcraft-yaml/task.yaml
+++ b/tests/spread/smoketests/metafiles-unified-charmcraft-yaml/task.yaml
@@ -10,7 +10,7 @@ prepare: |
   rm -f charm/config.yaml
 
   cat <<- EOF > charm/charmcraft.yaml
-  name: test-charm-name
+  name: charmcraft-test
   type: charm
   summary: test-summary
   description: test-description
@@ -19,7 +19,7 @@ prepare: |
     - build-on:
       - name: ubuntu
         channel: "22.04"
-    run-on:
+      run-on:
       - name: ubuntu
         channel: "22.04"
 
@@ -65,20 +65,21 @@ prepare: |
       required: [filename]
       additionalProperties: false
 
-  options:
-    test-int:
-      default: 123
-      description: test-1
-      type: int
-    test-string:
-      description: test-2
-      type: string
-    test-float:
-      default: 1.23
-      type: float
-    test-bool:
-      default: true
-      type: boolean
+  config:
+    options:
+      test-int:
+        default: 123
+        description: test-1
+        type: int
+      test-string:
+        description: test-2
+        type: string
+      test-float:
+        default: 1.23
+        type: float
+      test-bool:
+        default: true
+        type: boolean
 
   EOF
 
@@ -96,7 +97,7 @@ execute: |
   unzip -l charm*.charm | MATCH "actions.yaml"
   unzip -l charm*.charm | MATCH "config.yaml"
   unzip -l charm*.charm | MATCH "metadata.yaml"
-  unzip -p actions.yaml charm*.charm | MATCH "description: The type of compression to use."
-  unzip -p config.yaml charm*.charm | MATCH "description: test-2"
-  unzip -p metadata.yaml charm*.charm | MATCH "issues: https://example.com/issues"
+  unzip -p charm*.charm actions.yaml | MATCH "description: The type of compression to use."
+  unzip -p charm*.charm config.yaml | MATCH "description: test-2"
+  unzip -p charm*.charm metadata.yaml | MATCH "issues: https://example.com/issues"
   test ! -d build

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3312,3 +3312,63 @@ def test_actions_defined_in_charmcraft_yaml_and_actions_yaml(
         Bad charmcraft.yaml content:
         - 'actions.yaml' file not allowed when an 'actions' section is defined in 'charmcraft.yaml' in field 'actions'"""  # NOQA: E501
     )
+
+
+@pytest.mark.parametrize(
+    "charmcraft_yaml, metadata_yaml",
+    [
+        [
+            dedent(
+                """\
+                type: charm
+                bases:
+                  - name: test-name
+                    channel: test-channel
+                """
+            ),
+            dedent(
+                """\
+                name: test-charm-name-from-metadata-yaml
+                summary: test summary
+                description: test description
+                """
+            ),
+        ],
+        [
+            dedent(
+                """\
+                type: charm
+                name: test-charm-name-from-charmcraft-yaml
+                summary: test summary
+                description: test description
+                bases:
+                  - name: test-name
+                    channel: test-channel
+                """
+            ),
+            None,
+        ],
+    ],
+)
+def test_actions_bad_unenforced_defined_in_actions_yaml(
+    tmp_path,
+    create_checker,
+    prepare_charmcraft_yaml,
+    prepare_metadata_yaml,
+    prepare_actions_yaml,
+    charmcraft_yaml,
+    metadata_yaml,
+):
+    """Load a bad actions in actions.yaml. Should not raise an error since check unenforced."""
+    prepare_charmcraft_yaml(charmcraft_yaml)
+    prepare_metadata_yaml(metadata_yaml)
+    prepare_actions_yaml(
+        dedent(
+            """\
+            invalid: 111
+            """
+        )
+    )
+
+    config = load(tmp_path)
+    assert config.actions is None

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -18,6 +18,7 @@ import re
 from textwrap import dedent
 
 import pytest
+import pydantic
 from craft_cli import CraftError
 
 from charmcraft.metafiles.metadata import parse_charm_metadata_yaml, read_metadata_yaml
@@ -85,14 +86,8 @@ def test_parse_metadata_yaml_error_invalid_names(
 ):
     prepare_metadata_yaml(metadata_yaml_template.format(name=name))
 
-    with pytest.raises(CraftError) as cm:
+    with pytest.raises(pydantic.ValidationError):
         parse_charm_metadata_yaml(tmp_path)
-
-    assert str(cm.value) == dedent(
-        """\
-        Bad metadata.yaml content:
-        - string type expected in field 'name'"""
-    )
 
 
 def test_parse_metadata_yaml_error_missing(tmp_path):

--- a/tests/test_metafiles.py
+++ b/tests/test_metafiles.py
@@ -45,6 +45,12 @@ def test_dump_metadata_from_charmcraft_yaml(tmp_path, prepare_charmcraft_yaml):
               - any-of:
                   - extra-feature-1
                   - extra-feature-2
+                  - all-of:
+                    - juju >= 2.9.44
+                    - juju < 3
+                  - all-of:
+                    - juju >= 3.1.6
+                    - juju < 4
               - all-of:
                   - test-feature-1
                   - test-feature-2
@@ -157,7 +163,14 @@ def test_dump_metadata_from_charmcraft_yaml(tmp_path, prepare_charmcraft_yaml):
         "description": "test-description",
         "assumes": [
             "test-feature",
-            {"any-of": ["extra-feature-1", "extra-feature-2"]},
+            {
+                "any-of": [
+                    "extra-feature-1",
+                    "extra-feature-2",
+                    {"all-of": ["juju >= 2.9.44", "juju < 3"]},
+                    {"all-of": ["juju >= 3.1.6", "juju < 4"]},
+                ]
+            },
             {"all-of": ["test-feature-1", "test-feature-2"]},
         ],
         "containers": {
@@ -243,6 +256,12 @@ def test_copy_metadata_from_metadata_yaml(
               - any-of:
                   - extra-feature-1
                   - extra-feature-2
+                  - all-of:
+                    - juju >= 2.9.44
+                    - juju < 3
+                  - all-of:
+                    - juju >= 3.1.6
+                    - juju < 4
               - all-of:
                   - test-feature-1
                   - test-feature-2
@@ -367,7 +386,14 @@ def test_copy_metadata_from_metadata_yaml(
         "description": "test-description",
         "assumes": [
             "test-feature",
-            {"any-of": ["extra-feature-1", "extra-feature-2"]},
+            {
+                "any-of": [
+                    "extra-feature-1",
+                    "extra-feature-2",
+                    {"all-of": ["juju >= 2.9.44", "juju < 3"]},
+                    {"all-of": ["juju >= 3.1.6", "juju < 4"]},
+                ]
+            },
             {"all-of": ["test-feature-1", "test-feature-2"]},
         ],
         "containers": {

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -301,6 +301,39 @@ def test_load_minimal_metadata_from_metadata_yaml_missing_summary(
         load(tmp_path)
 
 
+def test_load_minimal_metadata_from_metadata_yaml_bad_others_allowed(
+    tmp_path, prepare_charmcraft_yaml, prepare_metadata_yaml
+):
+    """Load a mimimal charmcraft.yaml with metadata.yaml. Had bad other fields but allowed."""
+    prepare_charmcraft_yaml(
+        dedent(
+            """
+            type: charm
+
+            bases:
+                - name: test-name
+                  channel: test-channel
+            """
+        ),
+    )
+    prepare_metadata_yaml(
+        dedent(
+            """
+            name: test-charm-name
+            summary: test-summary
+            description: test-description
+
+            peers:
+              - aaa
+              - bbb
+              - ccc
+            """
+        ),
+    )
+
+    load(tmp_path)
+
+
 def test_load_minimal_metadata_from_metadata_yaml_missing_description(
     tmp_path, prepare_charmcraft_yaml, prepare_metadata_yaml
 ):
@@ -1159,6 +1192,31 @@ def test_load_config_in_config_yaml(tmp_path, prepare_charmcraft_yaml, prepare_c
             "test-bool": {"default": True, "type": "boolean"},
         },
     }
+
+
+def test_load_bad_config_in_config_yaml(tmp_path, prepare_charmcraft_yaml, prepare_config_yaml):
+    """Load a bad config in config.yaml. Should not raise an error since check unenforced."""
+    prepare_charmcraft_yaml(
+        dedent(
+            """
+            name: test-charm-name
+            type: charm
+            summary: test-summary
+            description: test-description
+            """
+        ),
+    )
+    prepare_config_yaml(
+        dedent(
+            """
+            options:
+              test-int:
+            """
+        ),
+    )
+    config = load(tmp_path)
+
+    assert config.config is None
 
 
 def test_load_bad_config_in_charmcraft_yaml(tmp_path, prepare_charmcraft_yaml):


### PR DESCRIPTION
Only warning when found invalid file for backward compatible.

Fixes #1208