### PR TITLE
refactor(linters): stricter typing for linters

### DIFF
--- a/charmcraft/commands/analyze.py
+++ b/charmcraft/commands/analyze.py
@@ -25,6 +25,7 @@ from craft_cli import CraftError, emit
 
 from charmcraft import linters
 from charmcraft.cmdbase import BaseCommand
+from charmcraft.models.lint import LintResult
 from charmcraft.utils import useful_filepath
 
 
@@ -110,9 +111,9 @@ class AnalyzeCommand(BaseCommand):
             else:
                 # linters
                 group_key = result.result
-                if result.result == linters.Result.OK:
+                if result.result == LintResult.OK:
                     result_info = "no issues found"
-                elif result.result in (linters.Result.FATAL, linters.Result.IGNORED):
+                elif result.result in (LintResult.FATAL, LintResult.IGNORED):
                     result_info = None
                 else:
                     result_info = result.text
@@ -121,11 +122,11 @@ class AnalyzeCommand(BaseCommand):
         # present the results
         titles = [
             ("Attributes", linters.CheckType.ATTRIBUTE),
-            ("Lint Ignored", linters.Result.IGNORED),
-            ("Lint Warnings", linters.Result.WARNINGS),
-            ("Lint Errors", linters.Result.ERRORS),
-            ("Lint Fatal", linters.Result.FATAL),
-            ("Lint OK", linters.Result.OK),
+            ("Lint Ignored", LintResult.IGNORED),
+            ("Lint Warnings", LintResult.WARNINGS),
+            ("Lint Errors", LintResult.ERRORS),
+            ("Lint Fatal", LintResult.FATAL),
+            ("Lint OK", LintResult.OK),
         ]
         for title, key in titles:
             results = grouped.get(key)
@@ -138,11 +139,11 @@ class AnalyzeCommand(BaseCommand):
                         emit.message(f"- {result.name} ({result.url})")
 
         # the return code depends on the presence of different issues
-        if linters.Result.FATAL in grouped:
+        if LintResult.FATAL in grouped:
             retcode = 1
-        elif linters.Result.ERRORS in grouped:
+        elif LintResult.ERRORS in grouped:
             retcode = 2
-        elif linters.Result.WARNINGS in grouped:
+        elif LintResult.WARNINGS in grouped:
             retcode = 3
         else:
             retcode = 0

--- a/charmcraft/models/lint.py
+++ b/charmcraft/models/lint.py
@@ -1,0 +1,56 @@
+# Copyright 2023 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For further info, check https://github.com/canonical/charmcraft
+"""Models for linters."""
+import enum
+from typing import final
+
+from pydantic import dataclasses
+
+
+# Making this a str subclass makes it JSON serialisable as that string.
+# This can be replaced with StrEnum once we can drop support for Python < 3.11
+class CheckType(str, enum.Enum):
+    """Type of analyzer, either attribute check or linter.
+
+    More documentation: https://juju.is/docs/sdk/charmcraft-analyzers-and-linters.
+    """
+
+    ATTRIBUTE = "attribute"
+    LINT = "lint"
+
+
+@final
+class LintResult:
+    """Check results."""
+
+    OK = "ok"
+    WARNINGS = "warnings"
+    ERRORS = "errors"
+    FATAL = "fatal"
+    IGNORED = "ignored"
+    UNKNOWN = "unknown"
+    NONAPPLICABLE = "nonapplicable"
+
+
+@dataclasses.dataclass(frozen=True)
+class CheckResult:
+    """The result of a single linter check."""
+
+    name: str
+    result: str
+    url: str
+    check_type: CheckType
+    text: str

--- a/charmcraft/package.py
+++ b/charmcraft/package.py
@@ -44,6 +44,7 @@ from charmcraft.metafiles.config import create_config_yaml
 from charmcraft.metafiles.manifest import create_manifest
 from charmcraft.metafiles.metadata import create_metadata_yaml
 from charmcraft.models.charmcraft import Base, BasesConfiguration
