### PR TITLE
chore: bump minimum Python version to 3.10

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -46,10 +46,8 @@ jobs:
     strategy:
       matrix:
         os: [macos-11, macos-12, windows-2019, windows-2022]
-        python-version: [3.8, "3.10", "3.11"]
+        python-version: ["3.10", "3.11"]
         include:
-          - os: ubuntu-20.04
-            python-version: "3.8"
           - os: ubuntu-22.04
             python-version: "3.10"
 
@@ -72,18 +70,12 @@ jobs:
         run: |
           pip install -U wheel setuptools
       - name: Install Ubuntu-specific dependencies
-        if: ${{ matrix.os == 'ubuntu-20.04' || matrix.os == 'ubuntu-22.04' }}
+        if: ${{ startsWith(matrix.os, 'ubuntu') }}
         run: |
           sudo apt update
           sudo apt install -y python3-pip python3-setuptools python3-wheel python3-venv libapt-pkg-dev
-      - name: Install Ubuntu 20.04-specific dependencies
-        if: ${{ matrix.os == 'ubuntu-20.04' }}
-        run: |
-          pip install -U -r requirements-focal.txt
-      - name: Install Ubuntu 22.04-specific dependencies
-        if: ${{ matrix.os == 'ubuntu-22.04' }}
-        run: |
-          pip install -U -r requirements-jammy.txt
+          export $(cat /etc/os-release | grep VERSION_CODENAME)
+          pip install -U -r "requirements-${VERSION_CODENAME}.txt"
       - name: Install charmcraft and dependencies
         run: |
           pip install -U -r requirements-dev.txt

--- a/charmcraft/bases.py
+++ b/charmcraft/bases.py
@@ -16,7 +16,6 @@
 
 """Logic dealing with bases."""
 
-from typing import Tuple, Union
 
 from charmcraft.models.charmcraft import Base
 from charmcraft.utils import get_host_architecture, get_os_platform
@@ -37,7 +36,7 @@ def get_host_as_base() -> Base:
     return Base(name=name, channel=channel, architectures=[host_arch])
 
 
-def check_if_base_matches_host(base: Base) -> Tuple[bool, Union[str, None]]:
+def check_if_base_matches_host(base: Base) -> tuple[bool, str | None]:
     """Check if given base matches the host.
 
     :param base: Base to check.

--- a/charmcraft/charm_builder.py
+++ b/charmcraft/charm_builder.py
@@ -27,7 +27,6 @@ import pathlib
 import shutil
 import subprocess
 import sys
-from typing import List
 
 from charmcraft import const, instrum
 from charmcraft.env import get_charm_builder_metrics_path
@@ -60,9 +59,9 @@ class CharmBuilder:
         installdir: pathlib.Path,
         entrypoint: pathlib.Path,
         allow_pip_binary: bool = None,
-        binary_python_packages: List[str] = None,
-        python_packages: List[str] = None,
-        requirements: List[pathlib.Path] = None,
+        binary_python_packages: list[str] = None,
+        python_packages: list[str] = None,
+        requirements: list[pathlib.Path] = None,
         strict_dependencies: bool = False,
     ) -> None:
         self.builddir = builddir
@@ -375,7 +374,7 @@ def _find_venv_site_packages(basedir):
     return basedir / "lib" / f"python{major}.{minor}" / "site-packages"
 
 
-def _process_run(cmd: List[str]) -> None:
+def _process_run(cmd: list[str]) -> None:
     """Run an external command logging its output.
 
     :raises CraftError: if execution crashes or ends with return code not zero.

--- a/charmcraft/commands/extensions.py
+++ b/charmcraft/commands/extensions.py
@@ -17,7 +17,6 @@
 """Infrastructure for the 'extensions' command."""
 import argparse
 from textwrap import dedent
-from typing import Dict
 
 import tabulate
 import yaml
@@ -46,7 +45,7 @@ class ListExtensionsCommand(BaseCommand):
 
     def run(self, parsed_args: argparse.Namespace):
         """Print the list of available extensions and their bases."""
-        extension_presentation: Dict[str, ExtensionModel] = {}
+        extension_presentation: dict[str, ExtensionModel] = {}
 
         for extension_name in extensions.registry.get_extension_names():
             extension_class = extensions.registry.get_extension_class(extension_name)

--- a/charmcraft/commands/init.py
+++ b/charmcraft/commands/init.py
@@ -19,7 +19,6 @@
 import os
 import re
 from datetime import date
-from typing import Optional
 
 from craft_cli import CraftError, emit
 
@@ -98,7 +97,7 @@ README.md
 """
 
 
-def _get_users_full_name_gecos() -> Optional[str]:
+def _get_users_full_name_gecos() -> str | None:
     """Get user's full name from Gecos (/etc/passwd)."""
     try:
         return pwd.getpwuid(os.getuid()).pw_gecos.split(",", 1)[0]

--- a/charmcraft/commands/pack.py
+++ b/charmcraft/commands/pack.py
@@ -17,7 +17,6 @@
 """Infrastructure for the 'pack' command."""
 import argparse
 import pathlib
-from typing import Dict, List
 
 import yaml
 from craft_cli import ArgumentParsingError, CraftError, emit
@@ -163,7 +162,7 @@ class PackCommand(BaseCommand):
                 charm_names = bundle.get("applications", {}).keys()
                 charms = find_charm_sources(self.config.project.dirpath, charm_names)
             elif parsed_args.include_charm:
-                charms: Dict[str, pathlib.Path] = {}
+                charms: dict[str, pathlib.Path] = {}
                 for path in parsed_args.include_charm:
                     if not path.is_absolute():
                         path = self.config.project.dirpath / path
@@ -195,7 +194,7 @@ class PackCommand(BaseCommand):
             if bases_index >= len_configured_bases:
                 raise CraftError(msg.format(bases_index))
 
-    def _pack_charm(self, parsed_args, builder: package.Builder) -> List[pathlib.Path]:
+    def _pack_charm(self, parsed_args, builder: package.Builder) -> list[pathlib.Path]:
         """Pack a charm."""
         self._validate_bases_indices(parsed_args.bases_index)
 
@@ -222,7 +221,7 @@ class PackCommand(BaseCommand):
     def _pack_bundle(
         self,
         parsed_args: argparse.Namespace,
-        charms: Dict[str, pathlib.Path],
+        charms: dict[str, pathlib.Path],
         builder: package.Builder,
         overwrite_bundle: bool = False,
     ) -> None:

--- a/charmcraft/commands/store/__init__.py
+++ b/charmcraft/commands/store/__init__.py
@@ -26,7 +26,7 @@ import textwrap
 import typing
 import zipfile
 from operator import attrgetter
-from typing import Dict, List, Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 import yaml
 from craft_cli import emit, ArgumentParsingError
@@ -854,7 +854,7 @@ class PromoteBundleCommand(BaseCommand):
                 f"{from_channel.track} to {to_channel.track})"
             )
 
-        output_bundle: Optional[pathlib.Path] = parsed_args.output_bundle
+        output_bundle: pathlib.Path | None = parsed_args.output_bundle
         if output_bundle is not None and output_bundle.exists():
             if output_bundle.is_file() or output_bundle.is_symlink():
                 emit.verbose(f"Overwriting existing bundle file: {str(output_bundle)}")
@@ -898,7 +898,7 @@ class PromoteBundleCommand(BaseCommand):
             )
 
         store = Store(self.config.charmhub)
-        registered_names: List[Entity] = store.list_registered_names(include_collaborations=True)
+        registered_names: list[Entity] = store.list_registered_names(include_collaborations=True)
         name_map = {entity.name: entity for entity in registered_names}
 
         if bundle_name not in name_map:
@@ -938,8 +938,8 @@ class PromoteBundleCommand(BaseCommand):
             raise CraftError("Cannot find a bundle released to the given source channel.")
 
         # Get source channel charms
-        charm_revisions: Dict[str, int] = {}
-        charm_resources: Dict[str, List[str]] = collections.defaultdict(list)
+        charm_revisions: dict[str, int] = {}
+        charm_resources: dict[str, list[str]] = collections.defaultdict(list)
         error_charms = []
         for charm_name in charms:
             channel_map, *_ = store.list_releases(charm_name)

--- a/charmcraft/commands/store/client.py
+++ b/charmcraft/commands/store/client.py
@@ -19,7 +19,7 @@
 import os
 import platform
 from json.decoder import JSONDecodeError
-from typing import Any, Dict
+from typing import Any
 
 import craft_store
 import requests
@@ -59,7 +59,7 @@ class AnonymousClient:
         """Return a request.Response to a urlpath."""
         return self._http_client.request(method, self.api_base_url + urlpath, *args, **kwargs).text
 
-    def request_urlpath_json(self, method: str, urlpath: str, *args, **kwargs) -> Dict[str, Any]:
+    def request_urlpath_json(self, method: str, urlpath: str, *args, **kwargs) -> dict[str, Any]:
         """Return .json() from a request.Response to a urlpath."""
         response = self._http_client.request(method, self.api_base_url + urlpath, *args, **kwargs)
 
@@ -110,7 +110,7 @@ class Client(craft_store.StoreClient):
         """Return a request.Response to a urlpath."""
         return super().request(method, self.api_base_url + urlpath, *args, **kwargs).text
 
-    def request_urlpath_json(self, method: str, urlpath: str, *args, **kwargs) -> Dict[str, Any]:
+    def request_urlpath_json(self, method: str, urlpath: str, *args, **kwargs) -> dict[str, Any]:
         """Return .json() from a request.Response to a urlpath."""
         response = super().request(method, self.api_base_url + urlpath, *args, **kwargs)
 

--- a/charmcraft/commands/store/registry.py
+++ b/charmcraft/commands/store/registry.py
@@ -24,7 +24,7 @@ import json
 import os
 import tarfile
 import tempfile
-from typing import Any, Dict, Union
+from typing import Any
 from urllib.request import parse_http_list, parse_keqv_list
 
 import requests
