### PR TITLE
requirements: bump craft-providers

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,7 +10,7 @@ colorama==0.4.6
 coverage==7.2.7
 craft-cli==2.0.1
 craft-parts==1.23.0
-craft-providers==1.14.1
+craft-providers==1.15.0
 craft-store==2.4.0
 cryptography==41.0.3
 Deprecated==1.2.14

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ cffi==1.15.1
 charset-normalizer==3.2.0
 craft-cli==2.0.1
 craft-parts==1.23.0
-craft-providers==1.14.1
+craft-providers==1.15.0
 craft-store==2.4.0
 cryptography==41.0.3
 Deprecated==1.2.14

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -26,7 +26,7 @@ from datetime import datetime
 from charmcraft import snap
 
 PROJECT_NAME = "charmcraft"
-MINIMAL_BASE_VERISON = "1.0"
+MINIMAL_BASE_VERISON = "2.0"
 
 # We need get image info tuple from regex
 # (craft base metadata version, remote image provider, remote image os, remote image version)

--- a/tests/spread/smoketests/lxd/task.yaml
+++ b/tests/spread/smoketests/lxd/task.yaml
@@ -1,0 +1,58 @@
+summary: pack a init-created charm with lxd
+
+# run last because this test deletes base instances
+priority: -10
+
+prepare: |
+  charmcraft init --project-dir=charm
+  cd charm
+  sed -i "s/22.04/$(echo $SPREAD_SYSTEM | cut -c 8-12)/g" charmcraft.yaml
+
+  # delete charmcraft instances
+  ALL_INSTANCES="$(lxc list --project=charmcraft --format=csv --columns="n")"
+  if [ -n "$ALL_INSTANCES" ]; then
+    for instance in $ALL_INSTANCES; do
+      lxc delete --project=charmcraft --force "$instance"
+    done
+  fi
+
+restore: |
+  pushd charm
+  charmcraft clean
+  popd
+
+  rm -rf charm
+
+execute: |
+  cd charm
+  charmcraft pack --verbose
+  test -f charm*.charm
+
+  # there should be two instances, sorted alphabetically:
+  # - base-instance-charmcraft...
+  # - charmcraft-charm-...
+  INSTANCE="$(lxc --project=charmcraft list --format=csv -c n | tail -n 1)"
+
+  lxc --project charmcraft start "$INSTANCE"
+  REFRESH_HOLD="$(lxc --project charmcraft exec "$INSTANCE" -- snap get system refresh.hold)"
+
+  # assert snap refreshes are held
+  if [[ "$REFRESH_HOLD" != "forever" ]]; then
+    echo "snap refresh not set as expected"
+    exit 1
+  fi
+
+  charmcraft clean
+  ALL_INSTANCES="$(lxc --project=charmcraft list --format=csv -c n)"
+
+  # confirm only one instance remains
+  if [[ $(echo "$ALL_INSTANCES" | wc -l) != 1 ]]; then
+    echo "wrong number of lxd instances"
+    exit 1
+  fi
+
+  # confirm the remaining instance is the base instance
+  if ! grep -q "^base-instance-charmcraft" <<< "$ALL_INSTANCES"; then
+    echo "could not find base instance"
+    exit 1
+  fi


### PR DESCRIPTION
## Changelog

### 1.15.0 (2023-08-21)

- Update base compatibility tag from `base-v1` to `base-v2`
- Use `snap refresh --hold` inside instances
- Re-level log messages
- Add more info-level log messages
- Update links from linuxcontainers.org to ubuntu.com
- Set timezone of LXD instances to match host's timezone
- Add name and install recommendations to Providers


Resolves #1202 
(CRAFT-1953)