+from charmcraft.models.lint import LintResult
 from charmcraft.utils import (
     build_zip,
     collect_charmlib_pydeps,
@@ -135,7 +136,7 @@ class Builder:
         attribute_results = []
         lint_results_by_outcome = {}
         for result in linting_results:
-            if result.result == charmcraft.linters.Result.IGNORED:
+            if result.result == LintResult.IGNORED:
                 continue
             if result.check_type == charmcraft.linters.CheckType.ATTRIBUTE:
                 attribute_results.append(result)
@@ -151,13 +152,13 @@ class Builder:
 
         # show warnings (if any), then errors (if any)
         template = "- {0.name}: {0.text} ({0.url})"
-        if charmcraft.linters.Result.WARNINGS in lint_results_by_outcome:
+        if LintResult.WARNINGS in lint_results_by_outcome:
             emit.progress("Lint Warnings:", permanent=True)
-            for result in lint_results_by_outcome[charmcraft.linters.Result.WARNINGS]:
+            for result in lint_results_by_outcome[LintResult.WARNINGS]:
                 emit.progress(template.format(result), permanent=True)
-        if charmcraft.linters.Result.ERRORS in lint_results_by_outcome:
+        if LintResult.ERRORS in lint_results_by_outcome:
             emit.progress("Lint Errors:", permanent=True)
-            for result in lint_results_by_outcome[charmcraft.linters.Result.ERRORS]:
+            for result in lint_results_by_outcome[LintResult.ERRORS]:
                 emit.progress(template.format(result), permanent=True)
             if self.force_packing:
                 emit.progress("Packing anyway as requested.", permanent=True)

--- a/tests/commands/test_analyze.py
+++ b/tests/commands/test_analyze.py
@@ -26,6 +26,7 @@ from craft_cli import CraftError
 from charmcraft import linters
 from charmcraft.cmdbase import JSON_FORMAT
 from charmcraft.commands.analyze import AnalyzeCommand
+from charmcraft.models.lint import LintResult
 from charmcraft.utils import useful_filepath
 
 
@@ -143,21 +144,21 @@ def test_complete_set_of_results(emitter, config, monkeypatch, tmp_path, indicat
             check_type=linters.CheckType.LINT,
             url="url-01",
             text="text-01",
-            result=linters.Result.WARNINGS,
+            result=LintResult.WARNINGS,
         ),
         linters.CheckResult(
             name="check-lint-02",
             check_type=linters.CheckType.LINT,
             url="url-02",
             text="text-02",
-            result=linters.Result.OK,
+            result=LintResult.OK,
         ),
         linters.CheckResult(
             name="check-lint-03",
             check_type=linters.CheckType.LINT,
             url="url-03",
             text="text-03",
-            result=linters.Result.ERRORS,
+            result=LintResult.ERRORS,
         ),
         linters.CheckResult(
             name="check-attribute-04",
@@ -171,21 +172,21 @@ def test_complete_set_of_results(emitter, config, monkeypatch, tmp_path, indicat
             check_type=linters.CheckType.ATTRIBUTE,
             url="url-05",
             text="text-05",
-            result=linters.Result.IGNORED,
+            result=LintResult.IGNORED,
         ),
         linters.CheckResult(
             name="check-lint-06",
             check_type=linters.CheckType.LINT,
             url="url-06",
             text="text-06",
-            result=linters.Result.IGNORED,
+            result=LintResult.IGNORED,
         ),
         linters.CheckResult(
             name="check-lint-07",
             check_type=linters.CheckType.LINT,
             url="url-07",
             text="text-07",
-            result=linters.Result.FATAL,
+            result=LintResult.FATAL,
         ),
     ]
 
@@ -308,7 +309,7 @@ def test_only_warnings(emitter, config, monkeypatch, tmp_path):
             check_type=linters.CheckType.LINT,
             url="url",
             text="text",
-            result=linters.Result.WARNINGS,
+            result=LintResult.WARNINGS,
         ),
     ]
 