@@ -50,7 +50,7 @@ CHUNK_SIZE = 2**20
 
 def assert_response_ok(
     response: requests.Response, expected_status: int = 200
-) -> Union[Dict[str, Any], None]:
+) -> dict[str, Any] | None:
     """Assert the response is ok."""
     if response.status_code != expected_status:
         ct = response.headers.get("Content-Type", "")
@@ -286,7 +286,7 @@ class LocalDockerdInterface:
     def __init__(self):
         self.session = requests_unixsocket.Session()
 
-    def get_image_info_from_id(self, image_id: str) -> Union[dict, None]:
+    def get_image_info_from_id(self, image_id: str) -> dict | None:
         """Get the info for a specific image using its id.
 
         Returns None to flag that the requested id was not found for any reason.
@@ -311,7 +311,7 @@ class LocalDockerdInterface:
             return None
         return None
 
-    def get_image_info_from_digest(self, digest: str) -> Union[dict, None]:
+    def get_image_info_from_digest(self, digest: str) -> dict | None:
         """Get the info for a specific image using its digest.
 
         Returns None to flag that the requested digest was not found for any reason.
@@ -396,7 +396,7 @@ class ImageHandler:
         # finally remove the temp filepath
         os.unlink(filepath)
 
-    def upload_from_local(self, image_info: Dict[str, Any]) -> Union[str, None]:
+    def upload_from_local(self, image_info: dict[str, Any]) -> str | None:
         """Upload the image from the local registry.
 
         Returns the new remote digest.

--- a/charmcraft/commands/store/store.py
+++ b/charmcraft/commands/store/store.py
@@ -21,7 +21,7 @@ import os
 import platform
 import time
 from functools import wraps
-from typing import Any, Dict, List, Literal, Optional, Tuple
+from typing import Any, Literal, Optional
 
 import craft_store
 from craft_cli import CraftError, emit
@@ -53,7 +53,7 @@ class Package:
     Deprecated in favour of implementation in craft-store.
     """
 
-    id: Optional[str]
+    id: str | None
     name: str
     type: Literal["charm", "bundle"]
 
@@ -66,9 +66,9 @@ class MacaroonInfo:
     """
 
     account: Account
-    channels: Optional[List[str]]
-    packages: Optional[List[Package]]
-    permissions: List[str]
+    channels: list[str] | None
+    packages: list[Package] | None
+    permissions: list[str]
 
 
 @dataclasses.dataclass(frozen=True)
@@ -106,7 +106,7 @@ class Uploaded:
     ok: bool
     status: int
     revision: int
-    errors: List[Error]
+    errors: list[Error]
 
 
 # XXX Facundo 2020-07-23: Need to do a massive rename to call `revno` to the "revision as
@@ -135,8 +135,8 @@ class Revision:
     version: Optional
     created_at: datetime.datetime
     status: str
-    errors: List[Error]
-    bases: List[Base]
+    errors: list[Error]
+    bases: list[Base]
 
 
 @dataclasses.dataclass(frozen=True)
@@ -174,7 +174,7 @@ class Release:
     revision: int
     channel: str
     expires_at: datetime.datetime
-    resources: List[Resource]
+    resources: list[Resource]
     base: Base
 
 
@@ -204,7 +204,7 @@ class Library:
     charm_name: str
     api: int
     patch: int
-    content: Optional[str]
+    content: str | None
     content_hash: str
 
 
@@ -242,7 +242,7 @@ def _build_errors(item):
     return [Error(message=e["message"], code=e["code"]) for e in (item["errors"] or [])]
 
 
-def _build_revision(item: Dict[str, Any]) -> Revision:
+def _build_revision(item: dict[str, Any]) -> Revision:
     """Build a Revision from a response item."""
     bases = [(None if base is None else Base(**base)) for base in item["bases"]]
     return Revision(
@@ -438,7 +438,7 @@ class Store:
         self._client.unregister_name(name)
 
     @_store_client_wrapper()
-    def list_registered_names(self, include_collaborations: bool) -> List[Entity]:
+    def list_registered_names(self, include_collaborations: bool) -> list[Entity]:
         """Return names registered by the authenticated user."""
         endpoint = "/v1/charm"
         if include_collaborations:
@@ -511,7 +511,7 @@ class Store:
         return [_build_revision(item) for item in response["revisions"]]
 
     @_store_client_wrapper()
-    def release(self, name: str, revision: int, channels: List[str], resources) -> Dict[str, Any]:
+    def release(self, name: str, revision: int, channels: list[str], resources) -> dict[str, Any]:
         """Release one or more revisions for a package."""
         endpoint = f"/v1/charm/{name}/releases"
         resources = [{"name": res.name, "revision": res.revision} for res in resources]
@@ -523,7 +523,7 @@ class Store:
         return self._client.request_urlpath_json("POST", endpoint, json=items)
 
     @_store_client_wrapper()
-    def list_releases(self, name: str) -> Tuple[List[Release], List[Channel], List[Revision]]:
+    def list_releases(self, name: str) -> tuple[list[Release], list[Channel], list[Revision]]:
         """List current releases for a package."""
         endpoint = f"/v1/charm/{name}/releases"
         response = self._client.request_urlpath_json("GET", endpoint)

--- a/charmcraft/config.py
+++ b/charmcraft/config.py
@@ -72,7 +72,6 @@ Object with the following properties:
 
 import datetime
 import pathlib
-from typing import Optional
 
 from charmcraft import const
 from charmcraft.env import (
@@ -83,7 +82,7 @@ from charmcraft.models.charmcraft import CharmcraftConfig, Project
 from charmcraft.utils import load_yaml
 
 
-def load(dirpath: Optional[str]) -> CharmcraftConfig:
+def load(dirpath: str | None) -> CharmcraftConfig:
     """Load the config from charmcraft.yaml in the indicated directory."""
     if dirpath is None:
         if is_charmcraft_running_in_managed_mode():

--- a/charmcraft/deprecations.py
+++ b/charmcraft/deprecations.py
@@ -23,7 +23,6 @@ When a new deprecation has occurred, write a Deprecation Notice for it here
 
 Then add that ID along with the deprecation title in the list below.
 """
-from typing import Dict
 
 from craft_cli import emit
 
@@ -31,7 +30,7 @@ from charmcraft.env import is_charmcraft_running_in_managed_mode
 
 # the message to show for each deprecation ID (this needs to be in sync with the
 # documentation)
