### PR TITLE
test: use MATCH in spread tests

### DIFF
--- a/tests/spread/smoketests/basic-centos-7/task.yaml
+++ b/tests/spread/smoketests/basic-centos-7/task.yaml
@@ -30,5 +30,5 @@ execute: |
   cd charm
   charmcraft pack --verbose
   test -f charm*.charm
-  unzip -l charm*.charm | grep "venv/ops/charm.py"
+  unzip -l charm*.charm | MATCH "venv/ops/charm.py"
   test ! -d build

--- a/tests/spread/smoketests/basic/task.yaml
+++ b/tests/spread/smoketests/basic/task.yaml
@@ -29,5 +29,5 @@ execute: |
   cd charm
   charmcraft pack --verbose
   test -f charm*.charm
-  unzip -l charm*.charm | grep "venv/ops/charm.py"
+  unzip -l charm*.charm | MATCH "venv/ops/charm.py"
   test ! -d build

--- a/tests/spread/smoketests/different-dependencies/task.yaml
+++ b/tests/spread/smoketests/different-dependencies/task.yaml
@@ -1,6 +1,6 @@
 summary: pack a charm with different dependencies specified
 
-include: 
+include:
   - tests/
 
 prepare: |
@@ -21,13 +21,13 @@ restore: |
   pushd charm
   charmcraft clean
   popd
-  
+
   rm -rf charm
 
 execute: |
   cd charm
   charmcraft pack --verbose
   test -f charm*.charm
-  unzip -l charm*.charm | grep "venv/pytest/__init__.py"
-  unzip -l charm*.charm | grep "venv/bumpversion/__init__.py"
-  unzip -l charm*.charm | grep "venv/fades/__init__.py"
+  unzip -l charm*.charm | MATCH "venv/pytest/__init__.py"
+  unzip -l charm*.charm | MATCH "venv/bumpversion/__init__.py"
+  unzip -l charm*.charm | MATCH "venv/fades/__init__.py"

--- a/tests/spread/smoketests/full-lifecycle/task.yaml
+++ b/tests/spread/smoketests/full-lifecycle/task.yaml
@@ -1,6 +1,6 @@
 summary: pack a charm that uses several lifecycle mechanisms and extra files
 
-include: 
+include:
   - tests/
 
 kill-timeout: 30m
@@ -31,14 +31,14 @@ restore: |
   pushd charm
   charmcraft clean
   popd
-  
+
   rm -rf charm
 
 execute: |
   cd charm
   charmcraft pack --verbose
   test -f charm*.charm
-  unzip -c charm*.charm hello.txt | grep "^Hello, world!"
-  unzip -l charm*.charm | grep "venv/ops/charm.py"
-  unzip -l charm*.charm | grep extra_file.txt
-  ! unzip -l charm*.charm | grep secrets.txt
+  unzip -c charm*.charm hello.txt | MATCH "^Hello, world!"
+  unzip -l charm*.charm | MATCH "venv/ops/charm.py"
+  unzip -l charm*.charm | MATCH extra_file.txt
+  unzip -l charm*.charm | NOMATCH secrets.txt


### PR DESCRIPTION
We've got a few places where we use grep directly in a way that doesn't guarantee test failure when it should.