### PR TITLE
ci: reduce the python/OS matrix size

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -44,8 +44,13 @@ jobs:
   run-tests:
     strategy:
       matrix:
-        os: [macos-11, macos-12, ubuntu-20.04, ubuntu-22.04, windows-2019, windows-2022]
-        python-version: [3.8, 3.9, "3.10"]
+        os: [macos-11, macos-12, windows-2019, windows-2022]
+        python-version: [3.8, "3.10", "3.11"]
+        include:
+          - os: ubuntu-20.04
+            python-version: "3.8"
+          - os: ubuntu-22.04
+            python-version: "3.10"
 
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
This will also need adjustments to our required checks.

* Remove Python 3.9 tests (no longer widely used in any of our use cases)
* Use only built-in Python versions on Ubuntu releases (but ready to add 3.12 for 24.04)
* Add 3.11 (current latest) on Windows/mac