### PR TITLE
templates: remove k8s info from machine charm template

### DIFF
--- a/charmcraft/templates/init-machine/charmcraft.yaml.j2
+++ b/charmcraft/templates/init-machine/charmcraft.yaml.j2
@@ -36,24 +36,3 @@ bases:
     run-on:
     - name: ubuntu
       channel: "22.04"
-
-# The containers and resources metadata apply to Kubernetes charms only.
-# See https://juju.is/docs/sdk/metadata-reference for a checklist and guidance.
-
-# Your workload’s containers.
-containers:
-  some-container:
-    resource: some-container-image
-
-
-# This field populates the Resources tab on Charmhub.
-resources:
-  # An OCI image resource for each container listed above.
-  # You may remove this if your charm will run without a workload sidecar container.
-  some-container-image:
-    type: oci-image
-    description: OCI image for the 'some-container' container
-    # The upstream-source field is ignored by Juju. It is included here as a reference
-    # so the integration testing suite knows which image to deploy during testing. This field
-    # is also used by the 'canonical/charming-actions' Github action for automated releasing.
-    upstream-source: some-repo/some-image:some-tag


### PR DESCRIPTION
This change should make the `charm-upload-and-release` store task pass.

Progress on #1193 