### PR TITLE
Revert "chore(deps): update dependency ubuntu to v22 (#1222)"

### DIFF
--- a/.github/workflows/cla-check.yaml
+++ b/.github/workflows/cla-check.yaml
@@ -3,7 +3,7 @@ on: [pull_request]
 
 jobs:
   cla-check:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Check if CLA signed
         uses: canonical/has-signed-canonical-cla@v1

--- a/.github/workflows/spread-large.yaml
+++ b/.github/workflows/spread-large.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   snap-build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   snap-build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -87,7 +87,7 @@ jobs:
           pytest -ra tests
 
   snap-build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
This reverts commit 09f1b19f1261889c3ca365c1a8c8c5d4486a8e4a.

The builds were working on the branch, but main seems to be having issues with lxd now