### PR TITLE
build: use ruff snap

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,6 +15,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
+      - name: Begin snap installs
+        run: |
+          echo "Installing snaps in the background while running apt and pip..."
+          sudo snap install --no-wait shellcheck ruff
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -26,10 +30,6 @@ jobs:
           cache: 'pip'
       - name: Configure environment
         run: |
-          echo "::group::Begin snap install"
-          echo "Installing snaps in the background while running apt and pip..."
-          sudo snap install --no-wait shellcheck
-          echo "::endgroup::"
           echo "::group::pip install"
           python -m pip install tox
           echo "::endgroup::"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,21 @@
 ## Development environment
 
 To set up an initial development environment:
-    
+
     git clone https://github.com/canonical/charmcraft.git
     cd charmcraft
     virtualenv venv
     . venv/bin/activate
     pip install -r requirements-dev.txt -e .
+
+You will need a copy of `ruff` installed. On many Linux distributions, you
+can install ruff with:
+
+    sudo snap install ruff
+
+Otherwise, you can install ruff in your virtual environment with:
+
+    pip install ruff
 
 
 ## Developing against Charmcraft source

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -70,7 +70,6 @@ requests-toolbelt==1.0.0
 requests-unixsocket==0.3.0
 responses==0.23.3
 rpds-py==0.10.6
-ruff==0.0.282
 SecretStorage==3.3.3
 six==1.16.0
 snap-helpers==0.4.2

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,6 @@ install_requires = [
 lint_requires = [
     "black>=23.10.1,<24.0.0",
     "codespell[tomli]>=2.2.6,<3.0.0",
-    "ruff~=0.1.1",
     "yamllint>=1.32.0,<2.0.0",
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -70,6 +70,7 @@ base = testenv, lint
 labels = lint
 allowlist_externals =
     shellcheck: bash, xargs
+    ruff: ruff
 commands_pre =
     shellcheck: bash -c '{[shellcheck]find} | {[shellcheck]filter} > {env_tmp_dir}/shellcheck_files'
 commands =
@@ -97,6 +98,8 @@ commands =
 description = Automatically format source code
 base = testenv, lint
 labels = format
+allowlist_externals =
+    ruff: ruff
 commands =
     black: black {tty:--color} {posargs} .
     ruff: ruff check --fix --respect-gitignore {posargs:.}


### PR DESCRIPTION
Uses the version of ruff from snap in CI and tox.

Testing this in charmcraft as a canary before changing all of our repos over.