### PR TITLE
feat(extensions): add bundle extension

### DIFF
--- a/charmcraft/application/commands/lifecycle.py
+++ b/charmcraft/application/commands/lifecycle.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 import os
 import pathlib
 import subprocess
-import sys
 import textwrap
 from typing import TYPE_CHECKING
 

--- a/charmcraft/application/commands/lifecycle.py
+++ b/charmcraft/application/commands/lifecycle.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import os
 import pathlib
 import subprocess
+import sys
 import textwrap
 from typing import TYPE_CHECKING
 
@@ -387,7 +388,10 @@ class PackCommand(PrimeCommand):
         commands do.
         """
         charmcraft_yaml = utils.load_yaml(pathlib.Path("charmcraft.yaml"))
-        if charmcraft_yaml and charmcraft_yaml.get("type") == "bundle":
+        # Always use a runner on non-posix platforms.
+        # Craft-parts is not designed to work on non-posix platforms, and most
+        # notably here, the bundle plugin doesn't work on Windows.
+        if os.name == "posix" and charmcraft_yaml and charmcraft_yaml.get("type") == "bundle":
             return False
         return super().run_managed(parsed_args)
 

--- a/charmcraft/application/main.py
+++ b/charmcraft/application/main.py
@@ -25,7 +25,7 @@ import craft_cli
 from craft_application import Application, AppMetadata, util
 from craft_parts import plugins
 
-from charmcraft import const, errors, models, services
+from charmcraft import const, errors, extensions, models, services
 from charmcraft.application import commands
 from charmcraft.main import GENERAL_SUMMARY
 from charmcraft.main import main as old_main
@@ -66,6 +66,12 @@ class Charmcraft(Application):
         self, yaml_data: dict[str, Any], *, build_on: str, build_for: str | None
     ) -> dict[str, Any]:
         yaml_data = yaml_data.copy()
+
+        # Default extensions
+        if yaml_data.get("type") == "bundle":
+            yaml_data.setdefault("extensions", []).append("bundle")
+
+        yaml_data = extensions.apply_extensions(self.project_dir, yaml_data)
 
         metadata_path = pathlib.Path(self.project_dir / "metadata.yaml")
         if metadata_path.exists():

--- a/charmcraft/extensions/__init__.py
+++ b/charmcraft/extensions/__init__.py
@@ -18,6 +18,7 @@
 
 from charmcraft.extensions._utils import apply_extensions
 from charmcraft.extensions.extension import Extension
+from charmcraft.extensions.bundle import Bundle
 from charmcraft.extensions.registry import (
     get_extension_class,
     get_extension_names,
@@ -26,8 +27,11 @@ from charmcraft.extensions.registry import (
     unregister,
 )
 
+register("bundle", Bundle)
+
 __all__ = [
     "Extension",
+    "Bundle",
     "get_extension_class",
     "get_extension_names",
     "get_extensions",

--- a/charmcraft/extensions/bundle.py
+++ b/charmcraft/extensions/bundle.py
@@ -1,0 +1,57 @@
+# Copyright 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For further info, check https://github.com/canonical/charmcraft
+"""Bundle extension."""
+from typing import Any
+
+from overrides import override
+
+from charmcraft.extensions import extension
+
+
+class Bundle(extension.Extension):
+    """An extension that generates the bits for a bundle."""
+
+    @override
+    @staticmethod
+    def get_supported_bases() -> list[tuple[str, str]]:
+        """Bundles don't have bases."""
+        return []
+
+    @override
+    @staticmethod
+    def is_experimental(base: tuple[str, str] | None) -> bool:  # noqa: ARG004
+        """Bundles are never experimental."""
+        return False
+
+    @override
+    def get_root_snippet(self) -> dict[str, Any]:
+        """No root snippet to add."""
+        return {}
+
+    @override
+    def get_part_snippet(self) -> dict[str, Any]:
+        """Nothing to add to an existing part."""
+        return {}
+
+    @override
+    def get_parts_snippet(self) -> dict[str, Any]:
+        """Generate the bundle part if there isn't one."""
+        parts = self.yaml_data.get("parts", {})
+        has_bundle = any(part.get("plugin") == "bundle" for part in parts.values())
+        if has_bundle:
+            return {}
+
+        return {"bundle": {"plugin": "bundle", "source": "."}}

--- a/charmcraft/parts/bundle.py
+++ b/charmcraft/parts/bundle.py
@@ -66,6 +66,7 @@ class BundlePlugin(plugins.Plugin):
     def get_build_commands(self) -> list[str]:
         """Return a list of commands to run during the build step."""
         install_dir = self._part_info.part_install_dir