@@ -334,7 +335,7 @@ def test_only_errors(emitter, config, monkeypatch, tmp_path):
             check_type=linters.CheckType.LINT,
             url="url",
             text="text",
-            result=linters.Result.ERRORS,
+            result=LintResult.ERRORS,
         ),
     ]
 
@@ -360,14 +361,14 @@ def test_both_errors_and_warnings(emitter, config, monkeypatch, tmp_path):
             check_type=linters.CheckType.LINT,
             url="url-1",
             text="text-1",
-            result=linters.Result.ERRORS,
+            result=LintResult.ERRORS,
         ),
         linters.CheckResult(
             name="check-lint-2",
             check_type=linters.CheckType.LINT,
             url="url-2",
             text="text-2",
-            result=linters.Result.WARNINGS,
+            result=LintResult.WARNINGS,
         ),
     ]
 
@@ -395,7 +396,7 @@ def test_only_lint_ok(emitter, config, monkeypatch, tmp_path):
             check_type=linters.CheckType.LINT,
             url="url",
             text="text",
-            result=linters.Result.OK,
+            result=LintResult.OK,
         ),
     ]
 
@@ -421,7 +422,7 @@ def test_only_fatal(emitter, config, monkeypatch, tmp_path):
             check_type=linters.CheckType.LINT,
             url="url",
             text="text",
-            result=linters.Result.FATAL,
+            result=LintResult.FATAL,
         ),
     ]
 

--- a/tests/test_linters.py
+++ b/tests/test_linters.py
@@ -25,6 +25,7 @@ import pytest
 
 from charmcraft.linters import (
     CHECKERS,
+    BaseChecker,
     CheckType,
     Entrypoint,
     Framework,
@@ -32,11 +33,11 @@ from charmcraft.linters import (
     JujuConfig,
     JujuMetadata,
     Language,
-    Result,
     analyze,
     check_dispatch_with_python_entrypoint,
     get_entrypoint_from_dispatch,
 )
+from charmcraft.models.lint import LintResult
 
 EXAMPLE_DISPATCH = """
 #!/bin/sh
@@ -146,18 +147,18 @@ def test_language_python():
     """The charm is written in Python."""
     with patch("charmcraft.linters.check_dispatch_with_python_entrypoint") as mock_check:
         mock_check.return_value = pathlib.Path("entrypoint")
-        result = Language().run("somedir")
-    assert result == Language.Result.python
-    mock_check.assert_called_with("somedir")
+        result = Language().run(pathlib.Path("somedir"))
+    assert result == Language.Result.PYTHON
+    mock_check.assert_called_with(pathlib.Path("somedir"))
 
 
 def test_language_no_dispatch(tmp_path):
     """The charm has no dispatch at all."""
     with patch("charmcraft.linters.check_dispatch_with_python_entrypoint") as mock_check:
         mock_check.return_value = None
-        result = Language().run("somedir")
-    assert result == Language.Result.unknown
-    mock_check.assert_called_with("somedir")
+        result = Language().run(pathlib.Path("somedir"))
+    assert result == Language.Result.UNKNOWN
+    mock_check.assert_called_with(pathlib.Path("somedir"))
 
 
 # --- tests for Framework checker
@@ -167,8 +168,8 @@ def test_framework_run_operator():
     """Check for Operator Framework was successful."""
     checker = Framework()
     with patch.object(Framework, "_check_operator", lambda self, path: True):
-        result = checker.run("somepath")
-    assert result == Framework.CharmFramework.operator
+        result = checker.run(pathlib.Path("somepath"))
+    assert result == Framework.Result.OPERATOR
     assert checker.text == "The charm is based on the Operator Framework."
 
 
@@ -177,8 +178,8 @@ def test_framework_run_reactive():
     checker = Framework()
     with patch.object(Framework, "_check_operator", lambda self, path: False):
         with patch.object(Framework, "_check_reactive", lambda self, path: True):
-            result = checker.run("somepath")
-    assert result == Framework.CharmFramework.reactive
+            result = checker.run(pathlib.Path("somepath"))
+    assert result == Framework.Result.REACTIVE
     assert checker.text == "The charm is based on the Reactive Framework."
 
 
@@ -187,8 +188,8 @@ def test_framework_run_unknown():
     checker = Framework()
     with patch.object(Framework, "_check_operator", lambda self, path: False):
         with patch.object(Framework, "_check_reactive", lambda self, path: False):
-            result = checker.run("somepath")
-    assert result == Framework.CharmFramework.unknown
+            result = checker.run(pathlib.Path("somepath"))
+    assert result == Framework.Result.UNKNOWN
     assert checker.text == "The charm is not based on any known Framework."
 
 
@@ -586,14 +587,14 @@ def test_jujumetadata_all_ok(tmp_path):
     """
     )
     result = JujuMetadata().run(tmp_path)
