### PR TITLE
tests (templates): Use pytest fixtures and asserts instead of unittest

### DIFF
--- a/charmcraft/templates/init-kubernetes/tests/unit/test_charm.py.j2
+++ b/charmcraft/templates/init-kubernetes/tests/unit/test_charm.py.j2
@@ -6,7 +6,6 @@
 import ops
 import ops.testing
 import pytest
-
 from charm import {{ class_name }}
 
 
@@ -16,6 +15,7 @@ def harness():
     harness.begin()
     yield harness
     harness.cleanup()
+
 
 def test_pebble_ready(harness: ops.testing.Harness[{{ class_name }}]):
     # Simulate the container coming up and emission of pebble-ready event

--- a/charmcraft/templates/init-kubernetes/tests/unit/test_charm.py.j2
+++ b/charmcraft/templates/init-kubernetes/tests/unit/test_charm.py.j2
@@ -3,21 +3,22 @@
 #
 # Learn more about testing at: https://juju.is/docs/sdk/testing
 
-import unittest
-
 import ops
 import ops.testing
+import pytest
+
 from charm import {{ class_name }}
 
 
-class TestCharm(unittest.TestCase):
-    def setUp(self):
-        self.harness = ops.testing.Harness({{ class_name }})
-        self.addCleanup(self.harness.cleanup)
-        self.harness.begin()
+@pytest.fixture
+def harness():
+    harness = ops.testing.Harness({{ class_name }})
+    harness.begin()
+    yield harness
+    harness.cleanup()
 
-    def test_pebble_ready(self):
-        # Simulate the container coming up and emission of pebble-ready event
-        self.harness.container_pebble_ready("some-container")
-        # Ensure we set an ActiveStatus with no message
-        self.assertEqual(self.harness.model.unit.status, ops.ActiveStatus())
+def test_pebble_ready(harness: ops.testing.Harness[{{ class_name }}]):
+    # Simulate the container coming up and emission of pebble-ready event
+    harness.container_pebble_ready("some-container")
+    # Ensure we set an ActiveStatus with no message
+    assert harness.model.unit.status == ops.ActiveStatus()

--- a/charmcraft/templates/init-machine/tests/unit/test_charm.py.j2
+++ b/charmcraft/templates/init-machine/tests/unit/test_charm.py.j2
@@ -6,7 +6,6 @@
 import ops
 import ops.testing
 import pytest
-
 from charm import {{ class_name }}
 
 
@@ -15,6 +14,7 @@ def harness():
     harness = ops.testing.Harness({{ class_name }})
     yield harness
     harness.cleanup()
+
 
 def test_start(harness: ops.testing.Harness[{{ class_name }}]):
     # Simulate the charm starting

--- a/charmcraft/templates/init-machine/tests/unit/test_charm.py.j2
+++ b/charmcraft/templates/init-machine/tests/unit/test_charm.py.j2
@@ -3,21 +3,22 @@
 #
 # Learn more about testing at: https://juju.is/docs/sdk/testing
 
-import unittest
-
 import ops
 import ops.testing
+import pytest
+
 from charm import {{ class_name }}
 
 
-class TestCharm(unittest.TestCase):
-    def setUp(self):
-        self.harness = ops.testing.Harness({{ class_name }})
-        self.addCleanup(self.harness.cleanup)
+@pytest.fixture
+def harness():
+    harness = ops.testing.Harness({{ class_name }})
+    yield harness
+    harness.cleanup()
 
-    def test_start(self):
-        # Simulate the charm starting
-        self.harness.begin_with_initial_hooks()
+def test_start(harness: ops.testing.Harness[{{ class_name }}]):
+    # Simulate the charm starting
+    harness.begin_with_initial_hooks()
 
-        # Ensure we set an ActiveStatus with no message
-        self.assertEqual(self.harness.model.unit.status, ops.ActiveStatus())
+    # Ensure we set an ActiveStatus with no message
+    assert harness.model.unit.status == ops.ActiveStatus()

--- a/charmcraft/templates/init-simple/src/charm.py.j2
+++ b/charmcraft/templates/init-simple/src/charm.py.j2
@@ -27,7 +27,7 @@ class {{ class_name }}(ops.CharmBase):
 
     def __init__(self, framework: ops.Framework):
         super().__init__(framework)
