### PR TITLE
feat: deprecate 'series' in metadata.yaml & patch linter

### DIFF
--- a/charmcraft/linters.py
+++ b/charmcraft/linters.py
@@ -264,6 +264,13 @@ class JujuMetadata(Linter):
             self.text = f"The metadata.yaml file is missing the following attribute(s): {missing}."
             return self.Result.ERRORS
 
+        if "series" in metadata:
+            self.text = (
+                "The metadata.yaml file contains the deprecated attribute: series."
+                "This attribute will be rejected starting in Juju 4.0."
+            )
+            return self.Result.WARNINGS
+
         return self.Result.OK
 
 

--- a/charmcraft/templates/init-kubernetes/charmcraft.yaml.j2
+++ b/charmcraft/templates/init-kubernetes/charmcraft.yaml.j2
@@ -3,7 +3,7 @@
 
 # (Required)
 name: {{ name }}
- 
+
 
 # (Required)
 type: charm

--- a/charmcraft/templates/init-kubernetes/pyproject.toml.j2
+++ b/charmcraft/templates/init-kubernetes/pyproject.toml.j2
@@ -38,4 +38,3 @@ skip = "build,lib,venv,icon.svg,.tox,.git,.mypy_cache,.ruff_cache,.coverage"
 
 [tool.pyright]
 include = ["src/**.py"]
-

--- a/charmcraft/templates/init-machine/charmcraft.yaml.j2
+++ b/charmcraft/templates/init-machine/charmcraft.yaml.j2
@@ -3,7 +3,7 @@
 
 # (Required)
 name: {{ name }}
- 
+
 
 # (Required)
 type: charm

--- a/charmcraft/templates/init-machine/pyproject.toml.j2
+++ b/charmcraft/templates/init-machine/pyproject.toml.j2
@@ -38,4 +38,3 @@ skip = "build,lib,venv,icon.svg,.tox,.git,.mypy_cache,.ruff_cache,.coverage"
 
 [tool.pyright]
 include = ["src/**.py"]
-

--- a/charmcraft/templates/init-simple/charmcraft.yaml.j2
+++ b/charmcraft/templates/init-simple/charmcraft.yaml.j2
@@ -5,7 +5,7 @@
 # The charm package name, no spaces
 # See https://juju.is/docs/sdk/naming#heading--naming-charms for guidance.
 name: {{ name }}
- 
+
 
 # (Required)
 # The charm type, either 'charm' or 'bundle'.
@@ -61,7 +61,7 @@ resources:
   httpbin-image:
     type: oci-image
     description: OCI image for httpbin
-    # The upstream-source field is ignored by Juju. It is included here as a 
+    # The upstream-source field is ignored by Juju. It is included here as a
     # reference so the integration testing suite knows which image to deploy
     # during testing. This field is also used by the 'canonical/charming-actions'
     # Github action for automated releasing.
@@ -77,7 +77,7 @@ config:
     # An example config option to customise the log level of the workload
     log-level:
       description: |
-        Configures the log level of gunicorn. 
+        Configures the log level of gunicorn.
 
         Acceptable values are: "info", "debug", "warning", "error" and "critical"
       default: "info"

--- a/charmcraft/templates/init-simple/pyproject.toml.j2
+++ b/charmcraft/templates/init-simple/pyproject.toml.j2
@@ -38,4 +38,3 @@ skip = "build,lib,venv,icon.svg,.tox,.git,.mypy_cache,.ruff_cache,.coverage"
 
 [tool.pyright]
 include = ["src/**.py"]
-

--- a/tests/test_linters.py
+++ b/tests/test_linters.py
@@ -648,6 +648,26 @@ def test_jujumetadata_missing_field_multiple(tmp_path):
     )
 
 
+def test_jujumetadata_series_is_deprecated(tmp_path):
+    """A deprecated field is included in the metadata file"""
+    metadata_file = tmp_path / const.METADATA_FILENAME
+    metadata_file.write_text(
+        """
+        name: foobar
+        summary: summary
+        description: desc
+        series: focal
+    """
+    )
+    linter = JujuMetadata()
+    result = linter.run(tmp_path)
+    assert result == JujuMetadata.Result.WARNINGS
+    assert linter.text == (
+        "The metadata.yaml file contains the deprecated attribute: series."
+        "This attribute will be rejected starting in Juju 4.0."
+    )
+
+
 # --- tests for analyze function
 
 


