### PR TITLE
feat(testing): add spread testing template files

### DIFF
--- a/charmcraft/application/commands/__init__.py
+++ b/charmcraft/application/commands/__init__.py
@@ -61,6 +61,7 @@ from charmcraft.application.commands.store import (
     SetResourceArchitecturesCommand,
     UploadResourceCommand,
 )
+from charmcraft.application.commands.test import TestCommand
 from charmcraft.application.commands.version import Version
 
 
@@ -117,6 +118,7 @@ def fill_command_groups(app: craft_application.Application) -> None:
         [
             Analyse,
             Analyze,
+            TestCommand,
             Version,
         ],
     )
@@ -156,5 +158,6 @@ __all__ = [
     "ListResourcesCommand",
     "ListResourceRevisionsCommand",
     "SetResourceArchitecturesCommand",
+    "TestCommand",
     "UploadResourceCommand",
 ]

--- a/charmcraft/application/commands/init.py
+++ b/charmcraft/application/commands/init.py
@@ -70,9 +70,15 @@ files and directories:
     │                             linting tools
     ├── README.md              - Frontpage for your charmhub.io/charm/
     ├── requirements.txt       - PyPI dependencies for your charm, with `ops`
+    ├── spread.yaml            - Spread testing configuration file
     ├── src
     │   └── charm.py           - Minimal operator using Python operator framework
     ├── tests
+    │   ├── spread
+    │   │   ├── lib
+    │   │   │   └── funcs.sh   - Helpers for spread testing
+    │   │   └── minimal
+    │   │       └── task.yaml  - Minimal task definition
     │   ├── integration
     │   │   └── test_charm.py  - Integration tests
     │   └── unit

--- a/charmcraft/application/commands/test.py
+++ b/charmcraft/application/commands/test.py
@@ -1,0 +1,55 @@
+# Copyright 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For further info, check https://github.com/canonical/charmcraft
+
+"""Infrastructure for the 'test' command."""
+import argparse
+import os
+import subprocess
+import sys
+
+from craft_cli import CraftError, emit
+
+from charmcraft.application.commands import base
+
+_overview = """
+Run charm tests in different back-ends.
+
+This command will run charm test suites using the spread tool. See
+the spread documentation for further information.
+"""
+
+class TestCommand(base.CharmcraftCommand):
+    """Initialize a directory to be a charm project."""
+
+    name = "test"
+    help_msg = "Execute charm test suites"
+    overview = _overview
+    common = True
+
+    arguments = []
+
+    def fill_parser(self, parser):
+        """Specify command's specific parameters."""
+        self.arguments = sys.argv[2:]
+
+    def run(self, parsed_args: argparse.Namespace):
+        """Execute command's actual functionality."""
+        try:
+            cmd = f"{os.environ['SNAP']}/bin/spread"
+            with emit.pause():
+                subprocess.run([cmd, "-v", *self.arguments], check=True)
+        except subprocess.CalledProcessError as err:
+            raise CraftError(err)

