### PR TITLE
build(deps): bump craft-providers to 1.19.2

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,7 +11,7 @@ colorama==0.4.6
 coverage==7.3.2
 craft-cli==2.4.0
 craft-parts==1.25.1
-craft-providers==1.19.0
+craft-providers==1.19.2
 craft-store==2.4.0
 cryptography==41.0.4
 Deprecated==1.2.14

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ cffi==1.16.0
 charset-normalizer==3.3.1
 craft-cli==2.4.0
 craft-parts==1.25.1
-craft-providers==1.19.0
+craft-providers==1.19.2
 craft-store==2.4.0
 cryptography==41.0.4
 Deprecated==1.2.14

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -26,7 +26,7 @@ from datetime import datetime
 from charmcraft import snap
 
 PROJECT_NAME = "charmcraft"
-MINIMAL_BASE_VERISON = "2.0"
+MINIMAL_BASE_VERISON = "3.0"
 
 # We need get image info tuple from regex
 # (craft base metadata version, remote image provider, remote image os, remote image version)


### PR DESCRIPTION
### Changelog

#### 1.19.2 (2023-11-02)
- Update base compatibility tag from ``base-v2`` to ``base-v3``
  This fixes an issue where LXD instances created with
  ``craft-providers==1.16.0`` may fail to start with
  ``craft-providers>=1.17.0``.

#### 1.19.1 (2023-10-26)
- Require a disk device in the default LXD profile