### PR DESCRIPTION
Patch the metadata linter to fail if the 'series' key is present. For a long time charmcraft has generated a manifest.yaml on pack which has been used instead series in metadata.

Juju ignores 'series' in metadata for any packed charm (i.e. a charm with a manifest.yaml)

There is an effort to remove the notion of a series from Juju entirely, substituting it for bases. As such, Juju is roadmapped to deprecate support for charms without manifest.yaml files in 3.4, removing support entirely in 4.0 (i.e. showing an error).

Showing a linter error in `charmcraft analyze` will be a convenient way to begin communicating this

As a flyby fix, remove whitespace from the end of line in the templates

## QA Steps

```
$ juju download kafka
Fetching charm "kafka" revision 123 using "stable" channel and base "amd64/ubuntu/22.04"
Install the "kafka" charm with:
    juju deploy ./kafka_r123.charm

$ charmcraft analyze ./kafka_r123.charm
Attributes:                                                                                                                                                                                                                                                                                     
- language: python (https://juju.is/docs/sdk/charmcraft-analyzers-and-linters#heading--language)                                                                                                                                                                                                
- framework: operator (https://juju.is/docs/sdk/charmcraft-analyzers-and-linters#heading--framework)                                                                                                                                                                                            
Lint Errors:                                                                                                                                                                                                                                                                                    
- metadata: The metadata.yaml file contains deprecated attribute: series. (https://juju.is/docs/sdk/charmcraft-analyzers-and-linters#heading--metadata)                                                                                                                                         
Lint OK:                                                                                                                                                                                                                                                                                        
- juju-actions: no issues found (https://juju.is/docs/sdk/charmcraft-analyzers-and-linters#heading--juju-actions)                                                                                                                                                                               
- juju-config: no issues found (https://juju.is/docs/sdk/charmcraft-analyzers-and-linters#heading--juju-config)                                                                                                                                                                                 
- entrypoint: no issues found (https://juju.is/docs/sdk/charmcraft-analyzers-and-linters#heading--entrypoint)

$ unzip kafka.charm
$ rm kafka.charm
(edit metadata.yaml to remove series key)
$ cat metdata.yaml
# Copyright 2023 Canonical Ltd.
# See LICENSE file for licensing details.

description: |
  Kafka is an event streaming platform. This charm deploys and operates Kafka.
display-name: Kafka
issues: https://github.com/canonical/kafka-operator/issues/new
docs: https://discourse.charmhub.io/t/charmed-kafka-documentation/10288
maintainers:
  - Marc Oppenheimer <marc.oppenheimer@canonical.com>
name: kafka
source: https://github.com/canonical/kafka-operator
summary: The Charmed Kafka Operator

peers:
  cluster:
    interface: cluster
  restart:
    interface: rolling_op

requires:
  zookeeper:
    interface: zookeeper
  certificates:
    interface: tls-certificates
    limit: 1
    optional: true
  trusted-ca:
    interface: tls-certificates
    optional: true
  trusted-certificate:
    interface: tls-certificates
    optional: true

provides:
  kafka-client:
    interface: kafka_client
  cos-agent:
    interface: cos_agent

storage:
  data:
    type: filesystem
    description: Directories where the log data is stored
    minimum-size: 10G
    location: /var/snap/charmed-kafka/common/var/lib/kafka
    multiple:
      range: 1-

$ zip -r kafka_r123.charm .
$ charmcraft analyze kafka_r123.charm
Attributes:                                                                                                                                                                                                                                                                                     
- language: python (https://juju.is/docs/sdk/charmcraft-analyzers-and-linters#heading--language)                                                                                                                                                                                                
- framework: operator (https://juju.is/docs/sdk/charmcraft-analyzers-and-linters#heading--framework)                                                                                                                                                                                            
Lint OK:                                                                                                                                                                                                                                                                                        
- juju-actions: no issues found (https://juju.is/docs/sdk/charmcraft-analyzers-and-linters#heading--juju-actions)                                                                                                                                                                               
- juju-config: no issues found (https://juju.is/docs/sdk/charmcraft-analyzers-and-linters#heading--juju-config)                                                                                                                                                                                 
- metadata: no issues found (https://juju.is/docs/sdk/charmcraft-analyzers-and-linters#heading--metadata)                                                                                                                                                                                       
- entrypoint: no issues found (https://juju.is/docs/sdk/charmcraft-analyzers-and-linters#heading--entrypoint)    
```

## Documentation changes

https://juju.is/docs/sdk/charmcraft-analyzers-and-linters#heading--metadata will require updating with the new linter check