-_DEPRECATION_MESSAGES: Dict[str, str] = {
+_DEPRECATION_MESSAGES: dict[str, str] = {
     # example of item in this structure when something is deprecated:
 }
 

--- a/charmcraft/env.py
+++ b/charmcraft/env.py
@@ -20,7 +20,6 @@
 import distutils.util
 import os
 import pathlib
-from typing import Optional
 
 import platformdirs
 
@@ -63,7 +62,7 @@ def get_managed_environment_project_path():
     return get_managed_environment_home_path() / "project"
 
 
-def get_managed_environment_snap_channel() -> Optional[str]:
+def get_managed_environment_snap_channel() -> str | None:
     """User-specified channel to use when installing Charmcraft snap from Snap Store.
 
     :returns: Channel string if specified, else None.

--- a/charmcraft/errors.py
+++ b/charmcraft/errors.py
@@ -16,7 +16,7 @@
 """Charmcraft error classes."""
 import io
 import pathlib
-from typing import Iterable, Mapping
+from collections.abc import Iterable, Mapping
 
 from craft_cli import CraftError
 

--- a/charmcraft/extensions/_utils.py
+++ b/charmcraft/extensions/_utils.py
@@ -18,13 +18,13 @@
 
 import copy
 from pathlib import Path
-from typing import Any, Dict, List, Set, Union, cast
+from typing import Any, cast
 
 from charmcraft.extensions.extension import Extension
 from charmcraft.extensions.registry import get_extension_class
 
 
-def apply_extensions(project_root: Path, yaml_data: Dict[str, Any]) -> Dict[str, Any]:
+def apply_extensions(project_root: Path, yaml_data: dict[str, Any]) -> dict[str, Any]:
     """Apply all extensions.
 
     :param dict yaml_data: Loaded, unprocessed charmcraft.yaml
@@ -32,7 +32,7 @@ def apply_extensions(project_root: Path, yaml_data: Dict[str, Any]) -> Dict[str,
     """
     # Don't modify the dict passed in
     yaml_data = copy.deepcopy(yaml_data)
-    declared_extensions: List[str] = cast(List[str], yaml_data.get("extensions", []))
+    declared_extensions: list[str] = cast(list[str], yaml_data.get("extensions", []))
     if not declared_extensions:
         return yaml_data
 
@@ -48,7 +48,7 @@ def apply_extensions(project_root: Path, yaml_data: Dict[str, Any]) -> Dict[str,
 
 
 def _apply_extension(
-    yaml_data: Dict[str, Any],
+    yaml_data: dict[str, Any],
     extension: Extension,
 ) -> None:
     # Apply the root components of the extension (if any)
@@ -78,8 +78,8 @@ def _apply_extension(
 
 
 def _apply_extension_property(
-    existing_property: Union[Dict, List], extension_property: Union[Dict, List]
-) -> Union[Dict, List]:
+    existing_property: dict | list, extension_property: dict | list
+) -> dict | list:
     if existing_property:
         # If the property is not scalar, merge them
         if isinstance(existing_property, list) and isinstance(extension_property, list):
@@ -102,10 +102,10 @@ def _apply_extension_property(
     return extension_property
 
 
-def _remove_list_duplicates(seq: List[str]) -> List[str]:
+def _remove_list_duplicates(seq: list[str]) -> list[str]:
     """De-dupe string list maintaining ordering."""
-    seen: Set[str] = set()
-    deduped: List[str] = []
+    seen: set[str] = set()
+    deduped: list[str] = []
 
     for item in seq:
         if item not in seen:

--- a/charmcraft/extensions/extension.py
+++ b/charmcraft/extensions/extension.py
@@ -19,8 +19,9 @@
 import abc
 import os
 import sys
+from collections.abc import Sequence
 from pathlib import Path
-from typing import Any, Dict, Final, List, Optional, Sequence, Tuple, final
+from typing import Any, Final, final
 
 from craft_cli import emit
 
@@ -40,32 +41,32 @@ class Extension(abc.ABC):
         self,
         *,
         project_root: Path,
-        yaml_data: Dict[str, Any],
+        yaml_data: dict[str, Any],
     ) -> None:
         """Create a new Extension."""
         self.project_root = project_root
-        self.yaml_data: Final[Dict[str, Any]] = yaml_data
+        self.yaml_data: Final[dict[str, Any]] = yaml_data
 
     @staticmethod
     @abc.abstractmethod
-    def get_supported_bases() -> List[Tuple[str, ...]]:
+    def get_supported_bases() -> list[tuple[str, ...]]:
         """Return a list of tuple of supported bases."""
 
     @staticmethod
     @abc.abstractmethod
-    def is_experimental(base: Optional[Tuple[str, ...]]) -> bool:
+    def is_experimental(base: tuple[str, ...] | None) -> bool:
         """Return whether or not this extension is unstable for given base."""
 
     @abc.abstractmethod
-    def get_root_snippet(self) -> Dict[str, Any]:
+    def get_root_snippet(self) -> dict[str, Any]:
         """Return the root snippet to apply."""
 
     @abc.abstractmethod
-    def get_part_snippet(self) -> Dict[str, Any]:
+    def get_part_snippet(self) -> dict[str, Any]:
         """Return the part snippet to apply to existing parts."""
 
     @abc.abstractmethod
-    def get_parts_snippet(self) -> Dict[str, Any]:
+    def get_parts_snippet(self) -> dict[str, Any]:
         """Return the parts to add to parts."""
 
     @final
@@ -79,7 +80,7 @@ class Extension(abc.ABC):
             # There is nothing to validate, the extension will set the preferred base.
             return
 
-        bases: List = self.yaml_data["bases"]
+        bases: list = self.yaml_data["bases"]
 
         for base in bases:
             for build_on in base.get("build-on", []):

--- a/charmcraft/extensions/registry.py
+++ b/charmcraft/extensions/registry.py
@@ -16,15 +16,14 @@
 
 """Extension registry."""
 
-from typing import Dict, List
 
 from charmcraft import errors
 from charmcraft.extensions.extension import Extension
 
-_EXTENSIONS: Dict[str, Extension] = {}
+_EXTENSIONS: dict[str, Extension] = {}
 
 
-def get_extension_names() -> List[str]:
+def get_extension_names() -> list[str]:
     """Obtain a extension class given the name.
 
     :param name: The extension name.

--- a/charmcraft/format.py
+++ b/charmcraft/format.py
@@ -16,8 +16,6 @@
 
 """Reformat pydantic errors."""
 
-from typing import Tuple
-
 from charmcraft import const
 
 
@@ -48,7 +46,7 @@ def format_pydantic_error_message(msg: str) -> str:
     return msg.replace("str type expected", "string type expected")
 
 
-def printable_field_location_split(location: str) -> Tuple[str, str]:
+def printable_field_location_split(location: str) -> tuple[str, str]:
     """Return split field location.
 
     If top-level, location is returned as unquoted "top-level".

--- a/charmcraft/instrum.py
+++ b/charmcraft/instrum.py
@@ -19,7 +19,7 @@
 import json
 import uuid
 from time import time
-from typing import Any, Dict
+from typing import Any
 
 # the base time of the started process: all the recorded times will be relative to
 # this one (they will be easier to read and simple to understand the time passed since
@@ -40,7 +40,7 @@ class _Measurements:
         # id and each value holds all it info
         self.measurements = {}
 
-    def start(self, msg: str, extra_info: Dict[str, Any]):
+    def start(self, msg: str, extra_info: dict[str, Any]):
         """Start a measurement."""
         this_id = uuid.uuid4().hex
         parent_id = self.parents[-1]
@@ -126,7 +126,7 @@ class Timer:
             ...
     """
 
-    def __init__(self, msg: str, **extra_info: Dict[str, Any]):
+    def __init__(self, msg: str, **extra_info: dict[str, Any]):
         self.msg = msg
         self.extra_info = extra_info
         self.measurement_id = None
@@ -138,7 +138,7 @@ class Timer:
     def __exit__(self, *exc):
         _measurements.end(self.measurement_id)
 
-    def mark(self, msg: str, **extra_info: Dict[str, Any]):
+    def mark(self, msg: str, **extra_info: dict[str, Any]):
         """Mark middle measurements inside a contextual one."""
         # close the previous one, and start a new measure
         _measurements.end(self.measurement_id)

--- a/charmcraft/jujuignore.py
+++ b/charmcraft/jujuignore.py
@@ -154,7 +154,7 @@ class JujuIgnore:
     """Track a set of ignore patterns from a .jujuignore file."""
 
     def __init__(self, patterns: typing.Iterable[str]):
-        self._matchers: typing.List[_Matcher] = []
+        self._matchers: list[_Matcher] = []
         self._compile_from(patterns)
 
     def extend_patterns(self, patterns: typing.Iterable[str]) -> None:

--- a/charmcraft/linters.py
+++ b/charmcraft/linters.py
@@ -20,7 +20,7 @@ import ast
 import os
 import pathlib
 import shlex
-from typing import Generator, List, Type, Union
+from collections.abc import Generator
 
 import yaml
 
@@ -32,7 +32,7 @@ from charmcraft.models.lint import CheckResult, CheckType, LintResult
 BASE_DOCS_URL = "https://juju.is/docs/sdk/charmcraft-analyzers-and-linters"
 
 
-def get_entrypoint_from_dispatch(basedir: pathlib.Path) -> Union[pathlib.Path, None]:
+def get_entrypoint_from_dispatch(basedir: pathlib.Path) -> pathlib.Path | None:
     """Verify if the charm has a dispatch file pointing to a Python entrypoint.
 
     :returns: the entrypoint path if all succeeds, None otherwise.
@@ -55,7 +55,7 @@ def get_entrypoint_from_dispatch(basedir: pathlib.Path) -> Union[pathlib.Path, N
     return basedir / entrypoint_str
 
 
-def check_dispatch_with_python_entrypoint(basedir: pathlib.Path) -> Union[pathlib.Path, None]:
+def check_dispatch_with_python_entrypoint(basedir: pathlib.Path) -> pathlib.Path | None:
     """Verify if the charm has a dispatch file pointing to a Python entrypoint.
 
     :returns: the entrypoint path if all succeeds, None otherwise.
@@ -162,7 +162,7 @@ class Framework(AttributeChecker):
             return None
         return self.result_texts[self.result]
 
-    def _get_imports(self, filepath: pathlib.Path) -> Generator[List[str], None, None]:
+    def _get_imports(self, filepath: pathlib.Path) -> Generator[list[str], None, None]:
         """Parse a Python filepath and yield its imports.
 
         If the file does not exist or cannot be parsed, return empty. Otherwise
@@ -373,7 +373,7 @@ class Entrypoint(Linter):
 
 # all checkers to run; the order here is important, as some checkers depend on the
 # results from others
-CHECKERS: List[Type[BaseChecker]] = [
+CHECKERS: list[type[BaseChecker]] = [
     Language,
     JujuActions,
     JujuConfig,
@@ -388,7 +388,7 @@ def analyze(
     basedir: pathlib.Path,
     *,
     override_ignore_config: bool = False,
-) -> List[CheckResult]:
+) -> list[CheckResult]:
     """Run all checkers and linters."""
     all_results = []
     for cls in CHECKERS:

--- a/charmcraft/metafiles/__init__.py
+++ b/charmcraft/metafiles/__init__.py
@@ -17,7 +17,7 @@
 """Submodule for handling the all extra yaml files."""
 
 import pathlib
-from typing import Any, Dict
+from typing import Any
 
 import yaml
 
@@ -26,7 +26,7 @@ from craft_cli import emit
 __all__ = ["actions", "manifest", "metadata", "config", "read_yaml"]
 
 
-def read_yaml(yaml_file_path: pathlib.Path) -> Dict[str, Any]:
+def read_yaml(yaml_file_path: pathlib.Path) -> dict[str, Any]:
     """Parse yaml file.
 
     :returns: the YAML decoded yaml content

--- a/charmcraft/metafiles/actions.py
+++ b/charmcraft/metafiles/actions.py
@@ -20,7 +20,7 @@ import contextlib
 import logging
 import pathlib
 import shutil
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 import pydantic
 import yaml
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def parse_actions_yaml(charm_dir: pathlib.Path, allow_broken=False) -> Optional[JujuActions]:
+def parse_actions_yaml(charm_dir: pathlib.Path, allow_broken=False) -> JujuActions | None:
     """Parse project's actions.yaml.
 
     :param charm_dir: Directory to read actions.yaml from.
@@ -70,7 +70,7 @@ def parse_actions_yaml(charm_dir: pathlib.Path, allow_broken=False) -> Optional[
 def create_actions_yaml(
     basedir: pathlib.Path,
     charmcraft_config: "CharmcraftConfig",
-) -> Optional[pathlib.Path]:
+) -> pathlib.Path | None:
     """Create actions.yaml in basedir for given project configuration.
 
     :param basedir: Directory to create Charm in.

--- a/charmcraft/metafiles/config.py
+++ b/charmcraft/metafiles/config.py
@@ -20,7 +20,7 @@ import contextlib
 import logging
 import pathlib
 import shutil
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 import pydantic
 import yaml
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def parse_config_yaml(charm_dir: pathlib.Path, allow_broken=False) -> Optional[JujuConfig]:
+def parse_config_yaml(charm_dir: pathlib.Path, allow_broken=False) -> JujuConfig | None:
     """Parse project's config.yaml.
 
     :param charm_dir: Directory to read config.yaml from.
@@ -70,7 +70,7 @@ def parse_config_yaml(charm_dir: pathlib.Path, allow_broken=False) -> Optional[J
 def create_config_yaml(
     basedir: pathlib.Path,
     charmcraft_config: "CharmcraftConfig",
-) -> Optional[pathlib.Path]:
+) -> pathlib.Path | None:
     """Create actions.yaml in basedir for given project configuration.
 
     :param basedir: Directory to create Charm in.

--- a/charmcraft/metafiles/manifest.py
+++ b/charmcraft/metafiles/manifest.py
@@ -21,7 +21,7 @@ import json
 import logging
 import os
 import pathlib
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 import yaml
 from craft_cli import CraftError
@@ -36,8 +36,8 @@ logger = logging.getLogger(__name__)
 def create_manifest(
     basedir: pathlib.Path,
     started_at: datetime.datetime,
-    bases_config: Optional[charmcraft.models.charmcraft.BasesConfiguration],
-    linting_results: List[charmcraft.linters.CheckResult],
+    bases_config: charmcraft.models.charmcraft.BasesConfiguration | None,
+    linting_results: list[charmcraft.linters.CheckResult],
 ) -> pathlib.Path:
     """Create manifest.yaml in basedir for given base configuration.
 
@@ -50,7 +50,7 @@ def create_manifest(
 
     :returns: Path to created manifest.yaml.
     """
-    content: Dict[str, Any] = {
+    content: dict[str, Any] = {
         "charmcraft-version": charmcraft.__version__,
         "charmcraft-started-at": started_at.isoformat() + "Z",
     }

--- a/charmcraft/metafiles/metadata.py
+++ b/charmcraft/metafiles/metadata.py
@@ -20,7 +20,7 @@ import contextlib
 import logging
 import pathlib
 import shutil
-from typing import TYPE_CHECKING, Any, Dict
+from typing import TYPE_CHECKING, Any
 
 import pydantic
 import yaml
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def read_metadata_yaml(charm_dir: pathlib.Path) -> Dict[str, Any]:
+def read_metadata_yaml(charm_dir: pathlib.Path) -> dict[str, Any]:
     """Parse project's metadata.yaml.
 
     :returns: the YAML decoded metadata.yaml content

--- a/charmcraft/models/actions.py
+++ b/charmcraft/models/actions.py
@@ -18,7 +18,6 @@
 
 import keyword
 import re
-from typing import Dict, Optional
 
 import pydantic
 
@@ -32,7 +31,7 @@ class JujuActions(ModelConfigDefaults):
     """
 
     _action_name_regex = re.compile(r"^[a-zA-Z_][a-zA-Z0-9-_]*$")
-    actions: Optional[Dict[str, Dict]]
+    actions: dict[str, dict] | None
 
     @pydantic.validator("actions")
     def validate_actions(cls, actions):

--- a/charmcraft/models/charmcraft.py
+++ b/charmcraft/models/charmcraft.py
@@ -18,7 +18,7 @@
 import datetime
 import os
 import pathlib
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import Any, Literal
 
 import pydantic
 from craft_cli import CraftError
@@ -55,7 +55,7 @@ class Base(ModelConfigDefaults):
 
     name: pydantic.StrictStr
     channel: pydantic.StrictStr
-    architectures: List[pydantic.StrictStr] = [get_host_architecture()]
+    architectures: list[pydantic.StrictStr] = [get_host_architecture()]
 
 
 class BasesConfiguration(
@@ -64,8 +64,8 @@ class BasesConfiguration(
 ):
     """Definition of build-on/run-on combinations."""
 
-    build_on: List[Base]
-    run_on: List[Base]
+    build_on: list[Base]
+    run_on: list[Base]
 
 
 class Project(ModelConfigDefaults):
@@ -84,8 +84,8 @@ class Project(ModelConfigDefaults):
 class Ignore(ModelConfigDefaults):
     """Definition of `analysis.ignore` configuration."""
 
-    attributes: List[AttributeName] = []
-    linters: List[LinterName] = []
+    attributes: list[AttributeName] = []
+    linters: list[LinterName] = []
 
 
 class AnalysisConfig(ModelConfigDefaults, allow_population_by_field_name=True):
@@ -97,11 +97,11 @@ class AnalysisConfig(ModelConfigDefaults, allow_population_by_field_name=True):
 class Links(ModelConfigDefaults):
     """Definition of `links` in metadata."""
 
-    contact: Optional[Union[pydantic.StrictStr, List[pydantic.StrictStr]]]
-    documentation: Optional[pydantic.AnyHttpUrl]
-    issues: Optional[Union[pydantic.AnyHttpUrl, List[pydantic.AnyHttpUrl]]]
-    source: Optional[Union[pydantic.AnyHttpUrl, List[pydantic.AnyHttpUrl]]]
-    website: Optional[Union[pydantic.AnyHttpUrl, List[pydantic.AnyHttpUrl]]]
+    contact: pydantic.StrictStr | list[pydantic.StrictStr] | None
+    documentation: pydantic.AnyHttpUrl | None
+    issues: pydantic.AnyHttpUrl | list[pydantic.AnyHttpUrl] | None
+    source: pydantic.AnyHttpUrl | list[pydantic.AnyHttpUrl] | None
+    website: pydantic.AnyHttpUrl | list[pydantic.AnyHttpUrl] | None
 
 
 class CharmcraftConfig(
@@ -117,28 +117,28 @@ class CharmcraftConfig(
     metadata_legacy: bool = False
 
     type: Literal["bundle", "charm"]
-    name: Optional[pydantic.StrictStr]
-    summary: Optional[pydantic.StrictStr]
-    description: Optional[pydantic.StrictStr]
+    name: pydantic.StrictStr | None
+    summary: pydantic.StrictStr | None
+    description: pydantic.StrictStr | None
     charmhub: CharmhubConfig = CharmhubConfig()
-    parts: Optional[Dict[str, Any]]
-    bases: Optional[List[BasesConfiguration]]
+    parts: dict[str, Any] | None
+    bases: list[BasesConfiguration] | None
     analysis: AnalysisConfig = AnalysisConfig()
-    actions: Optional[JujuActions]
-    assumes: Optional[List[Union[str, Dict[str, Union[List, Dict]]]]]
-    containers: Optional[Dict[str, Any]]
-    devices: Optional[Dict[str, Any]]
-    title: Optional[pydantic.StrictStr]
-    extra_bindings: Optional[Dict[str, Any]]
-    peers: Optional[Dict[str, Any]]
-    provides: Optional[Dict[str, Any]]
-    requires: Optional[Dict[str, Any]]
-    resources: Optional[Dict[str, Any]]
-    storage: Optional[Dict[str, Any]]
-    subordinate: Optional[bool]
-    terms: Optional[List[str]]
-    links: Optional[Links]
-    config: Optional[JujuConfig]
+    actions: JujuActions | None
+    assumes: list[str | dict[str, list | dict]] | None
+    containers: dict[str, Any] | None
+    devices: dict[str, Any] | None
+    title: pydantic.StrictStr | None
+    extra_bindings: dict[str, Any] | None
+    peers: dict[str, Any] | None
+    provides: dict[str, Any] | None
+    requires: dict[str, Any] | None
+    resources: dict[str, Any] | None
+    storage: dict[str, Any] | None
+    subordinate: bool | None
+    terms: list[str] | None
+    links: Links | None
+    config: JujuConfig | None
 
     @pydantic.validator("name", pre=True, always=True)
     def validate_name(cls, name, values):
@@ -255,7 +255,7 @@ class CharmcraftConfig(
             return JujuConfig.parse_obj(config)
 
     @classmethod
-    def expand_short_form_bases(cls, bases: List[Dict[str, Any]]) -> None:
+    def expand_short_form_bases(cls, bases: list[dict[str, Any]]) -> None:
         """Expand short-form base configuration into long-form in-place."""
         for index, base in enumerate(bases):
             # Skip if already long-form. Account for common typos in case user
@@ -279,7 +279,7 @@ class CharmcraftConfig(
             base["run-on"] = [converted_base.dict()]
 
     @classmethod
-    def unmarshal(cls, obj: Dict[str, Any], project: Project):
+    def unmarshal(cls, obj: dict[str, Any], project: Project):
         """Unmarshal object with necessary translations and error handling.
 
         (1) Perform any necessary translations.
@@ -349,7 +349,7 @@ class CharmcraftConfig(
             raise CraftError(format_pydantic_errors(error.errors()))
 
     @classmethod
-    def schema(cls, **kwargs) -> Dict[str, Any]:
+    def schema(cls, **kwargs) -> dict[str, Any]:
         """Perform any schema fixups required to hide internal details."""
         schema = super().schema(**kwargs)
 

--- a/charmcraft/models/config.py
+++ b/charmcraft/models/config.py
@@ -16,7 +16,6 @@
 
 """Charmcraft Juju Config pydantic model."""
 
-from typing import Dict, Optional
 
 import pydantic
 
@@ -29,7 +28,7 @@ class JujuConfig(ModelConfigDefaults):
     See also: https://juju.is/docs/sdk/config
     """
 
-    options: Optional[Dict[str, Dict]]
+    options: dict[str, dict] | None
 
     @pydantic.validator("options", pre=True)
     def validate_actions(cls, options):

--- a/charmcraft/models/extension.py
+++ b/charmcraft/models/extension.py
@@ -16,7 +16,6 @@
 
 """Extension models."""
 
-from typing import Dict, List, Tuple
 
 from charmcraft.models.basic import ModelConfigDefaults
 
@@ -25,9 +24,9 @@ class ExtensionModel(ModelConfigDefaults, frozen=True):
     """Extension model for presentation."""
 
     name: str
-    bases: List[Tuple[str, str]]
+    bases: list[tuple[str, str]]
 
-    def marshal(self) -> Dict[str, str]:
+    def marshal(self) -> dict[str, str]:
         """Marshal model into a dictionary for presentation."""
         return {
             "Extension name": self.name,

--- a/charmcraft/models/metadata.py
+++ b/charmcraft/models/metadata.py
@@ -16,7 +16,7 @@
 
 """Charmcraft metadata pydantic model."""
 
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
 
 import pydantic
 from craft_cli import CraftError
@@ -42,26 +42,26 @@ class CharmMetadataLegacy(
     name: pydantic.StrictStr
     summary: pydantic.StrictStr
     description: pydantic.StrictStr
-    assumes: Optional[List[Union[str, Dict[str, Union[List, Dict]]]]]
-    containers: Optional[Dict[str, Any]]
-    devices: Optional[Dict[str, Any]]
-    display_name: Optional[pydantic.StrictStr]
-    docs: Optional[pydantic.AnyHttpUrl]
-    extra_bindings: Optional[Dict[str, Any]]
-    issues: Optional[Union[pydantic.AnyHttpUrl, List[pydantic.AnyHttpUrl]]]
-    maintainers: Optional[List[pydantic.StrictStr]]
-    peers: Optional[Dict[str, Any]]
-    provides: Optional[Dict[str, Any]]
-    requires: Optional[Dict[str, Any]]
-    resources: Optional[Dict[str, Any]]
-    source: Optional[Union[pydantic.AnyHttpUrl, List[pydantic.AnyHttpUrl]]]
-    storage: Optional[Dict[str, Any]]
-    subordinate: Optional[bool]
-    terms: Optional[List[pydantic.StrictStr]]
-    website: Optional[Union[pydantic.AnyHttpUrl, List[pydantic.AnyHttpUrl]]]
+    assumes: list[str | dict[str, list | dict]] | None
+    containers: dict[str, Any] | None
+    devices: dict[str, Any] | None
+    display_name: pydantic.StrictStr | None
+    docs: pydantic.AnyHttpUrl | None
+    extra_bindings: dict[str, Any] | None
+    issues: pydantic.AnyHttpUrl | list[pydantic.AnyHttpUrl] | None
+    maintainers: list[pydantic.StrictStr] | None
+    peers: dict[str, Any] | None
+    provides: dict[str, Any] | None
+    requires: dict[str, Any] | None
+    resources: dict[str, Any] | None
+    source: pydantic.AnyHttpUrl | list[pydantic.AnyHttpUrl] | None
+    storage: dict[str, Any] | None
+    subordinate: bool | None
+    terms: list[pydantic.StrictStr] | None
+    website: pydantic.AnyHttpUrl | list[pydantic.AnyHttpUrl] | None
 
     @classmethod
-    def unmarshal(cls, obj: Dict[str, Any]):
+    def unmarshal(cls, obj: dict[str, Any]):
         """Unmarshal object with necessary translations and error handling.
 
         :returns: valid CharmMetadataLegacy object.
@@ -96,10 +96,10 @@ class BundleMetadataLegacy(
     """
 
     name: pydantic.StrictStr
-    description: Optional[pydantic.StrictStr]
+    description: pydantic.StrictStr | None
 
     @classmethod
-    def unmarshal(cls, obj: Dict[str, Any]):
+    def unmarshal(cls, obj: dict[str, Any]):
         """Unmarshal object with necessary translations and error handling.
 
         :returns: valid BundleMetadataLegacy.

--- a/charmcraft/package.py
+++ b/charmcraft/package.py
@@ -21,7 +21,7 @@ import shutil
 import subprocess
 import tempfile
 import zipfile
-from typing import Collection, Dict, List, Mapping, Optional, Sequence
+from collections.abc import Collection, Mapping, Sequence
 
 import craft_parts
 import yaml
@@ -77,7 +77,7 @@ def format_charm_file_name(charm_name: str, bases_config: BasesConfiguration) ->
     return "_".join([charm_name, _format_bases_config(bases_config)]) + ".charm"
 
 
-def launch_shell(*, cwd: Optional[pathlib.Path] = None) -> None:
+def launch_shell(*, cwd: pathlib.Path | None = None) -> None:
     """Launch a user shell for debugging environment.
 
     :param cwd: Working directory to start user in.
@@ -257,8 +257,8 @@ class Builder:
 
     @charmcraft.instrum.Timer("Builder run")
     def run(
-        self, bases_indices: Optional[List[int]] = None, destructive_mode: bool = False
-    ) -> List[str]:
+        self, bases_indices: list[int] | None = None, destructive_mode: bool = False
+    ) -> list[str]:
         """Run build process.
 
         In managed-mode or destructive-mode, build for each bases configuration
@@ -268,7 +268,7 @@ class Builder:
 
         :returns: List of charm files created.
         """
-        charms: List[str] = []
+        charms: list[str] = []
 
         managed_mode = charmcraft.env.is_charmcraft_running_in_managed_mode()
         if not managed_mode and not destructive_mode:
@@ -445,7 +445,7 @@ class Builder:
         zipfh.close()
         return zipname
 
-    def _get_charm_pack_args(self, base_indeces: List[str], destructive_mode: bool) -> List[str]:
+    def _get_charm_pack_args(self, base_indeces: list[str], destructive_mode: bool) -> list[str]:
         """Get the arguments for a charmcraft pack subprocess to run."""
         args = ["charmcraft", "pack", "--verbose"]
         if destructive_mode:
@@ -459,8 +459,8 @@ class Builder:
     def pack_bundle(
         self,
         *,
-        charms: Dict[str, pathlib.Path],
-        base_indeces: List[str],
+        charms: dict[str, pathlib.Path],
+        base_indeces: list[str],
         destructive_mode: bool,
         overwrite: bool = False,
     ) -> OutputFiles:
@@ -523,7 +523,7 @@ class Builder:
 def _subprocess_pack_charms(
     charms: Mapping[str, pathlib.Path],
     command_args: Collection[str],
-) -> Dict[str, pathlib.Path]:
+) -> dict[str, pathlib.Path]:
     """Pack the given charms for a bundle in subprocesses.
 
     :param command_args: The initial arguments

--- a/charmcraft/parts/__init__.py
+++ b/charmcraft/parts/__init__.py
@@ -16,7 +16,7 @@
 
 """Craft-parts setup, lifecycle and plugins."""
 
-from typing import Any, Dict
+from typing import Any
 
 from craft_parts import plugins
 from craft_parts.parts import PartSpec
@@ -42,7 +42,7 @@ def setup_parts():
     plugins.register({"charm": CharmPlugin, "bundle": BundlePlugin, "reactive": ReactivePlugin})
 
 
-def process_part_config(data: Dict[str, Any]) -> Dict[str, Any]:
+def process_part_config(data: dict[str, Any]) -> dict[str, Any]:
     """Validate and fill the given part data against/with common and plugin models.
 
     :param data: The part data to use.

--- a/charmcraft/parts/bundle.py
+++ b/charmcraft/parts/bundle.py
@@ -15,7 +15,7 @@
 # For further info, check https://github.com/canonical/charmcraft
 """Bundle plugin for craft-parts."""
 import sys
-from typing import Any, Dict, List, Set
+from typing import Any
 
 from craft_parts import plugins
 
@@ -26,7 +26,7 @@ class BundlePluginProperties(plugins.PluginProperties, plugins.PluginModel):
     source: str
 
     @classmethod
-    def unmarshal(cls, data: Dict[str, Any]):
+    def unmarshal(cls, data: dict[str, Any]):
         """Populate bundle properties from the part specification.
 
         :param data: A dictionary containing part properties.
@@ -51,19 +51,19 @@ class BundlePlugin(plugins.Plugin):
     properties_class = BundlePluginProperties
 
     @classmethod
-    def get_build_snaps(cls) -> Set[str]:
+    def get_build_snaps(cls) -> set[str]:
         """Return a set of required snaps to install in the build environment."""
         return set()
 
-    def get_build_packages(self) -> Set[str]:
+    def get_build_packages(self) -> set[str]:
         """Return a set of required packages to install in the build environment."""
         return set()
 
-    def get_build_environment(self) -> Dict[str, str]:
+    def get_build_environment(self) -> dict[str, str]:
         """Return a dictionary with the environment to use in the build step."""
         return {}
 
-    def get_build_commands(self) -> List[str]:
+    def get_build_commands(self) -> list[str]:
         """Return a list of commands to run during the build step."""
         install_dir = self._part_info.part_install_dir
         if sys.platform == "linux":

--- a/charmcraft/parts/charm.py
+++ b/charmcraft/parts/charm.py
@@ -20,7 +20,7 @@ import re
 import shlex
 import sys
 from contextlib import suppress
-from typing import Any, Dict, List, Optional, Set, cast
+from typing import Any, cast
 
 import pydantic
 from craft_parts import Step, callbacks, plugins
@@ -43,9 +43,9 @@ class CharmPluginProperties(plugins.PluginProperties, plugins.PluginModel):
 
     source: str
     charm_entrypoint: str = "src/charm.py"
-    charm_binary_python_packages: List[str] = []
-    charm_python_packages: List[str] = []
-    charm_requirements: List[str] = []
+    charm_binary_python_packages: list[str] = []
+    charm_python_packages: list[str] = []
+    charm_requirements: list[str] = []
     charm_strict_dependencies: bool = False
     """Whether to select strict dependencies only.
 
@@ -105,7 +105,7 @@ class CharmPluginProperties(plugins.PluginProperties, plugins.PluginModel):
 
     @pydantic.validator("charm_strict_dependencies")
     def validate_strict_dependencies(
-        cls, charm_strict_dependencies: bool, values: Dict[str, Any]
+        cls, charm_strict_dependencies: bool, values: dict[str, Any]
     ) -> bool:
         """Validate basic requirements if strict dependencies are enabled.
 
@@ -152,7 +152,7 @@ class CharmPluginProperties(plugins.PluginProperties, plugins.PluginModel):
         return charm_strict_dependencies
 
     @classmethod
-    def unmarshal(cls, data: Dict[str, Any]):
+    def unmarshal(cls, data: dict[str, Any]):
         """Populate charm properties from the part specification.
 
         :param data: A dictionary containing part properties.
@@ -208,11 +208,11 @@ class CharmPlugin(plugins.Plugin):
     properties_class = CharmPluginProperties
 
     @classmethod
-    def get_build_snaps(cls) -> Set[str]:
+    def get_build_snaps(cls) -> set[str]:
         """Return a set of required snaps to install in the build environment."""
         return set()
 
-    def get_build_packages(self) -> Set[str]:
+    def get_build_packages(self) -> set[str]:
         """Return a set of required packages to install in the build environment."""
         if platform.is_deb_based():
             return {
@@ -263,7 +263,7 @@ class CharmPlugin(plugins.Plugin):
         else:
             return set()
 
-    def get_build_environment(self) -> Dict[str, str]:
+    def get_build_environment(self) -> dict[str, str]:
         """Return a dictionary with the environment to use in the build step."""
         os_special_paths = self._get_os_special_priority_paths()
         if os_special_paths:
@@ -271,7 +271,7 @@ class CharmPlugin(plugins.Plugin):
 
         return {}
 
-    def get_build_commands(self) -> List[str]:
+    def get_build_commands(self) -> list[str]:
         """Return a list of commands to run during the build step."""
         options = cast(CharmPluginProperties, self._options)
 
@@ -326,7 +326,7 @@ class CharmPlugin(plugins.Plugin):
 
         return commands
 
-    def _get_strict_dependencies_parameters(self) -> List[str]:
+    def _get_strict_dependencies_parameters(self) -> list[str]:
         """Get the parameters to pass to the charm builder if strict dependencies are enabled."""
         options = cast(CharmPluginProperties, self._options)
         return [
@@ -335,7 +335,7 @@ class CharmPlugin(plugins.Plugin):
             *(f"--requirement={reqs}" for reqs in options.charm_requirements),
         ]
 
-    def _get_legacy_dependencies_parameters(self) -> List[str]:
+    def _get_legacy_dependencies_parameters(self) -> list[str]:
         """Get the parameters to pass to the charm builder with strict dependencies disabled."""
         options = cast(CharmPluginProperties, self._options)
         parameters = []
@@ -376,7 +376,7 @@ class CharmPlugin(plugins.Plugin):
         """Collect metrics left by charm_builder.py."""
         instrum.merge_from(env.get_charm_builder_metrics_path())
 
-    def _get_os_special_priority_paths(self) -> Optional[str]:
+    def _get_os_special_priority_paths(self) -> str | None:
         """Return a str of PATH for special OS."""
         with suppress(OsReleaseIdError, OsReleaseVersionIdError):
             os_release = os_utils.OsRelease()

--- a/charmcraft/parts/lifecycle.py
+++ b/charmcraft/parts/lifecycle.py
@@ -20,7 +20,7 @@ PENDING DEPRECATION: we're moving this to a craft-application LifecycleService
 import os
 import pathlib
 import shlex
-from typing import Any, Dict, List
+from typing import Any
 
 from craft_cli import CraftError, emit
 from craft_parts import LifecycleManager, PartsError, Step
@@ -41,12 +41,12 @@ class PartsLifecycle:
 
     def __init__(
         self,
-        all_parts: Dict[str, Any],
+        all_parts: dict[str, Any],
         *,
         work_dir: pathlib.Path,
         project_dir: pathlib.Path,
         project_name: str,
-        ignore_local_sources: List[str],
+        ignore_local_sources: list[str],
     ):
         self._all_parts = all_parts.copy()
         self._project_dir = project_dir

--- a/charmcraft/parts/reactive.py
+++ b/charmcraft/parts/reactive.py
@@ -19,7 +19,7 @@ import shlex
 import subprocess
 import sys
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set, cast
+from typing import Any, cast
 
 from craft_parts import plugins
 from craft_parts.errors import PluginEnvironmentValidationError
@@ -29,10 +29,10 @@ class ReactivePluginProperties(plugins.PluginProperties, plugins.PluginModel):
     """Properties used to pack reactive charms using charm-tools."""
 
     source: str
-    reactive_charm_build_arguments: List[str] = []
+    reactive_charm_build_arguments: list[str] = []
 
     @classmethod
-    def unmarshal(cls, data: Dict[str, Any]):
+    def unmarshal(cls, data: dict[str, Any]):
         """Populate reactive plugin properties from the part specification.
 
         :param data: A dictionary containing part properties.
@@ -54,7 +54,7 @@ class ReactivePluginEnvironmentValidator(plugins.validator.PluginEnvironmentVali
     :param env: A string containing the build step environment setup.
     """
 
-    def validate_environment(self, *, part_dependencies: Optional[List[str]] = None):
+    def validate_environment(self, *, part_dependencies: list[str] | None = None):
         """Ensure the environment contains dependencies needed by the plugin.
 
         :param part_dependencies: A list of the parts this part depends on.
@@ -108,19 +108,19 @@ class ReactivePlugin(plugins.Plugin):
     validator_class = ReactivePluginEnvironmentValidator
 
     @classmethod
-    def get_build_snaps(cls) -> Set[str]:
+    def get_build_snaps(cls) -> set[str]:
         """Return a set of required snaps to install in the build environment."""
         return set()
 
-    def get_build_packages(self) -> Set[str]:
+    def get_build_packages(self) -> set[str]:
         """Return a set of required packages to install in the build environment."""
         return set()
 
-    def get_build_environment(self) -> Dict[str, str]:
+    def get_build_environment(self) -> dict[str, str]:
         """Return a dictionary with the environment to use in the build step."""
         return {}
 
-    def get_build_commands(self) -> List[str]:
+    def get_build_commands(self) -> list[str]:
         """Return a list of commands to run during the build step."""
         options = cast(ReactivePluginProperties, self._options)
 
@@ -142,7 +142,7 @@ class ReactivePlugin(plugins.Plugin):
         return [" ".join(shlex.quote(i) for i in command)]
 
 
-def run_charm_tool(args: List[str]):
+def run_charm_tool(args: list[str]):
     """Run the charm tool, log and check exit code."""
     result_classification = "SUCCESS"
     exc = None
@@ -164,7 +164,7 @@ def run_charm_tool(args: List[str]):
 
 
 def build(
-    *, charm_name: str, build_dir: Path, install_dir: Path, charm_build_arguments: List[str]
+    *, charm_name: str, build_dir: Path, install_dir: Path, charm_build_arguments: list[str]
 ):
     """Build a charm using charm tool.
 

--- a/charmcraft/providers.py
+++ b/charmcraft/providers.py
@@ -20,7 +20,7 @@ import enum
 import os
 import pathlib
 import sys
-from typing import Dict, List, NamedTuple, Optional, Tuple, Union
+from typing import NamedTuple
 
 from craft_cli import CraftError, emit
 from craft_providers import Base, Executor, Provider, ProviderError, lxd, multipass
@@ -64,12 +64,12 @@ class Plan(NamedTuple):
 
 def create_build_plan(
     *,
-    bases: Optional[List[BasesConfiguration]],
-    bases_indices: Optional[List[int]],
+    bases: list[BasesConfiguration] | None,
+    bases_indices: list[int] | None,
     destructive_mode: bool,
     managed_mode: bool,
     provider: "Provider",
-) -> List[Plan]:
+) -> list[Plan]:
     """Determine the build plan based on user inputs and host environment.
 
     Provide a list of bases that are buildable and scoped according to user
@@ -86,7 +86,7 @@ def create_build_plan(
     :returns: List of Plans
     :raises CraftError: if no bases are provided.
     """
-    build_plan: List[Plan] = []
+    build_plan: list[Plan] = []
 
     if not bases:
         raise CraftError("Cannot create build plan because no bases were provided.")
@@ -124,7 +124,7 @@ def create_build_plan(
     return build_plan
 
 
-def get_command_environment(base: Base) -> Dict[str, str]:
+def get_command_environment(base: Base) -> dict[str, str]:
     """Construct the required environment."""
     env = base.default_command_environment()
     env[const.MANAGED_MODE_ENV_VAR] = "1"
@@ -175,7 +175,7 @@ def get_base_configuration(
     *,
     alias: enum.Enum,
     instance_name: str,
-    shared_cache_path: Optional[pathlib.Path] = None,
+    shared_cache_path: pathlib.Path | None = None,
 ) -> Base:
     """Create a Base configuration."""
     # injecting a snap on a non-linux system is not supported, so default to
@@ -233,7 +233,7 @@ def ensure_provider_is_available(provider: "Provider") -> None:
     provider.ensure_provider_is_available()
 
 
-def is_base_available(base: Base) -> Tuple[bool, Union[str, None]]:
+def is_base_available(base: Base) -> tuple[bool, str | None]:
     """Check if provider can provide an environment matching given base.
 
     :param base: Base to check.

--- a/charmcraft/snap.py
+++ b/charmcraft/snap.py
@@ -17,7 +17,6 @@
 """Logic for snap configuration."""
 
 from dataclasses import dataclass
-from typing import Optional
 
 import snaphelpers
 
@@ -26,7 +25,7 @@ import snaphelpers
 class CharmcraftSnapConfiguration:
     """Charmcraft's snap configuration options."""
 
-    provider: Optional[str] = None
+    provider: str | None = None
 
 
 def _get_config_key(*, snap_config: snaphelpers.SnapConfig, key: str, default=None):

--- a/charmcraft/utils/charmlibs.py
+++ b/charmcraft/utils/charmlibs.py
@@ -21,7 +21,6 @@ import hashlib
 import os
 import pathlib
 from dataclasses import dataclass
-from typing import List, Optional, Set
 
 import yaml
 from craft_cli import CraftError
@@ -34,11 +33,11 @@ from charmcraft.errors import BadLibraryNameError, BadLibraryPathError
 class LibData:
     """All data fields for a library, including external ones."""
 
-    lib_id: Optional[str]
+    lib_id: str | None
     api: int
     patch: int
-    content: Optional[str]
-    content_hash: Optional[str]
+    content: str | None
+    content_hash: str | None
     full_name: str
     path: pathlib.Path
     lib_name: str
@@ -52,12 +51,12 @@ class LibInternals:
     lib_id: str
     api: int
     patch: int
-    pydeps: List[str]
+    pydeps: list[str]
     content_hash: str
     content: str
 
 
-def get_name_from_metadata() -> Optional[str]:
+def get_name_from_metadata() -> str | None:
     """Return the name if present and plausible in metadata.yaml."""
     try:
         with open(const.METADATA_FILENAME, "rb") as fh:
@@ -253,8 +252,8 @@ def get_lib_info(*, full_name=None, lib_path=None):
 
 
 def get_libs_from_tree(
-    charm_name: Optional[str] = None, root: Optional[pathlib.Path] = None
-) -> List[LibData]:
+    charm_name: str | None = None, root: pathlib.Path | None = None
+) -> list[LibData]:
     """Get library info from the directories tree (for a specific charm if specified).
 
     It only follows/uses the directories/files for a correct charmlibs
@@ -286,7 +285,7 @@ def get_libs_from_tree(
     return local_libs_data
 
 
-def collect_charmlib_pydeps(basedir: pathlib.Path) -> Set[str]:
+def collect_charmlib_pydeps(basedir: pathlib.Path) -> set[str]:
     """Collect the Python dependencies from all the project's charm libraries."""
     all_libs_data = get_libs_from_tree(root=basedir)
     charmlib_deps = set()

--- a/charmcraft/utils/cli.py
+++ b/charmcraft/utils/cli.py
@@ -16,8 +16,8 @@
 """CLI-related utilities for Charmcraft."""
 import datetime
 import sys
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Iterable, Optional
 
 from craft_cli import emit
 
@@ -59,8 +59,8 @@ class ResourceOption:
         parser.add_argument('--resource',  type=ResourceOption())
     """
 
-    name: Optional[str] = None
-    revision: Optional[int] = None
+    name: str | None = None
+    revision: int | None = None
 
     def __call__(self, value):
         """Run by argparse to validate and convert the given argument."""

--- a/charmcraft/utils/file.py
+++ b/charmcraft/utils/file.py
@@ -18,7 +18,6 @@ import io
 import os
 import pathlib
 import zipfile
-from typing import Union
 
 from _stat import S_IRGRP, S_IROTH, S_IRUSR, S_IXGRP, S_IXOTH, S_IXUSR
 from craft_cli import CraftError
@@ -27,7 +26,7 @@ from craft_cli import CraftError
 S_IXALL = S_IXUSR | S_IXGRP | S_IXOTH
 S_IRALL = S_IRUSR | S_IRGRP | S_IROTH
 
-PathOrString = Union[os.PathLike, str]
+PathOrString = os.PathLike | str
 
 
 def make_executable(fh: io.IOBase) -> None:

--- a/charmcraft/utils/package.py
+++ b/charmcraft/utils/package.py
@@ -18,14 +18,14 @@ import pathlib
 import re
 import string
 import subprocess
-from typing import Collection, Iterable, List, Set, Tuple
+from collections.abc import Collection, Iterable
 
 from charmcraft.errors import MissingDependenciesError
 
 PACKAGE_LINE_REGEX = re.compile(r"^([A-Za-z0-9_.-]+)( *[~<>=!]==?)?")
 
 
-def get_pypi_packages(*requirements: Iterable[str]) -> Set[str]:
+def get_pypi_packages(*requirements: Iterable[str]) -> set[str]:
     """Get a set of pypi packages from requirements files.
 
     :param requirements: An iterable of strings for each requirement.
@@ -44,7 +44,7 @@ def get_pypi_packages(*requirements: Iterable[str]) -> Set[str]:
     return packages
 
 
-def get_package_names(packages: Iterable[str]) -> Set[str]:
+def get_package_names(packages: Iterable[str]) -> set[str]:
     """Get just the names of packages from an iterable of package lines.
 
     :param packages: An iterable of package lines (e.g. ["abc==1.0.0", "def"])
@@ -58,7 +58,7 @@ def get_package_names(packages: Iterable[str]) -> Set[str]:
     return names
 
 
-def get_requirements_file_package_names(*requirements_files: pathlib.Path) -> Set[str]:
+def get_requirements_file_package_names(*requirements_files: pathlib.Path) -> set[str]:
     """Get all the package names from one or more requirements files as a single set."""
     packages = set()
     for file in requirements_files:
@@ -68,7 +68,7 @@ def get_requirements_file_package_names(*requirements_files: pathlib.Path) -> Se
     return packages
 
 
-def exclude_packages(requirements: Set[str], *, excluded: Collection[str]) -> Set[str]:
+def exclude_packages(requirements: set[str], *, excluded: Collection[str]) -> set[str]:
     """Filter a set of requirements lines by a collection of package names.
 
     :param requirements: A set of requirements lines (e.g. {"abc==1.0.0", "def>=1.0"})
@@ -90,7 +90,7 @@ def get_pip_command(
     *,
     source_deps: Collection[str] = (),
     binary_deps: Collection[str] = (),
-) -> List[str]:
+) -> list[str]:
     """Build a pip command based on requirements files and dependencies.
 
     :param prefix: The pip command and any earlier arguments.
@@ -127,7 +127,7 @@ def get_pip_command(
     ]
 
 
-def get_pip_version(pip_cmd: str) -> Tuple[int, ...]:
+def get_pip_version(pip_cmd: str) -> tuple[int, ...]:
     """Get the version of pip available from a specific pip command."""
     result = subprocess.run([pip_cmd, "--version"], text=True, capture_output=True, check=True)
     version_data = result.stdout.split(" ")
@@ -151,7 +151,7 @@ def validate_strict_dependencies(
     """
     dependency_names = get_package_names(dependencies)
 
-    extra_packages: Set[str] = set()
+    extra_packages: set[str] = set()
 
     for package_set in other_packages:
         other_names = get_package_names(package_set)

--- a/charmcraft/utils/project.py
+++ b/charmcraft/utils/project.py
@@ -19,7 +19,7 @@ import os
 import pathlib
 import sys
 from collections import defaultdict
-from typing import Container, Dict
+from collections.abc import Container
 
 from craft_cli import emit
 from jinja2 import Environment, FileSystemLoader, PackageLoader, StrictUndefined
@@ -31,7 +31,7 @@ from charmcraft.utils.yaml import load_yaml
 
 def find_charm_sources(
     base_path: pathlib.Path, charm_names: Container[str]
-) -> Dict[str, pathlib.Path]:
+) -> dict[str, pathlib.Path]:
     """Find all charm directories matching the given names under a base path.
 
     :param base_path: The base directory under which to look.
@@ -40,7 +40,7 @@ def find_charm_sources(
     :raises: DuplicateCharmsError if a charm is found in multiple directories.
     """
     duplicate_charms = defaultdict(list)
-    charm_paths: Dict[str, pathlib.Path] = {}
+    charm_paths: dict[str, pathlib.Path] = {}
     outer_potential_paths = itertools.chain(
         (p.parent.resolve() for p in base_path.glob("charms/*/metadata.yaml")),
         (p.parent.resolve() for p in base_path.glob("operators/*/metadata.yaml")),

--- a/charmcraft/utils/store.py
+++ b/charmcraft/utils/store.py
@@ -17,7 +17,6 @@
 import enum
 import functools
 from dataclasses import dataclass
-from typing import Optional
 
 from craft_cli import CraftError
 
@@ -47,9 +46,9 @@ class Risk(enum.Enum):
 class ChannelData:
     """Data class for a craft store channel."""
 
-    track: Optional[str]
+    track: str | None
     risk: Risk
-    branch: Optional[str]
+    branch: str | None
 
     @classmethod
     def from_str(cls, name: str):
@@ -59,8 +58,8 @@ class ChannelData:
         """
         invalid_channel_error = CraftError(f"Invalid channel name: {name!r}")
         parts = name.split("/")
-        track: Optional[str] = None
-        branch: Optional[str] = None
+        track: str | None = None
+        branch: str | None = None
         if len(parts) == 1:  # Just the risk, e.g. "stable"
             try:
                 risk = Risk[parts[0].upper()]

--- a/charmcraft/utils/yaml.py
+++ b/charmcraft/utils/yaml.py
@@ -14,13 +14,13 @@
 #
 # For further info, check https://github.com/canonical/charmcraft
 """YAML-related utilities for Charmcraft."""
-from typing import Any, Dict, Optional
+from typing import Any
 
 import yaml
 from craft_cli import emit
 
 
-def load_yaml(fpath) -> Optional[Dict[str, Any]]:
+def load_yaml(fpath) -> dict[str, Any] | None:
     """Return the content of a YAML file."""
     if not fpath.is_file():
         emit.debug(f"Couldn't find config file {str(fpath)!r}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.black]
-target-version = ["py38", "py39", "py310", "py311"]
+target-version = ["py310", "py311"]
 line-length = 99
 
 [tool.codespell]
@@ -32,13 +32,11 @@ skip_empty = true
 
 [tool.pyright]
 strict = ["charmcraft"]
-pythonVersion = "3.8"
+pythonVersion = "3.10"
 pythonPlatform = "Linux"
-venvPath = ".tox"
-venv = "py38"
 
 [tool.mypy]
-python_version = "3.8"
+python_version = "3.10"
 packages = [
     "charmcraft",
 ]
@@ -89,7 +87,7 @@ strict = false
 
 [tool.ruff]
 line-length = 88
-target-version = "py38"
+target-version = "py310"
 extend-exclude = [
     "docs",
     "__pycache__",

--- a/setup.py
+++ b/setup.py
@@ -102,6 +102,7 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.10",
     ],
     entry_points={
         "console_scripts": ["charmcraft = charmcraft.main:main"],

--- a/tests/commands/test_expand_extensions.py
+++ b/tests/commands/test_expand_extensions.py
@@ -16,7 +16,7 @@
 
 
 from textwrap import dedent
-from typing import Any, Dict
+from typing import Any
 
 import pytest
 from overrides import override
@@ -34,7 +34,7 @@ class TestExtension(FakeExtension):
     bases = [("ubuntu", "22.04")]
 
     @override
-    def get_root_snippet(self) -> Dict[str, Any]:
+    def get_root_snippet(self) -> dict[str, Any]:
         """Return the root snippet to apply."""
         return {"terms": ["https://example.com/test"]}
 

--- a/tests/commands/test_list_extensions.py
+++ b/tests/commands/test_list_extensions.py
@@ -16,7 +16,7 @@
 
 
 from textwrap import dedent
-from typing import Any, Dict
+from typing import Any
 
 import pytest
 from overrides import override
@@ -33,7 +33,7 @@ class TestExtension(FakeExtension):
     bases = [("ubuntu", "22.04")]
 
     @override
-    def get_root_snippet(self) -> Dict[str, Any]:
+    def get_root_snippet(self) -> dict[str, Any]:
         """Return the root snippet to apply."""
         return {"terms": ["https://example.com/test"]}
 
@@ -45,7 +45,7 @@ class TestExtension2(FakeExtension):
     bases = [("ubuntu", "23.04")]
 
     @override
-    def get_root_snippet(self) -> Dict[str, Any]:
+    def get_root_snippet(self) -> dict[str, Any]:
         """Return the root snippet to apply."""
         return {"terms": ["https://example.com/test2"]}
 

--- a/tests/commands/test_pack.py
+++ b/tests/commands/test_pack.py
@@ -20,7 +20,7 @@ import sys
 import zipfile
 from argparse import Namespace
 from textwrap import dedent
-from typing import Any, Dict, List, Optional
+from typing import Any
 from unittest import mock
 from unittest.mock import MagicMock, call, patch
 
@@ -48,8 +48,8 @@ def get_namespace(
     format=None,
     measure=None,
     include_all_charms: bool = False,
-    include_charm: Optional[List[pathlib.Path]] = None,
-    output_bundle: Optional[pathlib.Path] = None,
+    include_charm: list[pathlib.Path] | None = None,
+    output_bundle: pathlib.Path | None = None,
 ):
     if bases_index is None:
         bases_index = []
@@ -80,7 +80,7 @@ def bundle_yaml(tmp_path):
     bundle_path.write_text("{}")
     content = {}
 
-    def func(*, name, base_content: Optional[Dict[str, Any]] = None):
+    def func(*, name, base_content: dict[str, Any] | None = None):
         if base_content:
             content.update(base_content)
         content["name"] = name

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,6 @@ import os
 import pathlib
 import tempfile
 import types
-from typing import Optional
 from unittest.mock import Mock
 
 import craft_parts
@@ -218,7 +217,7 @@ def prepare_charmcraft_yaml(tmp_path: pathlib.Path):
     If content is not given, remove charmcraft.yaml if exists.
     """
 
-    def prepare_charmcraft_yaml(content: Optional[str] = None):
+    def prepare_charmcraft_yaml(content: str | None = None):
         if content is None:
             try:
                 os.remove(tmp_path / const.CHARMCRAFT_FILENAME)
@@ -240,7 +239,7 @@ def prepare_metadata_yaml(tmp_path: pathlib.Path):
     If content is not given, remove metadata.yaml if exists.
     """
 
-    def prepare_metadata_yaml(content: Optional[str] = None, remove: bool = False):
+    def prepare_metadata_yaml(content: str | None = None, remove: bool = False):
         if content is None:
             try:
                 os.remove(tmp_path / const.METADATA_FILENAME)
@@ -262,7 +261,7 @@ def prepare_actions_yaml(tmp_path: pathlib.Path):
     If content is not given, remove actions.yaml if exists.
     """
 
-    def prepare_actions_yaml(content: Optional[str] = None):
+    def prepare_actions_yaml(content: str | None = None):
         if content is None:
             try:
                 os.remove(tmp_path / const.JUJU_ACTIONS_FILENAME)
@@ -284,7 +283,7 @@ def prepare_config_yaml(tmp_path: pathlib.Path):
     If content is not given, remove config.yaml if exists.
     """
 
-    def prepare_config_yaml(content: Optional[str] = None):
+    def prepare_config_yaml(content: str | None = None):
         if content is None:
             try:
                 os.remove(tmp_path / const.JUJU_CONFIG_FILENAME)

--- a/tests/extensions/test_extensions.py
+++ b/tests/extensions/test_extensions.py
@@ -15,7 +15,7 @@
 # For further info, check https://github.com/canonical/charmcraft
 
 from textwrap import dedent
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any
 
 import pytest
 from overrides import override
@@ -32,24 +32,24 @@ class FakeExtension(Extension):
     bases = [("ubuntu", "22.04")]
 
     @classmethod
-    def get_supported_bases(cls) -> List[Tuple[str, ...]]:
+    def get_supported_bases(cls) -> list[tuple[str, ...]]:
         """Return a list of tuple of supported bases."""
         return cls.bases
 
     @staticmethod
-    def is_experimental(_base: Optional[Tuple[str, ...]]) -> bool:
+    def is_experimental(_base: tuple[str, ...] | None) -> bool:
         """Return whether or not this extension is unstable for given base."""
         return False
 
-    def get_root_snippet(self) -> Dict[str, Any]:
+    def get_root_snippet(self) -> dict[str, Any]:
         """Return the root snippet to apply."""
         return {}
 
-    def get_part_snippet(self) -> Dict[str, Any]:
+    def get_part_snippet(self) -> dict[str, Any]:
         """Return the part snippet to apply to existing parts."""
         return {}
 
-    def get_parts_snippet(self) -> Dict[str, Any]:
+    def get_parts_snippet(self) -> dict[str, Any]:
         """Return the parts to add to parts."""
         return {}
 
@@ -61,7 +61,7 @@ class ExperimentalExtension(FakeExtension):
     bases = [("ubuntu", "22.04")]
 
     @staticmethod
-    def is_experimental(_base: Optional[str]) -> bool:
+    def is_experimental(_base: str | None) -> bool:
         return True
 
 
@@ -72,7 +72,7 @@ class InvalidPartExtension(FakeExtension):
     bases = [("ubuntu", "22.04")]
 
     @override
-    def get_parts_snippet(self) -> Dict[str, Any]:
+    def get_parts_snippet(self) -> dict[str, Any]:
         return {"bad-name": {"plugin": "dump", "source": None}}
 
 
@@ -83,19 +83,19 @@ class FullExtension(FakeExtension):
     bases = [("ubuntu", "22.04")]
 
     @override
-    def get_root_snippet(self) -> Dict[str, Any]:
+    def get_root_snippet(self) -> dict[str, Any]:
         """Return the root snippet to apply."""
         return {
             "terms": ["https://example.com/terms", "https://example.com/terms2"],
         }
 
     @override
-    def get_part_snippet(self) -> Dict[str, Any]:
+    def get_part_snippet(self) -> dict[str, Any]:
         """Return the part snippet to apply to existing parts."""
         return {"stage-packages": ["new-package-1"]}
 
     @override
-    def get_parts_snippet(self) -> Dict[str, Any]:
+    def get_parts_snippet(self) -> dict[str, Any]:
         """Return the parts to add to parts."""
         return {"full-extension/new-part": {"plugin": "nil", "source": None}}
 

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -20,7 +20,6 @@ import subprocess
 import sys
 import zipfile
 from textwrap import dedent
-from typing import List
 from unittest import mock
 from unittest.mock import ANY, MagicMock, call, patch
 
@@ -134,7 +133,7 @@ def basic_project(tmp_path, monkeypatch, prepare_charmcraft_yaml, prepare_metada
 
 @pytest.fixture()
 def basic_project_builder(basic_project, prepare_charmcraft_yaml):
-    def _basic_project_builder(bases_configs: List[BasesConfiguration], **builder_kwargs):
+    def _basic_project_builder(bases_configs: list[BasesConfiguration], **builder_kwargs):
         charmcraft_yaml = dedent(
             """
             type: charm

--- a/tox.ini
+++ b/tox.ini
@@ -6,9 +6,8 @@ env_list =  # Environments to run when called with no parameters.
     format-{black,ruff,codespell}
     pre-commit
     lint-{black,ruff,mypy,pyright,shellcheck,codespell,yaml}
-    test-py3.8
-# Tests take a while, so we're only running them on Python
-# 3.8, which is included in core20.
+    test-py3.10
+# By default, only run tests on core22's Python 3.10
 minversion = 4.6
 # Tox will use these requirements to bootstrap a venv if necessary.
 # tox-igore-env-name-mismatch allows us to have one virtualenv for all linting.
@@ -45,14 +44,14 @@ extras = dev
 allowlist_externals = mkdir
 commands_pre = mkdir -p {tox_root}/results
 
-[testenv:{test}-py3.{8,9,10,11,12}]  # Configuration for all tests using pytest
+[testenv:{test}-py3.{10,11,12}]  # Configuration for all tests using pytest
 base = testenv, test
 deps =
     -rrequirements-dev.txt
     -rrequirements-jammy.txt
 description = Run tests with pytest
 labels =
-    py3.{8,10,11}: tests
+    py3.{10,11}: tests
 commands = pytest {tty:--color=yes} --cov={tox_root}/charmcraft --cov-config={tox_root}/pyproject.toml --cov-report=xml:{tox_root}/results/coverage-{env_name}.xml --junit-xml={tox_root}/results/test-results-{env_name}.xml {posargs}
 
 [lint]  # Standard linting configuration


### PR DESCRIPTION
Since charmcraft is on core22 now, we can drop the Python 3.8 requirements.

I'd recommend we rebase & merge this without squashing since bumping to Python 3.10 got ruff very excited (second commit).