### PR TITLE
chore: new craft-store

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,7 +12,7 @@ coverage==7.3.2
 craft-cli==2.4.0
 craft-parts==1.25.1
 craft-providers==1.19.2
-craft-store==2.4.0
+craft-store==2.5.0
 cryptography==41.0.4
 Deprecated==1.2.14
 distlib==0.3.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ charset-normalizer==3.3.1
 craft-cli==2.4.0
 craft-parts==1.25.1
 craft-providers==1.19.2
-craft-store==2.4.0
+craft-store==2.5.0
 cryptography==41.0.4
 Deprecated==1.2.14
 distro==1.8.0


### PR DESCRIPTION
Allows headless systems to fallback to a file based keyring backend.

---
Fixes #719 