-    assert result == Result.OK
+    assert result == JujuMetadata.Result.OK
 
 
 def test_jujumetadata_missing_file(tmp_path):
     """No metadata.yaml file at all."""
     linter = JujuMetadata()
     result = linter.run(tmp_path)
-    assert result == Result.ERRORS
+    assert result == JujuMetadata.Result.ERRORS
     assert linter.text == "Cannot read the metadata.yaml file."
 
 
@@ -603,7 +604,7 @@ def test_jujumetadata_file_corrupted(tmp_path):
     metadata_file.write_text(" - \n-")
     linter = JujuMetadata()
     result = linter.run(tmp_path)
-    assert result == Result.ERRORS
+    assert result == JujuMetadata.Result.ERRORS
     assert linter.text == "The metadata.yaml file is not a valid YAML file."
 
 
@@ -622,7 +623,7 @@ def test_jujumetadata_missing_field_simple(tmp_path, to_miss):
     metadata_file.write_text(content)
     linter = JujuMetadata()
     result = linter.run(tmp_path)
-    assert result == Result.ERRORS
+    assert result == JujuMetadata.Result.ERRORS
     assert linter.text == (
         f"The metadata.yaml file is missing the following attribute(s): '{missing}'."
     )
@@ -639,7 +640,7 @@ def test_jujumetadata_missing_field_multiple(tmp_path):
     )
     linter = JujuMetadata()
     result = linter.run(tmp_path)
-    assert result == Result.ERRORS
+    assert result == JujuMetadata.Result.ERRORS
     assert linter.text == (
         "The metadata.yaml file is missing the following attribute(s): "
         "'description' and 'summary'."
@@ -664,7 +665,7 @@ def create_fake_checker(**kwargs):
     }
     params.update(kwargs)
 
-    class FakeChecker:
+    class FakeChecker(BaseChecker):
         check_type = params["check_type"]
         name = params["name"]
         url = params["url"]
@@ -679,29 +680,29 @@ def create_fake_checker(**kwargs):
 def test_analyze_run_everything(config):
     """Check that analyze runs all and collect the results."""
     FakeChecker1 = create_fake_checker(
-        check_type="type1", name="name1", url="url1", text="text1", result="result1"
+        check_type=CheckType.ATTRIBUTE, name="name1", url="url1", text="text1", result="result1"
     )
     FakeChecker2 = create_fake_checker(
-        check_type="type2", name="name2", url="url2", text="text2", result="result2"
+        check_type=CheckType.LINT, name="name2", url="url2", text="text2", result="result2"
     )
 
     # hack the first fake checker to validate that it receives the indicated path
     def dir_validator(self, basedir):
-        assert basedir == "test-buildpath"
+        assert basedir == pathlib.Path("test-buildpath")
         return "result1"
 
     FakeChecker1.run = dir_validator
 
     with patch("charmcraft.linters.CHECKERS", [FakeChecker1, FakeChecker2]):
