### PR TITLE
ci: enable codespell

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -39,8 +39,9 @@ jobs:
           echo "::endgroup::"
       - name: Run Linters
         # Currently picking specific linters that pass until we can enable them all.
+        # Still missing: mypy, pyright, yamllint
         # run: tox run --skip-pkg-install --no-list-dependencies -m lint
-        run: tox run --skip-pkg-install --no-list-dependencies -e lint-black,lint-ruff,lint-shellcheck
+        run: tox run --skip-pkg-install --no-list-dependencies -e lint-black,lint-ruff,lint-shellcheck,lint-codespell
   run-tests:
     strategy:
       matrix:

--- a/charmcraft/cmdbase.py
+++ b/charmcraft/cmdbase.py
@@ -52,13 +52,13 @@ class BaseCommand(craft_cli.BaseCommand):
         )
 
     def _check_config(self, config_file: bool = False, bases: bool = False) -> None:
-        """Check if vaild config contents exists.
+        """Check if valid config contents exists.
 
         - config_file: if True, check if a valid "charmcraft.yaml" file exists.
         - bases: if True, check if a valid "bases" in "charmcraft.yaml" exists.
 
         :raises ArgumentParsingError: if 'charmcraft.yaml' file is missing.
-        :raises CraftError: if any specified config are missing or invaild.
+        :raises CraftError: if any specified config are missing or invalid.
         """
         if config_file and not self.config.project.config_provided:
             raise ArgumentParsingError(

--- a/charmcraft/commands/store/__init__.py
+++ b/charmcraft/commands/store/__init__.py
@@ -1119,7 +1119,7 @@ class StatusCommand(BaseCommand):
             by_channel = by_base.setdefault(item.base, {})
             by_channel[item.channel] = item
 
-        # groupe revision objects by revision number
+        # group revision objects by revision number
         revisions_by_revno = {item.revision: item for item in revisions}
 
         # process and order the channels, while preserving the tracks order

--- a/charmcraft/models/charmcraft.py
+++ b/charmcraft/models/charmcraft.py
@@ -302,7 +302,7 @@ class CharmcraftConfig(
 
             obj = apply_extensions(project.dirpath, obj)
 
-            # Re-expand it in case extenstions added short-form bases.
+            # Re-expand it in case extensions added short-form bases.
             if isinstance(obj.get("bases"), list):
                 cls.expand_short_form_bases(obj["bases"])
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ line-length = 99
 
 [tool.codespell]
 ignore-words-list = "buildd,crate,keyserver,comandos,ro,dedent,dedented"
-skip = ".tox,.git,build,.*_cache,__pycache__,*.tar,*.snap,*.png,./node_modules,./docs/_build,.direnv,.venv,venv,.vscode"
+skip = ".tox,.git,build,.*_cache,__pycache__,*.tar,*.snap,*.png,./node_modules,./docs/_build,.direnv,.venv,venv,.vscode,charmcraft.spec"
 quiet-level = 3
 check-filenames = true
 

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -156,7 +156,7 @@ def configure_hook_main():
         elif any(re.fullmatch(obsolete, instance["name"]) for obsolete in OBSOLETE_VERSIONS):
             _delete_lxd_instance(instance)
 
-        # Do nothing if not match any known pattens
+        # Do nothing if not match any known patterns
 
 
 if __name__ == "__main__":

--- a/tests/commands/test_store_charmlibs.py
+++ b/tests/commands/test_store_charmlibs.py
@@ -266,7 +266,7 @@ def test_getlibinternals_success_simple(tmp_path, monkeypatch):
 
 
 def test_getlibinternals_success_with_pydeps(tmp_path, monkeypatch):
-    """Simple basic succesful case that includes pydeps."""
+    """Simple basic successful case that includes pydeps."""
     monkeypatch.chdir(tmp_path)
     test_path = _create_lib(pydeps="PYDEPS = ['foo', 'bar']")
     internals = get_lib_internals(test_path)

--- a/tests/commands/test_store_registry.py
+++ b/tests/commands/test_store_registry.py
@@ -249,7 +249,7 @@ def test_hit_simple_re_auth_ok(responses):
     responses.add(responses.GET, "https://fakereg.com/api/stuff", headers=headers, status=401)
     responses.add(responses.GET, "https://fakereg.com/api/stuff")
 
-    # try it, isolating the re-authentication (tested separatedly above)
+    # try it, isolating the re-authentication (tested separately above)
     with patch.object(ocireg, "_authenticate") as mock_auth:
         mock_auth.return_value = "new auth token"
         response = ocireg._hit("GET", "https://fakereg.com/api/stuff")
@@ -278,7 +278,7 @@ def test_hit_simple_re_auth_problems(responses):
     headers = {"Www-Authenticate": "broken header"}
     responses.add(responses.GET, "https://fakereg.com/api/stuff", headers=headers, status=401)
 
-    # try it, isolating the re-authentication (tested separatedly above)
+    # try it, isolating the re-authentication (tested separately above)
     expected = (
         "Bad 401 response: Bearer not found; headers: {.*'Www-Authenticate': 'broken header'.*}"
     )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1316,7 +1316,7 @@ def test_schema_other_bundle_part_no_source(
 
 
 # -- tests to check the double layer schema loading; using the 'charm' plugin
-#    because it is the default (and has good default properties to be overriden and )
+#    because it is the default (and has good default properties to be overridden and )
 #    the 'dump' one because it's a special case of no having a model
 
 
@@ -1718,7 +1718,7 @@ def test_schema_doublelayer_parts_with_charm_plugin_different(
 def test_schema_doublelayer_parts_with_charm_overriding_properties(
     tmp_path, prepare_charmcraft_yaml, prepare_metadata_yaml, charmcraft_yaml, metadata_yaml
 ):
-    """A charm plugin is used and its default properties are overriden."""
+    """A charm plugin is used and its default properties are overridden."""
     prepare_charmcraft_yaml(charmcraft_yaml)
     prepare_metadata_yaml(metadata_yaml)
 
@@ -1747,7 +1747,7 @@ def test_schema_doublelayer_parts_with_charm_overriding_properties(
                     channel: "30.04"
                 parts:
                   charm:
-                    charm-point: different.py  # mispelled!
+                    charm-point: different.py  # misspelled!
                 """
             ),
             dedent(
@@ -1770,7 +1770,7 @@ def test_schema_doublelayer_parts_with_charm_overriding_properties(
                     channel: "30.04"
                 parts:
                   charm:
-                    charm-point: different.py  # mispelled!
+                    charm-point: different.py  # misspelled!
                 """
             ),
             None,

--- a/tests/test_infra.py
+++ b/tests/test_infra.py
@@ -52,7 +52,7 @@ def pep8_test(python_filepaths):
     with patch("sys.stdout", fake_stdout):
         report = style_guide.check_files(python_filepaths)
 
-    # if flake8 didnt' report anything, we're done
+    # if flake8 didn't report anything, we're done
     if report.total_errors == 0:
         return
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -762,7 +762,7 @@ def test_aesthetic_args_options_msg(command, config):
 
 @pytest.mark.parametrize("command_class", all_commands)
 def test_usage_of_parsed_args(command_class, config):
-    """The elements accesed on parsed_args need to be added before.
+    """The elements accessed on parsed_args need to be added before.
 
     This test is useful because normally all the tests for any command fake the
     Namespace and it happened in the past that we added functionality in the command

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -124,6 +124,6 @@ def test_read_metadata_yaml_error_invalid(tmp_path):
 
 
 def test_read_metadata_yaml_error_missing(tmp_path):
-    """Do not hide the file not being accesible."""
+    """Do not hide the file not being accessible."""
     with pytest.raises(OSError):
         read_metadata_yaml(tmp_path)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -32,7 +32,7 @@ from charmcraft.utils import get_host_architecture
 
 
 def test_load_minimal_metadata_from_charmcraft_yaml(tmp_path, prepare_charmcraft_yaml):
-    """Load a mimimal charmcraft.yaml with full metadata. (Spec ST087)"""
+    """Load a minimal charmcraft.yaml with full metadata. (Spec ST087)"""
     prepare_charmcraft_yaml(
         dedent(
             """
@@ -80,7 +80,7 @@ def test_load_minimal_metadata_from_charmcraft_yaml(tmp_path, prepare_charmcraft
 def test_load_minimal_metadata_from_charmcraft_yaml_missing_name(
     tmp_path, prepare_charmcraft_yaml
 ):
-    """Load a mimimal charmcraft.yaml with metadata. But missing name."""
+    """Load a minimal charmcraft.yaml with metadata. But missing name."""
     prepare_charmcraft_yaml(
         dedent(
             """
@@ -102,7 +102,7 @@ def test_load_minimal_metadata_from_charmcraft_yaml_missing_name(
 def test_load_minimal_metadata_from_charmcraft_yaml_missing_type(
     tmp_path, prepare_charmcraft_yaml
 ):
-    """Load a mimimal charmcraft.yaml with metadata. But missing type."""
+    """Load a minimal charmcraft.yaml with metadata. But missing type."""
     prepare_charmcraft_yaml(
         dedent(
             """
@@ -124,7 +124,7 @@ def test_load_minimal_metadata_from_charmcraft_yaml_missing_type(
 def test_load_minimal_metadata_from_charmcraft_yaml_missing_summary(
     tmp_path, prepare_charmcraft_yaml
 ):
-    """Load a mimimal charmcraft.yaml with metadata. But missing summary."""
+    """Load a minimal charmcraft.yaml with metadata. But missing summary."""
     prepare_charmcraft_yaml(
         dedent(
             """
@@ -146,7 +146,7 @@ def test_load_minimal_metadata_from_charmcraft_yaml_missing_summary(
 def test_load_minimal_metadata_from_charmcraft_yaml_missing_description(
     tmp_path, prepare_charmcraft_yaml
 ):
-    """Load a mimimal charmcraft.yaml with metadata. But missing description."""
+    """Load a minimal charmcraft.yaml with metadata. But missing description."""
     prepare_charmcraft_yaml(
         dedent(
             """
@@ -168,7 +168,7 @@ def test_load_minimal_metadata_from_charmcraft_yaml_missing_description(
 def test_load_minimal_metadata_from_metadata_yaml(
     tmp_path, prepare_charmcraft_yaml, prepare_metadata_yaml
 ):
-    """Load a mimimal charmcraft.yaml with full metadata. (Spec ST087)"""
+    """Load a minimal charmcraft.yaml with full metadata. (Spec ST087)"""
     prepare_charmcraft_yaml(
         dedent(
             """
@@ -222,7 +222,7 @@ def test_load_minimal_metadata_from_metadata_yaml(
 def test_load_minimal_metadata_from_metadata_yaml_missing_name(
     tmp_path, prepare_charmcraft_yaml, prepare_metadata_yaml
 ):
-    """Load a mimimal charmcraft.yaml with metadata.yaml. But missing name."""
+    """Load a minimal charmcraft.yaml with metadata.yaml. But missing name."""
     prepare_charmcraft_yaml(
         dedent(
             """
@@ -249,7 +249,7 @@ def test_load_minimal_metadata_from_metadata_yaml_missing_name(
 def test_load_minimal_metadata_from_metadata_yaml_missing_type(
     tmp_path, prepare_charmcraft_yaml, prepare_metadata_yaml
 ):
-    """Load a mimimal charmcraft.yaml with metadata.yaml. But missing type."""
+    """Load a minimal charmcraft.yaml with metadata.yaml. But missing type."""
     prepare_charmcraft_yaml(
         dedent(
             """
@@ -276,7 +276,7 @@ def test_load_minimal_metadata_from_metadata_yaml_missing_type(
 def test_load_minimal_metadata_from_metadata_yaml_missing_summary(
     tmp_path, prepare_charmcraft_yaml, prepare_metadata_yaml
 ):
-    """Load a mimimal charmcraft.yaml with metadata.yaml. But missing summary."""
+    """Load a minimal charmcraft.yaml with metadata.yaml. But missing summary."""
     prepare_charmcraft_yaml(
         dedent(
             """
@@ -304,7 +304,7 @@ def test_load_minimal_metadata_from_metadata_yaml_missing_summary(
 def test_load_minimal_metadata_from_metadata_yaml_bad_others_allowed(
     tmp_path, prepare_charmcraft_yaml, prepare_metadata_yaml
 ):
-    """Load a mimimal charmcraft.yaml with metadata.yaml. Had bad other fields but allowed."""
+    """Load a minimal charmcraft.yaml with metadata.yaml. Had bad other fields but allowed."""
     prepare_charmcraft_yaml(
         dedent(
             """
@@ -337,7 +337,7 @@ def test_load_minimal_metadata_from_metadata_yaml_bad_others_allowed(
 def test_load_minimal_metadata_from_metadata_yaml_missing_description(
     tmp_path, prepare_charmcraft_yaml, prepare_metadata_yaml
 ):
-    """Load a mimimal charmcraft.yaml with metadata.yaml. But missing description."""
+    """Load a minimal charmcraft.yaml with metadata.yaml. But missing description."""
     prepare_charmcraft_yaml(
         dedent(
             """

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1160,7 +1160,7 @@ def test_build_arguments_managed_charmcraft_measure(
     bases_config = [BasesConfiguration(**{"build-on": [host_base], "run-on": [host_base]})]
     project_managed_path = pathlib.Path("/root/project")
 
-    # fake a dumped mesure to be pulled from the instance
+    # fake a dumped measure to be pulled from the instance
     fake_local_m = tmp_path / "local.json"
     instrum._Measurements().dump(fake_local_m)
 


### PR DESCRIPTION
This is broken into two commits, first fixing spelling and then enabling codespell.