### PR TITLE
replaced metadata.yaml with charmcraft.yaml in integration test templates

### DIFF
--- a/charmcraft/templates/init-kubernetes/tests/integration/test_charm.py.j2
+++ b/charmcraft/templates/init-kubernetes/tests/integration/test_charm.py.j2
@@ -12,7 +12,7 @@ from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
 
-METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
+METADATA = yaml.safe_load(Path("./charmcraft.yaml").read_text())
 APP_NAME = METADATA["name"]
 
 

--- a/charmcraft/templates/init-machine/tests/integration/test_charm.py.j2
+++ b/charmcraft/templates/init-machine/tests/integration/test_charm.py.j2
@@ -12,7 +12,7 @@ from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
 
-METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
+METADATA = yaml.safe_load(Path("./charmcraft.yaml").read_text())
 APP_NAME = METADATA["name"]
 
 

--- a/charmcraft/templates/init-simple/tests/integration/test_charm.py.j2
+++ b/charmcraft/templates/init-simple/tests/integration/test_charm.py.j2
@@ -12,7 +12,7 @@ from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
 
-METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
+METADATA = yaml.safe_load(Path("./charmcraft.yaml").read_text())
 APP_NAME = METADATA["name"]
 
 


### PR DESCRIPTION
The integration test jinja templates used for `charmcraft init --<profile>` still contain some references to outdated metadata.yaml. Updated them to point to the new charmcraft.yaml.
