### PR TITLE
fix(charm_builder): bump minimum pip version to 23

### DIFF
--- a/charmcraft/charm_builder.py
+++ b/charmcraft/charm_builder.py
@@ -51,7 +51,7 @@ from charmcraft.utils import (
     validate_strict_dependencies,
 )
 
-MINIMUM_PIP_VERSION = (22, 0)
+MINIMUM_PIP_VERSION = (23, 0)
 KNOWN_GOOD_PIP_URL = "https://files.pythonhosted.org/packages/ba/19/e63fb4e0d20e48bd2167bb7e857abc0e21679e24805ba921a224df8977c0/pip-23.2.1.tar.gz"
 
 

--- a/tests/test_charm_builder.py
+++ b/tests/test_charm_builder.py
@@ -29,6 +29,7 @@ from charmcraft import charm_builder
 from charmcraft.charm_builder import (
     DEPENDENCIES_HASH_FILENAME,
     DISPATCH_CONTENT,
+    KNOWN_GOOD_PIP_URL,
     STAGING_VENV_DIRNAME,
     VENV_DIRNAME,
     CharmBuilder,
@@ -614,6 +615,7 @@ def test_build_dependencies_virtualenv_simple(tmp_path, assert_output):
 
     assert mock.mock_calls == [
         call(["python3", "-m", "venv", str(tmp_path / STAGING_VENV_DIRNAME)]),
+        call([pip_cmd, "install", f"pip@{KNOWN_GOOD_PIP_URL}"]),
         call([pip_cmd, "install", f"--requirement={reqs_file}"]),
     ]
 
@@ -650,6 +652,7 @@ def test_build_dependencies_virtualenv_multiple(tmp_path, assert_output):
     pip_cmd = str(charm_builder._find_venv_bin(tmp_path / STAGING_VENV_DIRNAME, "pip"))
     assert mock.mock_calls == [
         call(["python3", "-m", "venv", str(tmp_path / STAGING_VENV_DIRNAME)]),
+        call([pip_cmd, "install", f"pip@{KNOWN_GOOD_PIP_URL}"]),
         call(
             [
                 pip_cmd,
@@ -710,6 +713,7 @@ def test_build_dependencies_virtualenv_packages(tmp_path, assert_output):
 
     assert mock.mock_calls == [
         call(["python3", "-m", "venv", str(tmp_path / STAGING_VENV_DIRNAME)]),
+        call([pip_cmd, "install", f"pip@{KNOWN_GOOD_PIP_URL}"]),
         call([pip_cmd, "install", "--no-binary=pkg1,pkg2", "pkg1", "pkg2"]),
     ]
 
@@ -742,6 +746,7 @@ def test_build_dependencies_virtualenv_binary_packages(tmp_path, assert_output):
 
     assert mock.mock_calls == [
         call(["python3", "-m", "venv", str(tmp_path / STAGING_VENV_DIRNAME)]),
+        call([pip_cmd, "install", f"pip@{KNOWN_GOOD_PIP_URL}"]),
         call([pip_cmd, "install", "pkg1", "pkg2"]),
     ]
 
@@ -780,6 +785,7 @@ def test_build_dependencies_virtualenv_all(tmp_path, assert_output):
 
     assert mock.mock_calls == [
         call(["python3", "-m", "venv", str(tmp_path / STAGING_VENV_DIRNAME)]),
+        call([pip_cmd, "install", f"pip@{KNOWN_GOOD_PIP_URL}"]),
         call(
             [
                 pip_cmd,


### PR DESCRIPTION
fixes #1374

Pip 22 doesn't use the prebuilt wheel cache when using `--no-binary=[list of packages]`, but does when using `--no-binary=:all:`. As such, using strict dependencies won't use the cache with pip 22

Has potential regressions, so I'm going to run a large spread on this: https://github.com/canonical/charmcraft/actions/runs/7184537100

EDIT: Large spread failures are unrelated and are fixed in https://github.com/canonical/charmcraft/pull/1438. This should be cherry-picked to the 2.5 branch.