-        result = analyze(config, "test-buildpath")
+        result = analyze(config, pathlib.Path("test-buildpath"))
 
     r1, r2 = result
-    assert r1.check_type == "type1"
+    assert r1.check_type == "attribute"
     assert r1.name == "name1"
     assert r1.url == "url1"
     assert r1.text == "text1"
     assert r1.result == "result1"
-    assert r2.check_type == "type2"
+    assert r2.check_type == "lint"
     assert r2.name == "name2"
     assert r2.url == "url2"
     assert r2.text == "text2"
@@ -727,12 +728,12 @@ def test_analyze_ignore_attribute(config):
 
     config.analysis.ignore.attributes.append("name1")
     with patch("charmcraft.linters.CHECKERS", [FakeChecker1, FakeChecker2]):
-        result = analyze(config, "somepath")
+        result = analyze(config, pathlib.Path("somepath"))
 
     res1, res2 = result
     assert res1.check_type == CheckType.ATTRIBUTE
     assert res1.name == "name1"
-    assert res1.result == Result.IGNORED
+    assert res1.result == LintResult.IGNORED
     assert res1.text == ""
     assert res1.url == "url1"
     assert res2.check_type == CheckType.LINT
@@ -761,7 +762,7 @@ def test_analyze_ignore_linter(config):
 
     config.analysis.ignore.linters.append("name2")
     with patch("charmcraft.linters.CHECKERS", [FakeChecker1, FakeChecker2]):
-        result = analyze(config, "somepath")
+        result = analyze(config, pathlib.Path("somepath"))
 
     res1, res2 = result
     assert res1.check_type == CheckType.ATTRIBUTE
@@ -771,7 +772,7 @@ def test_analyze_ignore_linter(config):
     assert res1.url == "url1"
     assert res2.check_type == CheckType.LINT
     assert res2.name == "name2"
-    assert res2.result == Result.IGNORED
+    assert res2.result == LintResult.IGNORED
     assert res2.text == ""
     assert res2.url == "url2"
 
@@ -784,7 +785,7 @@ def test_analyze_override_ignore(config):
     config.analysis.ignore.attributes.append("name1")
     config.analysis.ignore.linters.append("name2")
     with patch("charmcraft.linters.CHECKERS", [FakeChecker1, FakeChecker2]):
-        result = analyze(config, "somepath", override_ignore_config=True)
+        result = analyze(config, pathlib.Path("somepath"), override_ignore_config=True)
 
     res1, res2 = result
     assert res1.check_type == CheckType.ATTRIBUTE
@@ -807,12 +808,12 @@ def test_analyze_crash_attribute(config):
     FakeChecker.run = raises
 
     with patch("charmcraft.linters.CHECKERS", [FakeChecker]):
-        result = analyze(config, "somepath")
+        result = analyze(config, pathlib.Path("somepath"))
 
     (res,) = result
     assert res.check_type == CheckType.ATTRIBUTE
     assert res.name == "name"
-    assert res.result == Result.UNKNOWN
+    assert res.result == LintResult.UNKNOWN
     assert res.text == "text"
     assert res.url == "url"
 
@@ -829,12 +830,12 @@ def test_analyze_crash_lint(config):
     FakeChecker.run = raises
 
     with patch("charmcraft.linters.CHECKERS", [FakeChecker]):
-        result = analyze(config, "somepath")
+        result = analyze(config, pathlib.Path("somepath"))
 
     (res,) = result
     assert res.check_type == CheckType.LINT
     assert res.name == "name"
-    assert res.result == Result.FATAL
+    assert res.result == LintResult.FATAL
     assert res.text == "text"
     assert res.url == "url"
 
@@ -847,8 +848,8 @@ def test_analyze_all_can_be_ignored(config):
     config.analysis.ignore.linters.extend(
         c.name for c in CHECKERS if c.check_type == CheckType.LINT
     )
