### PR TITLE
refactor(linters): make CheckType an enum

### DIFF
--- a/charmcraft/commands/analyze.py
+++ b/charmcraft/commands/analyze.py
@@ -101,8 +101,8 @@ class AnalyzeCommand(BaseCommand):
         # group by attributes and lint outcomes (discarding ignored ones)
         grouped = {}
         for result in linting_results:
-            if result.check_type == linters.CheckType.attribute:
-                group_key = linters.CheckType.attribute
+            if result.check_type == linters.CheckType.ATTRIBUTE:
+                group_key = linters.CheckType.ATTRIBUTE
                 result_info = result.result
             else:
                 # linters
@@ -117,7 +117,7 @@ class AnalyzeCommand(BaseCommand):
 
         # present the results
         titles = [
-            ("Attributes", linters.CheckType.attribute),
+            ("Attributes", linters.CheckType.ATTRIBUTE),
             ("Lint Ignored", linters.IGNORED),
             ("Lint Warnings", linters.WARNINGS),
             ("Lint Errors", linters.ERRORS),

--- a/charmcraft/linters.py
+++ b/charmcraft/linters.py
@@ -17,6 +17,7 @@
 """Analyze and lint charm structures and files."""
 
 import ast
+import enum
 import os
 import pathlib
 import shlex
@@ -28,7 +29,16 @@ import yaml
 from charmcraft import config, utils
 from charmcraft.metafiles.metadata import parse_charm_metadata_yaml, read_metadata_yaml
 
-CheckType = namedtuple("CheckType", "attribute lint")(attribute="attribute", lint="lint")
+
+class CheckType(str, enum.Enum):
+    """Type of analyzer, either attribute check or linter.
+
+    More documentation: https://juju.is/docs/sdk/charmcraft-analyzers-and-linters
+    """
+
+    ATTRIBUTE = "attribute"
+    LINT = "lint"
+
 
 # result information from each checker/linter
 CheckResult = namedtuple("CheckResult", "name result url check_type text")
@@ -90,7 +100,7 @@ class Language:
     - the entry point file is executable
     """
 
-    check_type = CheckType.attribute
+    check_type = CheckType.ATTRIBUTE
     name = "language"
     url = BASE_DOCS_URL + "#heading--language"
     text = "The charm is written with Python."
@@ -120,7 +130,7 @@ class Framework:
     - has a file name that starts with "charms.reactive-" inside the "wheelhouse" directory
     """
 
-    check_type = CheckType.attribute
+    check_type = CheckType.ATTRIBUTE
     name = "framework"
     url = BASE_DOCS_URL + "#heading--framework"
 
@@ -224,7 +234,7 @@ class JujuMetadata:
     - it has at least the following fields: name, summary, and description
     """
 
-    check_type = CheckType.lint
+    check_type = CheckType.LINT
     name = "metadata"
     url = BASE_DOCS_URL + "#heading--metadata"
 
@@ -258,7 +268,7 @@ class JujuMetadata:
 class JujuActions:
     """Check that the actions.yaml file is valid YAML if it exists."""
 
-    check_type = CheckType.lint
+    check_type = CheckType.LINT
     name = "juju-actions"
     url = BASE_DOCS_URL + "#heading--juju-actions"
     text = "The actions.yaml file is not a valid YAML file."
@@ -292,7 +302,7 @@ class JujuConfig:
     - each item inside has the mandatory 'type' key
     """
 
-    check_type = CheckType.lint
+    check_type = CheckType.LINT
     name = "juju-config"
     url = BASE_DOCS_URL + "#heading--juju-config"
 
@@ -339,7 +349,7 @@ class Entrypoint:
     - is executable
     """
 
-    check_type = CheckType.lint
+    check_type = CheckType.LINT
     name = "entrypoint"
     url = BASE_DOCS_URL + "#heading--entrypoint"
 
@@ -397,7 +407,7 @@ def analyze(
     all_results = []
     for cls in CHECKERS:
         # do not run the ignored ones
-        if cls.check_type == CheckType.attribute:
+        if cls.check_type == CheckType.ATTRIBUTE:
             ignore_list = config.analysis.ignore.attributes
         else:
             ignore_list = config.analysis.ignore.linters
@@ -417,7 +427,7 @@ def analyze(
         try:
             result = checker.run(basedir)
         except Exception:
-            result = UNKNOWN if checker.check_type == CheckType.attribute else FATAL
+            result = UNKNOWN if checker.check_type == CheckType.ATTRIBUTE else FATAL
         all_results.append(
             CheckResult(
                 check_type=checker.check_type,

--- a/charmcraft/metafiles/manifest.py
+++ b/charmcraft/metafiles/manifest.py
@@ -71,7 +71,7 @@ def create_manifest(
     attributes_info = [
         {"name": result.name, "result": result.result}
         for result in linting_results
-        if result.check_type == charmcraft.linters.CheckType.attribute
+        if result.check_type == charmcraft.linters.CheckType.ATTRIBUTE
     ]
     content["analysis"] = {"attributes": attributes_info}
 

--- a/charmcraft/models/basic.py
+++ b/charmcraft/models/basic.py
@@ -65,7 +65,7 @@ class AttributeName(CustomStrictStr):
         valid_names = [
             checker.name
             for checker in linters.CHECKERS
-            if checker.check_type == linters.CheckType.attribute
+            if checker.check_type == linters.CheckType.ATTRIBUTE
         ]
         if value not in valid_names:
             raise ValueError(f"Bad attribute name {value!r}")
@@ -83,7 +83,7 @@ class LinterName(CustomStrictStr):
         valid_names = [
             checker.name
             for checker in linters.CHECKERS
-            if checker.check_type == linters.CheckType.lint
+            if checker.check_type == linters.CheckType.LINT
         ]
         if value not in valid_names:
             raise ValueError(f"Bad lint name {value!r}")

--- a/charmcraft/package.py
+++ b/charmcraft/package.py
@@ -132,7 +132,7 @@ class Builder:
         for result in linting_results:
             if result.result == charmcraft.linters.IGNORED:
                 continue
-            if result.check_type == charmcraft.linters.CheckType.attribute:
+            if result.check_type == charmcraft.linters.CheckType.ATTRIBUTE:
                 attribute_results.append(result)
             else:
                 lint_results_by_outcome.setdefault(result.result, []).append(result)
@@ -140,7 +140,7 @@ class Builder:
         # show attribute results
         for result in attribute_results:
             emit.verbose(
-                f"Check result: {result.name} [{result.check_type}] {result.result} "
+                f"Check result: {result.name} [{result.check_type.value}] {result.result} "
                 f"({result.text}; see more at {result.url}).",
             )
 

--- a/tests/commands/test_analyze.py
+++ b/tests/commands/test_analyze.py
@@ -140,49 +140,49 @@ def test_complete_set_of_results(emitter, config, monkeypatch, tmp_path, indicat
     linting_results = [
         linters.CheckResult(
             name="check-lint-01",
-            check_type=linters.CheckType.lint,
+            check_type=linters.CheckType.LINT,
             url="url-01",
             text="text-01",
             result=linters.WARNINGS,
         ),
         linters.CheckResult(
             name="check-lint-02",
-            check_type=linters.CheckType.lint,
+            check_type=linters.CheckType.LINT,
             url="url-02",
             text="text-02",
             result=linters.OK,
         ),
         linters.CheckResult(
             name="check-lint-03",
-            check_type=linters.CheckType.lint,
+            check_type=linters.CheckType.LINT,
             url="url-03",
             text="text-03",
             result=linters.ERRORS,
         ),
         linters.CheckResult(
             name="check-attribute-04",
-            check_type=linters.CheckType.attribute,
+            check_type=linters.CheckType.ATTRIBUTE,
             url="url-04",
             text="text-04",
             result="check-result-04",
         ),
         linters.CheckResult(
             name="check-attribute-05",
-            check_type=linters.CheckType.attribute,
+            check_type=linters.CheckType.ATTRIBUTE,
             url="url-05",
             text="text-05",
             result=linters.IGNORED,
         ),
         linters.CheckResult(
             name="check-lint-06",
-            check_type=linters.CheckType.lint,
+            check_type=linters.CheckType.LINT,
             url="url-06",
             text="text-06",
             result=linters.IGNORED,
         ),
         linters.CheckResult(
             name="check-lint-07",
-            check_type=linters.CheckType.lint,
+            check_type=linters.CheckType.LINT,
             url="url-07",
             text="text-07",
             result=linters.FATAL,
@@ -279,7 +279,7 @@ def test_only_attributes(emitter, config, monkeypatch, tmp_path):
     linting_results = [
         linters.CheckResult(
             name="check-attribute",
-            check_type=linters.CheckType.attribute,
+            check_type=linters.CheckType.ATTRIBUTE,
             url="url",
             text="text",
             result="check-result",
@@ -305,7 +305,7 @@ def test_only_warnings(emitter, config, monkeypatch, tmp_path):
     linting_results = [
         linters.CheckResult(
             name="check-lint",
-            check_type=linters.CheckType.lint,
+            check_type=linters.CheckType.LINT,
             url="url",
             text="text",
             result=linters.WARNINGS,
@@ -331,7 +331,7 @@ def test_only_errors(emitter, config, monkeypatch, tmp_path):
     linting_results = [
         linters.CheckResult(
             name="check-lint",
-            check_type=linters.CheckType.lint,
+            check_type=linters.CheckType.LINT,
             url="url",
             text="text",
             result=linters.ERRORS,
@@ -357,14 +357,14 @@ def test_both_errors_and_warnings(emitter, config, monkeypatch, tmp_path):
     linting_results = [
         linters.CheckResult(
             name="check-lint-1",
-            check_type=linters.CheckType.lint,
+            check_type=linters.CheckType.LINT,
             url="url-1",
             text="text-1",
             result=linters.ERRORS,
         ),
         linters.CheckResult(
             name="check-lint-2",
-            check_type=linters.CheckType.lint,
+            check_type=linters.CheckType.LINT,
             url="url-2",
             text="text-2",
             result=linters.WARNINGS,
@@ -392,7 +392,7 @@ def test_only_lint_ok(emitter, config, monkeypatch, tmp_path):
     linting_results = [
         linters.CheckResult(
             name="check-lint",
-            check_type=linters.CheckType.lint,
+            check_type=linters.CheckType.LINT,
             url="url",
             text="text",
             result=linters.OK,
@@ -418,7 +418,7 @@ def test_only_fatal(emitter, config, monkeypatch, tmp_path):
     linting_results = [
         linters.CheckResult(
             name="check-lint",
-            check_type=linters.CheckType.lint,
+            check_type=linters.CheckType.LINT,
             url="url",
             text="text",
             result=linters.FATAL,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2812,8 +2812,8 @@ def test_schema_analysis_ignore_attributes(
     metadata_yaml,
 ):
     """Some attributes are correctly ignored."""
-    create_checker("check_ok_1", linters.CheckType.attribute)
-    create_checker("check_ok_2", linters.CheckType.attribute)
+    create_checker("check_ok_1", linters.CheckType.ATTRIBUTE)
+    create_checker("check_ok_2", linters.CheckType.ATTRIBUTE)
     prepare_charmcraft_yaml(charmcraft_yaml)
     prepare_metadata_yaml(metadata_yaml)
 
@@ -2867,8 +2867,8 @@ def test_schema_analysis_ignore_linters(
     metadata_yaml,
 ):
     """Some linters are correctly ignored."""
-    create_checker("check_ok_1", linters.CheckType.lint)
-    create_checker("check_ok_2", linters.CheckType.lint)
+    create_checker("check_ok_1", linters.CheckType.LINT)
+    create_checker("check_ok_2", linters.CheckType.LINT)
     prepare_charmcraft_yaml(charmcraft_yaml)
     prepare_metadata_yaml(metadata_yaml)
 
@@ -2924,8 +2924,8 @@ def test_schema_analysis_ignore_attribute_missing(
     metadata_yaml,
 ):
     """An attribute specified to ignore is missing in the system."""
-    create_checker("check_ok_1", linters.CheckType.attribute)
-    create_checker("check_ok_2", linters.CheckType.lint)
+    create_checker("check_ok_1", linters.CheckType.ATTRIBUTE)
+    create_checker("check_ok_2", linters.CheckType.LINT)
     prepare_charmcraft_yaml(charmcraft_yaml)
     prepare_metadata_yaml(metadata_yaml)
 
@@ -2985,8 +2985,8 @@ def test_schema_analysis_ignore_linter_missing(
     metadata_yaml,
 ):
     """A linter specified to ignore is missing in the system."""
-    create_checker("check_ok_1", linters.CheckType.attribute)
-    create_checker("check_ok_2", linters.CheckType.lint)
+    create_checker("check_ok_1", linters.CheckType.ATTRIBUTE)
+    create_checker("check_ok_2", linters.CheckType.LINT)
     prepare_charmcraft_yaml(charmcraft_yaml)
     prepare_metadata_yaml(metadata_yaml)
 

--- a/tests/test_linters.py
+++ b/tests/test_linters.py
@@ -713,14 +713,14 @@ def test_analyze_run_everything(config):
 def test_analyze_ignore_attribute(config):
     """Run all checkers except the ignored attribute."""
     FakeChecker1 = create_fake_checker(
-        check_type=CheckType.attribute,
+        check_type=CheckType.ATTRIBUTE,
         name="name1",
         result="res1",
         text="text1",
         url="url1",
     )
     FakeChecker2 = create_fake_checker(
-        check_type=CheckType.lint,
+        check_type=CheckType.LINT,
         name="name2",
         result="res2",
         text="text2",
@@ -732,12 +732,12 @@ def test_analyze_ignore_attribute(config):
         result = analyze(config, "somepath")
 
     res1, res2 = result
-    assert res1.check_type == CheckType.attribute
+    assert res1.check_type == CheckType.ATTRIBUTE
     assert res1.name == "name1"
     assert res1.result == IGNORED
     assert res1.text == ""
     assert res1.url == "url1"
-    assert res2.check_type == CheckType.lint
+    assert res2.check_type == CheckType.LINT
     assert res2.name == "name2"
     assert res2.result == "res2"
     assert res2.text == "text2"
@@ -747,14 +747,14 @@ def test_analyze_ignore_attribute(config):
 def test_analyze_ignore_linter(config):
     """Run all checkers except the ignored linter."""
     FakeChecker1 = create_fake_checker(
-        check_type=CheckType.attribute,
+        check_type=CheckType.ATTRIBUTE,
         name="name1",
         result="res1",
         text="text1",
         url="url1",
     )
     FakeChecker2 = create_fake_checker(
-        check_type=CheckType.lint,
+        check_type=CheckType.LINT,
         name="name2",
         result="res2",
         text="text2",
@@ -766,12 +766,12 @@ def test_analyze_ignore_linter(config):
         result = analyze(config, "somepath")
 
     res1, res2 = result
-    assert res1.check_type == CheckType.attribute
+    assert res1.check_type == CheckType.ATTRIBUTE
     assert res1.name == "name1"
     assert res1.result == "res1"
     assert res1.text == "text1"
     assert res1.url == "url1"
-    assert res2.check_type == CheckType.lint
+    assert res2.check_type == CheckType.LINT
     assert res2.name == "name2"
     assert res2.result == IGNORED
     assert res2.text == ""
@@ -780,8 +780,8 @@ def test_analyze_ignore_linter(config):
 
 def test_analyze_override_ignore(config):
     """Run all checkers even the ignored ones, if requested."""
-    FakeChecker1 = create_fake_checker(check_type=CheckType.attribute, name="name1", result="res1")
-    FakeChecker2 = create_fake_checker(check_type=CheckType.lint, name="name2", result="res2")
+    FakeChecker1 = create_fake_checker(check_type=CheckType.ATTRIBUTE, name="name1", result="res1")
+    FakeChecker2 = create_fake_checker(check_type=CheckType.LINT, name="name2", result="res2")
 
     config.analysis.ignore.attributes.append("name1")
     config.analysis.ignore.linters.append("name2")
@@ -789,10 +789,10 @@ def test_analyze_override_ignore(config):
         result = analyze(config, "somepath", override_ignore_config=True)
 
     res1, res2 = result
-    assert res1.check_type == CheckType.attribute
+    assert res1.check_type == CheckType.ATTRIBUTE
     assert res1.name == "name1"
     assert res1.result == "res1"
-    assert res2.check_type == CheckType.lint
+    assert res2.check_type == CheckType.LINT
     assert res2.name == "name2"
     assert res2.result == "res2"
 
@@ -800,7 +800,7 @@ def test_analyze_override_ignore(config):
 def test_analyze_crash_attribute(config):
     """The attribute checker crashes."""
     FakeChecker = create_fake_checker(
-        check_type=CheckType.attribute, name="name", text="text", url="url"
+        check_type=CheckType.ATTRIBUTE, name="name", text="text", url="url"
     )
 
     def raises(*a):
@@ -812,7 +812,7 @@ def test_analyze_crash_attribute(config):
         result = analyze(config, "somepath")
 
     (res,) = result
-    assert res.check_type == CheckType.attribute
+    assert res.check_type == CheckType.ATTRIBUTE
     assert res.name == "name"
     assert res.result == UNKNOWN
     assert res.text == "text"
@@ -822,7 +822,7 @@ def test_analyze_crash_attribute(config):
 def test_analyze_crash_lint(config):
     """The lint checker crashes."""
     FakeChecker = create_fake_checker(
-        check_type=CheckType.lint, name="name", text="text", url="url"
+        check_type=CheckType.LINT, name="name", text="text", url="url"
     )
 
     def raises(*a):
@@ -834,7 +834,7 @@ def test_analyze_crash_lint(config):
         result = analyze(config, "somepath")
 
     (res,) = result
-    assert res.check_type == CheckType.lint
+    assert res.check_type == CheckType.LINT
     assert res.name == "name"
     assert res.result == FATAL
     assert res.text == "text"
@@ -844,10 +844,10 @@ def test_analyze_crash_lint(config):
 def test_analyze_all_can_be_ignored(config):
     """Control that all real life checkers can be ignored."""
     config.analysis.ignore.attributes.extend(
-        c.name for c in CHECKERS if c.check_type == CheckType.attribute
+        c.name for c in CHECKERS if c.check_type == CheckType.ATTRIBUTE
     )
     config.analysis.ignore.linters.extend(
-        c.name for c in CHECKERS if c.check_type == CheckType.lint
+        c.name for c in CHECKERS if c.check_type == CheckType.LINT
     )
     result = analyze(config, "somepath")
     assert all(r.result == IGNORED for r in result)

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -57,7 +57,7 @@ def test_manifest_simple_ok(tmp_path):
     linting_results = [
         linters.CheckResult(
             name="check-name",
-            check_type=linters.CheckType.attribute,
+            check_type=linters.CheckType.ATTRIBUTE,
             url="url",
             text="text",
             result="check-result",
@@ -120,21 +120,21 @@ def test_manifest_checkers_multiple(tmp_path):
     linting_results = [
         linters.CheckResult(
             name="attrib-name-1",
-            check_type=linters.CheckType.attribute,
+            check_type=linters.CheckType.ATTRIBUTE,
             url="url",
             text="text",
             result="result-1",
         ),
         linters.CheckResult(
             name="attrib-name-2",
-            check_type=linters.CheckType.attribute,
+            check_type=linters.CheckType.ATTRIBUTE,
             url="url",
             text="text",
             result="result-2",
         ),
         linters.CheckResult(
             name="warning-name",
-            check_type=linters.CheckType.lint,
+            check_type=linters.CheckType.LINT,
             url="url",
             text="text",
             result="result",

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1578,14 +1578,14 @@ def test_build_using_linters_attributes(basic_project_builder, monkeypatch, tmp_
     linting_results = [
         linters.CheckResult(
             name="check-name-1",
-            check_type=linters.CheckType.attribute,
+            check_type=linters.CheckType.ATTRIBUTE,
             url="url",
             text="text",
             result="check-result-1",
         ),
         linters.CheckResult(
             name="check-name-2",
-            check_type=linters.CheckType.attribute,
+            check_type=linters.CheckType.ATTRIBUTE,
             url="url",
             text="text",
             result=linters.IGNORED,
@@ -1623,14 +1623,14 @@ def test_show_linters_attributes(basic_project, emitter, config):
     linting_results = [
         linters.CheckResult(
             name="check-name-1",
-            check_type=linters.CheckType.attribute,
+            check_type=linters.CheckType.ATTRIBUTE,
             url="url",
             text="text",
             result="check-result-1",
         ),
         linters.CheckResult(
             name="check-name-2",
-            check_type=linters.CheckType.attribute,
+            check_type=linters.CheckType.ATTRIBUTE,
             url="url",
             text="text",
             result=linters.IGNORED,
@@ -1651,7 +1651,7 @@ def test_show_linters_lint_warnings(basic_project, emitter, config):
     linting_results = [
         linters.CheckResult(
             name="check-name",
-            check_type=linters.CheckType.lint,
+            check_type=linters.CheckType.LINT,
             url="check-url",
             text="Some text",
             result=linters.WARNINGS,
@@ -1676,7 +1676,7 @@ def test_show_linters_lint_errors_normal(basic_project, emitter, config):
     linting_results = [
         linters.CheckResult(
             name="check-name",
-            check_type=linters.CheckType.lint,
+            check_type=linters.CheckType.LINT,
             url="check-url",
             text="Some text",
             result=linters.ERRORS,
@@ -1705,7 +1705,7 @@ def test_show_linters_lint_errors_forced(basic_project, emitter, config):
     linting_results = [
         linters.CheckResult(
             name="check-name",
-            check_type=linters.CheckType.lint,
+            check_type=linters.CheckType.LINT,
             url="check-url",
             text="Some text",
             result=linters.ERRORS,


### PR DESCRIPTION
Before this was essentially a singleton namedtuple instance, which can be harder for tools to evaluate.