--- a/charmcraft/templates/init-machine/spread.yaml.j2
+++ b/charmcraft/templates/init-machine/spread.yaml.j2
@@ -1,0 +1,115 @@
+project: {{ name }}-tests
+
+environment:
+  CHARMCRAFT_CHANNEL: latest/stable
+  JUJU_CHANNEL: latest/stable
+  LXD_CHANNEL: latest/stable
+
+  JUJU_BOOTSTRAP_OPTIONS: --model-default test-mode=true --model-default automatically-retry-hooks=false --model-default
+  JUJU_EXTRA_BOOTSTRAP_OPTIONS: ""
+  JUJU_BOOTSTRAP_CONSTRAINTS: ""
+
+  # important to ensure adhoc and linode/qemu behave the same
+  SUDO_USER: ""
+  SUDO_UID: ""
+  
+  LANG: "C.UTF-8"
+  LANGUAGE: "en"
+
+  PROJECT_PATH: /home/spread/proj
+  CRAFT_TEST_PATH: /home/spread/proj/tests/spread/lib
+
+backends:
+  multipass:
+    type: adhoc
+    allocate: |
+      sleep 0.$RANDOM
+      sleep 0.$RANDOM
+      sleep 0.$RANDOM
+
+      mkdir -p "$HOME/.spread"
+      export counter_file="$HOME/.spread/multipass-count"
+      instance_num=$(flock -x $counter_file bash -c '
+        [ -s $counter_file ] || echo 0 > $counter_file
+        num=$(< $counter_file)
+        echo $num
+        echo $(( $num + 1 )) > $counter_file')
+
+      multipass_image=$(echo "${SPREAD_SYSTEM}" | sed -e s/ubuntu-// -e s/-64//)
+
+      system=$(echo "${SPREAD_SYSTEM}" | tr . -)
+      instance_name="spread-${SPREAD_BACKEND}-${instance_num}-${system}"
+
+      multipass launch -vv --cpus 2 --disk 20G --memory 4G --name "${instance_name}" \
+        --cloud-init tests/spread/lib/cloud-config.yaml "${multipass_image}"
+
+      # Get the IP from the instance
+      ip=$(multipass info --format csv "$instance_name" | tail -1 | cut -d\, -f3)
+      ADDRESS "$ip"
+
+    discard: |
+      instance_name=$(multipass list --format csv | grep $SPREAD_SYSTEM_ADDRESS | cut -f1 -d\,)
+      multipass delete --purge "${instance_name}"
+
+    systems:
+      - ubuntu-22.04:
+          username: spread
+          password: spread
+          workers: 1
+
+      #- ubuntu-20.04:
+      #    username: spread
+      #    password: spread
+      #    workers: 1
+
+  github-ci:
+    type: adhoc
+
+    allocate: |
+      echo "Allocating ad-hoc $SPREAD_SYSTEM"
+      if [ -z "${GITHUB_RUN_ID:-}" ]; then
+        FATAL "this back-end only works inside GitHub CI"
+        exit 1
+      fi
+      echo 'ubuntu ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/99-spread-users
+      ADDRESS localhost:22
+
+    discard: |
+      echo "Discarding ad-hoc $SPREAD_SYSTEM"
+
+    systems:
+      - ubuntu-22.04-amd64:
+          username: ubuntu
+          password: ubuntu
+          workers: 1
+
+
+suites:
+  tests/spread/:
+    summary: Spread tests
+
+
+exclude:
+  - .git
+  - .tox
+
+path: /home/spread/proj
+
+prepare: |
+  snap refresh --hold
+
+  if systemctl is-enabled unattended-upgrades.service; then
+    systemctl stop unattended-upgrades.service
+    systemctl mask unattended-upgrades.service
+  fi
+
+restore: |
+  apt autoremove -y --purge
+  rm -Rf "$PROJECT_PATH"
+  mkdir -p "$PROJECT_PATH"
+
+
+kill-timeout: 15m
+
+workers: 1
+

--- a/charmcraft/templates/init-machine/tests/spread/lib/cloud-config.yaml.j2
+++ b/charmcraft/templates/init-machine/tests/spread/lib/cloud-config.yaml.j2
@@ -1,0 +1,10 @@
+#cloud-config
+
+ssh_pwauth: true
+
+users:
+  - default
+  - name: spread
+    plain_text_passwd: spread
+    lock_passwd: false
+    sudo: ALL=(ALL) NOPASSWD:ALL

--- a/charmcraft/templates/init-machine/tests/spread/lib/funcs.sh.j2
+++ b/charmcraft/templates/init-machine/tests/spread/lib/funcs.sh.j2
@@ -1,0 +1,32 @@
+
+export PATH=/snap/bin:$PROJECT_PATH/tests/spread/lib/tools:$PATH
+export CONTROLLER_NAME="craft-test-$PROVIDER"
+
+
+install_lxd() {
+    snap install lxd --channel "$LXD_CHANNEL"
+    lxd waitready
+    lxd init --auto
+    chmod a+wr /var/snap/lxd/common/lxd/unix.socket
+    lxc network set lxdbr0 ipv6.address none
+    usermod -a -G lxd "$USER"
+
+    # Work-around clash between docker and lxd on jammy
+    # https://github.com/docker/for-linux/issues/1034
+    iptables -F FORWARD
+    iptables -P FORWARD ACCEPT
+}
+
+
+bootstrap_juju() {
+    juju bootstrap --verbose "$PROVIDER" "$CONTROLLER_NAME" \
+      $JUJU_BOOTSTRAP_OPTIONS $JUJU_EXTRA_BOOTSTRAP_OPTIONS \
+      --bootstrap-constraints=$JUJU_BOOTSTRAP_CONSTRAINTS
+}
+
+
+restore_juju() {
+     juju controllers --refresh ||:
+     juju destroy-controller -v --no-prompt --show-log \
+       --destroy-storage --destroy-all-models "$CONTROLLER_NAME"
+}

--- a/charmcraft/templates/init-machine/tests/spread/minimal/task.yaml.j2
+++ b/charmcraft/templates/init-machine/tests/spread/minimal/task.yaml.j2
@@ -1,0 +1,51 @@
+summary: Minimal charm test
+
+systems:
+  - ubuntu-22.04
+  - ubuntu-20.04
+
+environment:
+  PROVIDER: lxd
+  JUJU_CHANNEL/alt1,alt2: 3.3/stable
+  JUJU_CHANNEL/alt3: 3.1/stable
+  CHARMCRAFT_CHANNEL/alt1,alt3: latest/stable
+  CHARMCRAFT_CHANNEL/alt2: latest/candidate
+
+# This creates 3 test variants:
+# - alt1: with juju 3.3 and charmcraft stable
+# - alt2: with juju 3.3 and charmcraft candidate
+# - alt3: with juju 3.1 and charmcraft stable
+
+prepare: |
+  . "$CRAFT_TEST_PATH"/funcs.sh
+
+  apt update -y
+  apt install -y python3-pip
+  pip3 install tox
+
+  install_lxd
+  snap install charmcraft --classic --channel "$CHARMCRAFT_CHANNEL"
+  snap install juju --classic --channel "$JUJU_CHANNEL"
+  mkdir -p "$HOME"/.local/share/juju
+
+  bootstrap_juju
+
+  juju add-model testing
+
+restore: |
+  . "$CRAFT_TEST_PATH"/funcs.sh
+
+  rm -f "$PROJECT_PATH"/*.charm
+  charmcraft clean -p "$PROJECT_PATH"
+
+  restore_juju
+
+  snap stop juju
+  snap remove --purge juju
+  snap remove --purge charmcraft
+  snap remove --purge lxd
+
+execute: |
+  tox -e integration
+
+kill-timeout: 30m

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -64,6 +64,9 @@ apps:
       # same for config
       XDG_CONFIG_HOME: $SNAP_USER_COMMON/config
 
+  spread:
+    command: bin/spread
+
 confinement: classic
 
 build-packages:
@@ -134,6 +137,20 @@ parts:
       sed -i -e '1 s|^#!/.*|#!/snap/charmcraft/current/bin/python -E|' $CRAFT_PART_INSTALL/bin/craftctl
     organize:
       bin/craftctl: libexec/charmcraft/craftctl
+
+  spread:
+    plugin: go
+    source: https://github.com/snapcore/spread
+    source-type: git
+    source-depth: 1
+    build-packages:
+      - golang-go
+    build-attributes:
+      - enable-patchelf
+    build-environment:
+      - CGO_ENABLED: 0
+    stage:
+      - -bin/humbox
 
 hooks:
   configure:


### PR DESCRIPTION
Add Jinja2 template files for machine charm testing, installed when
initializing a minimal charm with `charmcraft init --profile machine`.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