-    result = analyze(config, "somepath")
-    assert all(r.result == Result.IGNORED for r in result)
+    result = analyze(config, pathlib.Path("somepath"))
+    assert all(r.result == LintResult.IGNORED for r in result)
 
 
 # --- tests for JujuActions checker
@@ -859,13 +860,13 @@ def test_jujuactions_ok(tmp_path):
     actions_file = tmp_path / "actions.yaml"
     actions_file.write_text("stuff: foobar")
     result = JujuActions().run(tmp_path)
-    assert result == Result.OK
+    assert result == JujuActions.Result.OK
 
 
 def test_jujuactions_missing_file(tmp_path):
     """No actions.yaml file at all."""
     result = JujuActions().run(tmp_path)
-    assert result == Result.OK
+    assert result == JujuActions.Result.OK
 
 
 def test_jujuactions_file_corrupted(tmp_path):
@@ -873,7 +874,7 @@ def test_jujuactions_file_corrupted(tmp_path):
     actions_file = tmp_path / "actions.yaml"
     actions_file.write_text(" - \n-")
     result = JujuActions().run(tmp_path)
-    assert result == Result.ERRORS
+    assert result == JujuActions.Result.ERRORS
 
 
 # --- tests for JujuConfig checker
@@ -890,13 +891,13 @@ def test_jujuconfig_ok(tmp_path):
     """
     )
     result = JujuConfig().run(tmp_path)
-    assert result == Result.OK
+    assert result == JujuConfig.Result.OK
 
 
 def test_jujuconfig_missing_file(tmp_path):
     """No config.yaml file at all."""
     result = JujuConfig().run(tmp_path)
-    assert result == Result.OK
+    assert result == JujuConfig.Result.OK
 
 
 def test_jujuconfig_file_corrupted(tmp_path):
@@ -905,7 +906,7 @@ def test_jujuconfig_file_corrupted(tmp_path):
     config_file.write_text(" - \n-")
     linter = JujuConfig()
     result = linter.run(tmp_path)
-    assert result == Result.ERRORS
+    assert result == JujuConfig.Result.ERRORS
     assert linter.text == "The config.yaml file is not a valid YAML file."
 
 
@@ -919,7 +920,7 @@ def test_jujuconfig_no_options(tmp_path):
     )
     linter = JujuConfig()
     result = linter.run(tmp_path)
-    assert result == Result.ERRORS
+    assert result == JujuConfig.Result.ERRORS
     assert linter.text == "Error in config.yaml: must have an 'options' dictionary."
 
 
@@ -933,7 +934,7 @@ def test_jujuconfig_empty_options(tmp_path):
     )
     linter = JujuConfig()
     result = linter.run(tmp_path)
-    assert result == Result.ERRORS
+    assert result == JujuConfig.Result.ERRORS
     assert linter.text == "Error in config.yaml: must have an 'options' dictionary."
 
 
@@ -949,7 +950,7 @@ def test_jujuconfig_options_not_dict(tmp_path):
     )
     linter = JujuConfig()
     result = linter.run(tmp_path)
-    assert result == Result.ERRORS
+    assert result == JujuConfig.Result.ERRORS
     assert linter.text == "Error in config.yaml: must have an 'options' dictionary."
 
 
@@ -965,7 +966,7 @@ def test_jujuconfig_no_type_in_options_items(tmp_path):
     )
     linter = JujuConfig()
     result = linter.run(tmp_path)
-    assert result == Result.ERRORS
+    assert result == JujuConfig.Result.ERRORS
     assert linter.text == "Error in config.yaml: items under 'options' must have a 'type' key."
 
 
@@ -977,7 +978,7 @@ def test_entrypoint_not_used(tmp_path):
     with patch("charmcraft.linters.get_entrypoint_from_dispatch") as mock_check:
         mock_check.return_value = None
         result = Entrypoint().run(tmp_path)
-    assert result == Result.NONAPPLICABLE
+    assert result == Entrypoint.Result.NONAPPLICABLE
     mock_check.assert_called_with(tmp_path)
 
 
@@ -988,7 +989,7 @@ def test_entrypoint_all_ok(tmp_path):
     with patch("charmcraft.linters.get_entrypoint_from_dispatch") as mock_check:
         mock_check.return_value = entrypoint
         result = Entrypoint().run(tmp_path)
-    assert result == Result.OK
+    assert result == Entrypoint.Result.OK
     mock_check.assert_called_with(tmp_path)
 
 
@@ -998,7 +999,7 @@ def test_entrypoint_missing(tmp_path):
     linter = Entrypoint()
     with patch("charmcraft.linters.get_entrypoint_from_dispatch", return_value=entrypoint):
         result = linter.run(tmp_path)
-    assert result == Result.ERRORS
+    assert result == Entrypoint.Result.ERRORS
     assert linter.text == f"Cannot find the entrypoint file: {str(entrypoint)!r}"
 
 
@@ -1009,7 +1010,7 @@ def test_entrypoint_directory(tmp_path):
     linter = Entrypoint()
     with patch("charmcraft.linters.get_entrypoint_from_dispatch", return_value=entrypoint):
         result = linter.run(tmp_path)
-    assert result == Result.ERRORS
+    assert result == Entrypoint.Result.ERRORS
     assert linter.text == f"The entrypoint is not a file: {str(entrypoint)!r}"
 
 
@@ -1021,5 +1022,5 @@ def test_entrypoint_non_exec(tmp_path):
     linter = Entrypoint()
     with patch("charmcraft.linters.get_entrypoint_from_dispatch", return_value=entrypoint):
         result = linter.run(tmp_path)
-    assert result == Result.ERRORS
+    assert result == Entrypoint.Result.ERRORS
     assert linter.text == f"The entrypoint file is not executable: {str(entrypoint)!r}"

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -35,6 +35,7 @@ from charmcraft.charm_builder import relativise
 from charmcraft.config import load
 from charmcraft.const import BUILD_DIRNAME
 from charmcraft.models.charmcraft import Base, BasesConfiguration
+from charmcraft.models.lint import LintResult
 from charmcraft.package import (
     Builder,
     _subprocess_pack_charms,
@@ -1590,7 +1591,7 @@ def test_build_using_linters_attributes(basic_project_builder, monkeypatch, tmp_
             check_type=linters.CheckType.ATTRIBUTE,
             url="url",
             text="text",
-            result=linters.Result.IGNORED.value,
+            result=LintResult.IGNORED,
         ),
     ]
 
@@ -1635,7 +1636,7 @@ def test_show_linters_attributes(basic_project, emitter, config):
             check_type=linters.CheckType.ATTRIBUTE,
             url="url",
             text="text",
-            result=linters.Result.IGNORED,
+            result=LintResult.IGNORED,
         ),
     ]
 
@@ -1656,7 +1657,7 @@ def test_show_linters_lint_warnings(basic_project, emitter, config):
             check_type=linters.CheckType.LINT,
             url="check-url",
             text="Some text",
-            result=linters.Result.WARNINGS,
+            result=LintResult.WARNINGS,
         ),
     ]
 
@@ -1681,7 +1682,7 @@ def test_show_linters_lint_errors_normal(basic_project, emitter, config):
             check_type=linters.CheckType.LINT,
             url="check-url",
             text="Some text",
-            result=linters.Result.ERRORS,
+            result=LintResult.ERRORS,
         ),
     ]
 
@@ -1710,7 +1711,7 @@ def test_show_linters_lint_errors_forced(basic_project, emitter, config):
             check_type=linters.CheckType.LINT,
             url="check-url",
             text="Some text",
-            result=linters.Result.ERRORS,
+            result=LintResult.ERRORS,
         ),
     ]
 


### PR DESCRIPTION
* Moves data structures into models
* Base classes for checkers
* Constant classes for results
* LintResult is no longer an enum