### PR TITLE
test: make init tox test more informative

### DIFF
--- a/tests/integration/commands/test_init.py
+++ b/tests/integration/commands/test_init.py
@@ -240,7 +240,16 @@ def test_tox_success(new_path, init_command, profile):
 
     init_command.run(create_namespace(profile=profile))
 
-    subprocess.run(["tox", "-v"], cwd=new_path, check=True, env=env)
+    result = subprocess.run(
+        ["tox", "-v"],
+        cwd=new_path,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+    assert result.returncode == 0, "Tox run failed:\n" + result.stdout
 
 
 @pytest.mark.parametrize("profile", list(commands.init.PROFILES))


### PR DESCRIPTION
This PR was created to find the source of #1508, but it will be useful for other failures too.

macos 11 failure is what this PR is meant to debug, so it won't hurt to merge while that's failing.