### PR TITLE
packaging: update apt requirements, remove bionic

### DIFF
--- a/requirements-bionic.txt
+++ b/requirements-bionic.txt
@@ -1,1 +1,0 @@
-http://archive.ubuntu.com/ubuntu/pool/main/p/python-apt/python-apt_1.6.6.tar.xz; sys_platform == 'linux'

--- a/requirements-focal.txt
+++ b/requirements-focal.txt
@@ -1,1 +1,1 @@
-http://archive.ubuntu.com/ubuntu/pool/main/p/python-apt/python-apt_2.0.1ubuntu0.20.04.1.tar.xz; sys_platform == 'linux'
+https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/python-apt/2.0.1ubuntu0.20.04.1/python-apt_2.0.1ubuntu0.20.04.1.tar.xz; sys_platform == 'linux'

--- a/requirements-jammy.txt
+++ b/requirements-jammy.txt
@@ -1,1 +1,1 @@
-http://archive.ubuntu.com/ubuntu/pool/main/p/python-apt/python-apt_2.4.0ubuntu1.tar.xz; sys_platform == 'linux'
+https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/python-apt/2.4.0ubuntu2/python-apt_2.4.0ubuntu2.tar.xz; sys_platform == 'linux'


### PR DESCRIPTION
Bionic has entered ESM, we also no longer support the Python included in 18.04.