+        build_dir = self._part_info.part_build_subdir
         if sys.platform == "linux":
             cp_cmd = "cp --archive --link --no-dereference"
         else:
@@ -73,5 +74,5 @@ class BundlePlugin(plugins.Plugin):
 
         return [
             f'mkdir -p "{install_dir}"',
-            f'{cp_cmd} * "{install_dir}"',
+            f'{cp_cmd} {build_dir}/* "{install_dir}"',
         ]

--- a/tests/integration/commands/test_extensions.py
+++ b/tests/integration/commands/test_extensions.py
@@ -40,6 +40,11 @@ def create_extension(ext_name, bases, experimental):
 
 @pytest.fixture(autouse=True, scope="module")
 def registered_extensions():
+    default_extensions = {
+        name: extensions.get_extension_class(name) for name in extensions.get_extension_names()
+    }
+    for ext in default_extensions:
+        extensions.unregister(ext)
     fake_extensions = [
         create_extension("f1", [("ubuntu", "22.04")], [("ubuntu", "24.04")]),
         create_extension("f2", [], [("almalinux", "9")]),
@@ -49,6 +54,8 @@ def registered_extensions():
     yield fake_extensions
     for ext in fake_extensions:
         extensions.unregister(ext.name)
+    for name, cls in default_extensions.items():
+        extensions.register(name, cls)
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/commands/test_pack.py
+++ b/tests/integration/commands/test_pack.py
@@ -1,0 +1,46 @@
+# Copyright 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For further info, check https://github.com/canonical/charmcraft
+"""Integration tests for packing."""
+import textwrap
+import zipfile
+
+import pytest
+
+from charmcraft.application import main
+
+
+@pytest.mark.parametrize(
+    "bundle_yaml",
+    [
+        textwrap.dedent(
+            """\
+            name: my-bundle
+        """
+        )
+    ],
+)
+def test_build_basic_bundle(monkeypatch, new_path, bundle_yaml):
+    (new_path / "charmcraft.yaml").write_text("type: bundle")
+    (new_path / "bundle.yaml").write_text(bundle_yaml)
+
+    monkeypatch.setattr("sys.argv", ["charmcraft", "pack", f"--project-dir={new_path}"])
+
+    assert main() == 0
+
+    with zipfile.ZipFile(new_path / "bundle.zip") as bundle_zip:
+        actual_bundle_yaml = bundle_zip.read("bundle.yaml").decode()
+
+    assert actual_bundle_yaml == bundle_yaml

--- a/tests/integration/commands/test_pack.py
+++ b/tests/integration/commands/test_pack.py
@@ -44,7 +44,7 @@ def test_build_basic_bundle(monkeypatch, capsys, new_path, bundle_yaml):
         stdout, stderr = capsys.readouterr()
         raise ValueError(stdout, stderr)
 
-    with zipfile.ZipFile(new_path / "bundle.zip") as bundle_zip:
+    with zipfile.ZipFile("bundle.zip") as bundle_zip:
         actual_bundle_yaml = bundle_zip.read("bundle.yaml").decode()
 
     assert actual_bundle_yaml == bundle_yaml

--- a/tests/integration/commands/test_pack.py
+++ b/tests/integration/commands/test_pack.py
@@ -28,17 +28,21 @@ from charmcraft.application import main
         textwrap.dedent(
             """\
             name: my-bundle
-        """
+            """
         )
     ],
 )
-def test_build_basic_bundle(monkeypatch, new_path, bundle_yaml):
+def test_build_basic_bundle(monkeypatch, capsys, new_path, bundle_yaml):
     (new_path / "charmcraft.yaml").write_text("type: bundle")
     (new_path / "bundle.yaml").write_text(bundle_yaml)
 
     monkeypatch.setattr("sys.argv", ["charmcraft", "pack", f"--project-dir={new_path}"])
 
-    assert main() == 0
+    exit_code = main()
+
+    if exit_code != 0:
+        stdout, stderr = capsys.readouterr()
+        raise ValueError(stdout, stderr)
 
     with zipfile.ZipFile(new_path / "bundle.zip") as bundle_zip:
         actual_bundle_yaml = bundle_zip.read("bundle.yaml").decode()

--- a/tests/integration/commands/test_pack.py
+++ b/tests/integration/commands/test_pack.py
@@ -14,6 +14,7 @@
 #
 # For further info, check https://github.com/canonical/charmcraft
 """Integration tests for packing."""
+import sys
 import textwrap
 import zipfile
 
@@ -22,6 +23,9 @@ import pytest
 from charmcraft.application import main
 
 
+@pytest.mark.xfail(
+    sys.platform == "win32", reason="https://github.com/canonical/charmcraft/issues/1552"
+)
 @pytest.mark.parametrize(
     "bundle_yaml",
     [

--- a/tests/unit/commands/test_lifecycle.py
+++ b/tests/unit/commands/test_lifecycle.py
@@ -1,0 +1,34 @@
+# Copyright 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For further info, check https://github.com/canonical/charmcraft
+"""Unit tests for lifecycle commands."""
+import argparse
+import sys
+
+from charmcraft.application.commands import lifecycle
+
+
+def test_pack_run_managed_bundle_by_os(monkeypatch, new_path):
+    """When packing a bundle, run_managed should return False if and only if we're on posix."""
+    (new_path / "charmcraft.yaml").write_text("type: bundle")
+
+    pack = lifecycle.PackCommand(None)
+
+    result = pack.run_managed(argparse.Namespace())
+
+    if sys.platform in ("win32",):  # non-posix platforms
+        assert result, "Didn't ask for managed mode on non-posix platform"
+    else:
+        assert not result

--- a/tests/unit/commands/test_lifecycle.py
+++ b/tests/unit/commands/test_lifecycle.py
@@ -26,7 +26,7 @@ def test_pack_run_managed_bundle_by_os(monkeypatch, new_path):
 
     pack = lifecycle.PackCommand(None)
 
-    result = pack.run_managed(argparse.Namespace())
+    result = pack.run_managed(argparse.Namespace(destructive_mode=False))
 
     if sys.platform in ("win32",):  # non-posix platforms
         assert result, "Didn't ask for managed mode on non-posix platform"

--- a/tests/unit/extensions/test_bundle.py
+++ b/tests/unit/extensions/test_bundle.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/extensions/test_bundle.py
+++ b/tests/unit/extensions/test_bundle.py
@@ -1,0 +1,58 @@
+# Copyright 2023 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For further info, check https://github.com/canonical/charmcraft
+"""Unit tests for the bundle extension."""
+import pathlib
+
+import pytest
+
+from charmcraft import const
+from charmcraft.extensions import Bundle
+
+
+@pytest.fixture()
+def basic_bundle_extension():
+    return Bundle(project_root=pathlib.Path("/root/project"), yaml_data={})
+
+
+def test_get_supported_bases():
+    assert Bundle.get_supported_bases() == []
+
+
+@pytest.mark.parametrize("base", [None, *const.SUPPORTED_BASES])
+def test_is_experimental(base):
+    assert not Bundle.is_experimental(base)
+
+
+def test_get_root_snippet(basic_bundle_extension):
+    assert basic_bundle_extension.get_root_snippet() == {}
+
+
+def test_get_part_snippet(basic_bundle_extension):
+    assert basic_bundle_extension.get_part_snippet() == {}
+
+
+@pytest.mark.parametrize(
+    "yaml_data",
+    [
+        {},
+        {"parts": {}},
+        {"parts": {"my-part": {"plugin": "nil"}}},
+    ],
+)
+def test_get_parts_snippet_no_parts(basic_bundle_extension, yaml_data):
+    bundle_extension = Bundle(project_root=pathlib.Path("/root/project"), yaml_data=yaml_data)
+
+    assert bundle_extension.get_parts_snippet() == {"bundle": {"plugin": "bundle", "source": "."}}

--- a/tests/unit/parts/test_bundle.py
+++ b/tests/unit/parts/test_bundle.py
@@ -39,7 +39,7 @@ def test_bundleplugin_get_build_commands(bundle_plugin, tmp_path):
     if sys.platform == "linux":
         assert bundle_plugin.get_build_commands() == [
             f'mkdir -p "{str(tmp_path)}/parts/foo/install"',
-            f'cp --archive --link --no-dereference * "{str(tmp_path)}/parts/foo/install"',
+            f'cp --archive --link --no-dereference {tmp_path}/parts/foo/build/* "{str(tmp_path)}/parts/foo/install"',
         ]
     else:
         assert bundle_plugin.get_build_commands() == [

--- a/tests/unit/parts/test_bundle.py
+++ b/tests/unit/parts/test_bundle.py
@@ -44,7 +44,7 @@ def test_bundleplugin_get_build_commands(bundle_plugin, tmp_path):
     else:
         assert bundle_plugin.get_build_commands() == [
             f'mkdir -p "{str(tmp_path)}/parts/foo/install"',
-            f'cp -R -p -P * "{str(tmp_path)}/parts/foo/install"',
+            f'cp -R -p -P {tmp_path}/parts/foo/build/* "{str(tmp_path)}/parts/foo/install"',
         ]
 
 


### PR DESCRIPTION
This creates a basic extension that automatically fills in the parts for a bundle and default-enables it for bundles.

Future additions could include reading `bundle.yaml` into the bundle project.

Motivation for this was fixing bundle builds in the ca-2 feature branch