-        framework.observe(self.on['httpbin'].pebble_ready, self._on_httpbin_pebble_ready)
+        framework.observe(self.on["httpbin"].pebble_ready, self._on_httpbin_pebble_ready)
         framework.observe(self.on.config_changed, self._on_config_changed)
 
     def _on_httpbin_pebble_ready(self, event: ops.PebbleReadyEvent):

--- a/charmcraft/templates/init-simple/tests/unit/test_charm.py.j2
+++ b/charmcraft/templates/init-simple/tests/unit/test_charm.py.j2
@@ -6,16 +6,16 @@
 import ops
 import ops.testing
 import pytest
-
 from charm import {{ class_name }}
 
 
 @pytest.fixture
 def harness():
-    harness = ops.testing.Harness({{ class_name  }})
+    harness = ops.testing.Harness({{ class_name }})
     harness.begin()
     yield harness
     harness.cleanup()
+
 
 def test_httpbin_pebble_ready(harness: ops.testing.Harness[{{ class_name }}]):
     # Expected plan after Pebble ready with default config
@@ -42,6 +42,7 @@ def test_httpbin_pebble_ready(harness: ops.testing.Harness[{{ class_name }}]):
     # Ensure we set an ActiveStatus with no message
     assert harness.model.unit.status == ops.ActiveStatus()
 
+
 def test_config_changed_valid_can_connect(harness: ops.testing.Harness[{{ class_name }}]):
     # Ensure the simulated Pebble API is reachable
     harness.set_can_connect("httpbin", True)
@@ -54,11 +55,13 @@ def test_config_changed_valid_can_connect(harness: ops.testing.Harness[{{ class_
     assert updated_env == {"GUNICORN_CMD_ARGS": "--log-level debug"}
     assert harness.model.unit.status == ops.ActiveStatus()
 
+
 def test_config_changed_valid_cannot_connect(harness: ops.testing.Harness[{{ class_name }}]):
     # Trigger a config-changed event with an updated value
     harness.update_config({"log-level": "debug"})
     # Check the charm is in WaitingStatus
     assert isinstance(harness.model.unit.status, ops.WaitingStatus)
+
 
 def test_config_changed_invalid(harness: ops.testing.Harness[{{ class_name }}]):
     # Ensure the simulated Pebble API is reachable

--- a/charmcraft/templates/init-simple/tests/unit/test_charm.py.j2
+++ b/charmcraft/templates/init-simple/tests/unit/test_charm.py.j2
@@ -3,66 +3,67 @@
 #
 # Learn more about testing at: https://juju.is/docs/sdk/testing
 
-import unittest
-
 import ops
 import ops.testing
+import pytest
+
 from charm import {{ class_name }}
 
 
-class TestCharm(unittest.TestCase):
-    def setUp(self):
-        self.harness = ops.testing.Harness({{ class_name }})
-        self.addCleanup(self.harness.cleanup)
-        self.harness.begin()
+@pytest.fixture
+def harness():
+    harness = ops.testing.Harness({{ class_name  }})
+    harness.begin()
+    yield harness
+    harness.cleanup()
 
-    def test_httpbin_pebble_ready(self):
-        # Expected plan after Pebble ready with default config
-        expected_plan = {
-            "services": {
-                "httpbin": {
-                    "override": "replace",
-                    "summary": "httpbin",
-                    "command": "gunicorn -b 0.0.0.0:80 httpbin:app -k gevent",
-                    "startup": "enabled",
-                    "environment": {"GUNICORN_CMD_ARGS": "--log-level info"},
-                }
-            },
-        }
-        # Simulate the container coming up and emission of pebble-ready event
-        self.harness.container_pebble_ready("httpbin")
-        # Get the plan now we've run PebbleReady
-        updated_plan = self.harness.get_container_pebble_plan("httpbin").to_dict()
-        # Check we've got the plan we expected
-        self.assertEqual(expected_plan, updated_plan)
-        # Check the service was started
-        service = self.harness.model.unit.get_container("httpbin").get_service("httpbin")
-        self.assertTrue(service.is_running())
-        # Ensure we set an ActiveStatus with no message
-        self.assertEqual(self.harness.model.unit.status, ops.ActiveStatus())
+def test_httpbin_pebble_ready(harness: ops.testing.Harness[{{ class_name }}]):
+    # Expected plan after Pebble ready with default config
+    expected_plan = {
+        "services": {
+            "httpbin": {
+                "override": "replace",
+                "summary": "httpbin",
+                "command": "gunicorn -b 0.0.0.0:80 httpbin:app -k gevent",
+                "startup": "enabled",
+                "environment": {"GUNICORN_CMD_ARGS": "--log-level info"},
+            }
+        },
+    }
+    # Simulate the container coming up and emission of pebble-ready event
+    harness.container_pebble_ready("httpbin")
+    # Get the plan now we've run PebbleReady
+    updated_plan = harness.get_container_pebble_plan("httpbin").to_dict()
+    # Check we've got the plan we expected
+    assert expected_plan == updated_plan
+    # Check the service was started
+    service = harness.model.unit.get_container("httpbin").get_service("httpbin")
+    assert service.is_running()
+    # Ensure we set an ActiveStatus with no message
+    assert harness.model.unit.status == ops.ActiveStatus()
 
-    def test_config_changed_valid_can_connect(self):
-        # Ensure the simulated Pebble API is reachable
-        self.harness.set_can_connect("httpbin", True)
-        # Trigger a config-changed event with an updated value
-        self.harness.update_config({"log-level": "debug"})
-        # Get the plan now we've run PebbleReady
-        updated_plan = self.harness.get_container_pebble_plan("httpbin").to_dict()
-        updated_env = updated_plan["services"]["httpbin"]["environment"]
-        # Check the config change was effective
-        self.assertEqual(updated_env, {"GUNICORN_CMD_ARGS": "--log-level debug"})
-        self.assertEqual(self.harness.model.unit.status, ops.ActiveStatus())
+def test_config_changed_valid_can_connect(harness: ops.testing.Harness[{{ class_name }}]):
+    # Ensure the simulated Pebble API is reachable
+    harness.set_can_connect("httpbin", True)
+    # Trigger a config-changed event with an updated value
+    harness.update_config({"log-level": "debug"})
+    # Get the plan now we've run PebbleReady
+    updated_plan = harness.get_container_pebble_plan("httpbin").to_dict()
+    updated_env = updated_plan["services"]["httpbin"]["environment"]
+    # Check the config change was effective
+    assert updated_env == {"GUNICORN_CMD_ARGS": "--log-level debug"}
+    assert harness.model.unit.status == ops.ActiveStatus()
 
-    def test_config_changed_valid_cannot_connect(self):
-        # Trigger a config-changed event with an updated value
-        self.harness.update_config({"log-level": "debug"})
-        # Check the charm is in WaitingStatus
-        self.assertIsInstance(self.harness.model.unit.status, ops.WaitingStatus)
+def test_config_changed_valid_cannot_connect(harness: ops.testing.Harness[{{ class_name }}]):
+    # Trigger a config-changed event with an updated value
+    harness.update_config({"log-level": "debug"})
+    # Check the charm is in WaitingStatus
+    assert isinstance(harness.model.unit.status, ops.WaitingStatus)
 
-    def test_config_changed_invalid(self):
-        # Ensure the simulated Pebble API is reachable
-        self.harness.set_can_connect("httpbin", True)
-        # Trigger a config-changed event with an updated value
-        self.harness.update_config({"log-level": "foobar"})
-        # Check the charm is in BlockedStatus
-        self.assertIsInstance(self.harness.model.unit.status, ops.BlockedStatus)
+def test_config_changed_invalid(harness: ops.testing.Harness[{{ class_name }}]):
+    # Ensure the simulated Pebble API is reachable
+    harness.set_can_connect("httpbin", True)
+    # Trigger a config-changed event with an updated value
+    harness.update_config({"log-level": "foobar"})
+    # Check the charm is in BlockedStatus
+    assert isinstance(harness.model.unit.status, ops.BlockedStatus)


### PR DESCRIPTION
Related to https://github.com/canonical/operator/issues/1110.

I kept the changes as minimal as possible.