### PR TITLE
refactor(tests/spread): test with explicit charmcraft.yaml files

### DIFF
--- a/tests/spread/smoketests/basic/charmcraft-20.04.yaml
+++ b/tests/spread/smoketests/basic/charmcraft-20.04.yaml
@@ -1,0 +1,12 @@
+name: focal
+type: charm
+title: A charm built and running on focal
+summary: A charm built and running on focal
+description: A charm built and running on focal
+bases:
+  - build-on:
+    - name: ubuntu
+      channel: "20.04"
+    run-on:
+    - name: ubuntu
+      channel: "20.04"

--- a/tests/spread/smoketests/basic/charmcraft-22.04.yaml
+++ b/tests/spread/smoketests/basic/charmcraft-22.04.yaml
@@ -1,0 +1,12 @@
+name: jammy
+type: charm
+title: A charm built and running on jammy.
+summary: A charm built and running on jammy.
+description: A charm built and running on jammy.
+bases:
+  - build-on:
+    - name: ubuntu
+      channel: "22.04"
+    run-on:
+    - name: ubuntu
+      channel: "22.04"

--- a/tests/spread/smoketests/basic/charmcraft-23.10.yaml
+++ b/tests/spread/smoketests/basic/charmcraft-23.10.yaml
@@ -1,0 +1,12 @@
+name: mantic
+type: charm
+title: A charm built and running on mantic.
+summary: A charm built and running on mantic.
+description: A charm built and running on mantic.
+bases:
+  - build-on:
+    - name: ubuntu
+      channel: "23.10"
+    run-on:
+    - name: ubuntu
+      channel: "23.10"

--- a/tests/spread/smoketests/basic/charmcraft-alma9.yaml
+++ b/tests/spread/smoketests/basic/charmcraft-alma9.yaml
@@ -1,0 +1,12 @@
+name: alma9
+type: charm
+title: A charm built and running on Almalinux 9.
+summary: A charm built and running on Almalinux 9.
+description: A charm built and running on Almalinux 9.
+bases:
+  - build-on:
+    - name: almalinux
+      channel: "9"
+    run-on:
+      - name: almalinux
+        channel: "9"

--- a/tests/spread/smoketests/basic/task.yaml
+++ b/tests/spread/smoketests/basic/task.yaml
@@ -1,23 +1,18 @@
-summary: pack a simple init-created charm
+summary: pack a simple charm on various bases
 
 environment:
-  BASE_NAME: ubuntu
   BASE_CHANNEL/focal: 20.04
   BASE_CHANNEL/jammy: 22.04
   BASE_CHANNEL/mantic: 23.10  # Non-LTS
   # Alma Linux is disabled temporarily: https://github.com/canonical/charmcraft/issues/1496
-  #BASE_NAME/alma: almalinux
-  #BASE_CHANNEL/alma: 9
+  # BASE_CHANNEL/alma: alma9
 
 include:
   - tests/
 
 prepare: |
-  tests.pkgs install unzip
   charmcraft init --project-dir=charm
-
-  sed -i "s/- name: ubuntu/- name: ${BASE_NAME}/g" charm/charmcraft.yaml
-  sed -i "s/channel:.*/channel: '${BASE_CHANNEL}'/g" charm/charmcraft.yaml
+  cp charmcraft-$BASE_CHANNEL.yaml charm/charmcraft.yaml
 
 restore: |
   pushd charm
@@ -29,6 +24,7 @@ restore: |
 execute: |
   cd charm
   charmcraft pack --verbose
-  test -f charm*.charm
-  unzip -l charm*.charm | MATCH "venv/ops/charm.py"
+  test -f *.charm
+  unzip -l *.charm | MATCH "src/charm.py"
+  unzip -l *.charm | MATCH "venv/ops/charm.py"
   test ! -d build

--- a/tests/spread/smoketests/full-lifecycle/charmcraft-kubernetes.yaml
+++ b/tests/spread/smoketests/full-lifecycle/charmcraft-kubernetes.yaml
@@ -1,0 +1,91 @@
+# This file configures Charmcraft.
+# See https://juju.is/docs/sdk/charmcraft-config for guidance.
+
+# (Required)
+name: kubernetes-bases-charm
+
+
+# (Required)
+type: charm
+
+
+# (Recommended)
+title: Charm Template
+
+
+# (Required)
+summary: A very short one-line summary of the charm.
+
+
+# (Required)
+description: |
+  A single sentence that says what the charm is, concisely and memorably.
+
+  A paragraph of one to three short sentences, that describe what the charm does.
+
+  A third paragraph that explains what need the charm meets.
+
+  Finally, a paragraph that describes whom the charm is useful for.
+
+
+# (Required for 'charm' type)
+bases:
+  - build-on:
+    - name: ubuntu
+      channel: "22.04"
+    run-on:
+    - name: ubuntu
+      channel: "22.04"
+
+
+# (Optional) Configuration options for the charm
+# This config section defines charm config options, and populates the Configure
+# tab on Charmhub.
+# More information on this section at https://juju.is/docs/sdk/charmcraft-yaml#heading--config
+# General configuration documentation: https://juju.is/docs/sdk/config
+config:
+  options:
+    # An example config option to customise the log level of the workload
+    log-level:
+      description: |
+        Configures the log level of gunicorn.
+
+        Acceptable values are: "info", "debug", "warning", "error" and "critical"
+      default: "info"
+      type: string
+
+
+# The containers and resources metadata apply to Kubernetes charms only.
+# See https://juju.is/docs/sdk/metadata-reference for a checklist and guidance.
+
+# Your workload’s containers.
+containers:
+  some-container:
+    resource: some-container-image
+
+
+# This field populates the Resources tab on Charmhub.
+resources:
+  # An OCI image resource for each container listed above.
+  # You may remove this if your charm will run without a workload sidecar container.
+  some-container-image:
+    type: oci-image
+    description: OCI image for the 'some-container' container
+    # The upstream-source field is ignored by Juju. It is included here as a reference
+    # so the integration testing suite knows which image to deploy during testing. This field
+    # is also used by the 'canonical/charming-actions' Github action for automated releasing.
+    upstream-source: some-repo/some-image:some-tag
+
+# Added for the full lifecycle test:
+parts:
+  charm:
+    prime:
+      - extra_file.txt
+  hello:
+    plugin: nil
+    build-packages: [hello]
+    override-build: |
+      hello > "$CRAFT_PART_INSTALL/hello.txt"
+    override-prime: |
+      echo "Running the prime step"
+      craftctl default

--- a/tests/spread/smoketests/full-lifecycle/charmcraft-machine.yaml
+++ b/tests/spread/smoketests/full-lifecycle/charmcraft-machine.yaml
@@ -1,0 +1,70 @@
+# This file configures Charmcraft.
+# See https://juju.is/docs/sdk/charmcraft-config for guidance.
+
+# (Required)
+name: machine-bases-charm
+
+
+# (Required)
+type: charm
+
+
+# (Recommended)
+title: Charm Template
+
+
+# (Required)
+summary: A very short one-line summary of the charm.
+
+
+# (Required)
+description: |
+  A single sentence that says what the charm is, concisely and memorably.
+
+  A paragraph of one to three short sentences, that describe what the charm does.
+
+  A third paragraph that explains what need the charm meets.
+
+  Finally, a paragraph that describes whom the charm is useful for.
+
+
+# (Required for 'charm' type)
+bases:
+  - build-on:
+    - name: ubuntu
+      channel: "22.04"
+    run-on:
+    - name: ubuntu
+      channel: "22.04"
+
+
+# (Optional) Configuration options for the charm
+# This config section defines charm config options, and populates the Configure
+# tab on Charmhub.
+# More information on this section at https://juju.is/docs/sdk/charmcraft-yaml#heading--config
+# General configuration documentation: https://juju.is/docs/sdk/config
+config:
+  options:
+    # An example config option to customise the log level of the workload
+    log-level:
+      description: |
+        Configures the log level of gunicorn.
+
+        Acceptable values are: "info", "debug", "warning", "error" and "critical"
+      default: "info"
+      type: string
+
+
+# Added for the full lifecycle test:
+parts:
+  charm:
+    prime:
+      - extra_file.txt
+  hello:
+    plugin: nil
+    build-packages: [hello]
+    override-build: |
+      hello > "$CRAFT_PART_INSTALL/hello.txt"
+    override-prime: |
+      echo "Running the prime step"
+      craftctl default

--- a/tests/spread/smoketests/full-lifecycle/charmcraft-simple.yaml
+++ b/tests/spread/smoketests/full-lifecycle/charmcraft-simple.yaml
@@ -1,0 +1,99 @@
+# This file configures Charmcraft.
+# See https://juju.is/docs/sdk/charmcraft-config for guidance.
+
+# (Required)
+# The charm package name, no spaces
+# See https://juju.is/docs/sdk/naming#heading--naming-charms for guidance.
+name: simple-bases-charm
+
+
+# (Required)
+# The charm type, either 'charm' or 'bundle'.
+type: charm
+
+
+# (Recommended)
+title: Charm Template
+
+
+# (Required)
+summary: A very short one-line summary of the charm.
+
+
+# (Required)
+description: |
+  A single sentence that says what the charm is, concisely and memorably.
+
+  A paragraph of one to three short sentences, that describe what the charm does.
+
+  A third paragraph that explains what need the charm meets.
+
+  Finally, a paragraph that describes whom the charm is useful for.
+
+
+# (Required for 'charm' type)
+# A list of environments (OS version and architecture) where charms must be
+# built on and run on.
+bases:
+  - build-on:
+    - name: ubuntu
+      channel: "22.04"
+    run-on:
+    - name: ubuntu
+      channel: "22.04"
+
+
+# (Optional) Configuration options for the charm
+# This config section defines charm config options, and populates the Configure
+# tab on Charmhub.
+# More information on this section at https://juju.is/docs/sdk/charmcraft-yaml#heading--config
+# General configuration documentation: https://juju.is/docs/sdk/config
+config:
+  options:
+    # An example config option to customise the log level of the workload
+    log-level:
+      description: |
+        Configures the log level of gunicorn.
+
+        Acceptable values are: "info", "debug", "warning", "error" and "critical"
+      default: "info"
+      type: string
+
+
+# The containers and resources metadata apply to Kubernetes charms only.
+# See https://juju.is/docs/sdk/metadata-reference for a checklist and guidance.
+# Remove them if not required.
+
+
+# Your workload’s containers.
+containers:
+  httpbin:
+    resource: httpbin-image
+
+
+# This field populates the Resources tab on Charmhub.
+resources:
+  # An OCI image resource for each container listed above.
+  # You may remove this if your charm will run without a workload sidecar container.
+  httpbin-image:
+    type: oci-image
+    description: OCI image for httpbin
+    # The upstream-source field is ignored by Juju. It is included here as a
+    # reference so the integration testing suite knows which image to deploy
+    # during testing. This field is also used by the 'canonical/charming-actions'
+    # Github action for automated releasing.
+    upstream-source: kennethreitz/httpbin
+
+# Added for the full lifecycle test:
+parts:
+  charm:
+    prime:
+      - extra_file.txt
+  hello:
+    plugin: nil
+    build-packages: [hello]
+    override-build: |
+      hello > "$CRAFT_PART_INSTALL/hello.txt"
+    override-prime: |
+      echo "Running the prime step"
+      craftctl default

--- a/tests/spread/smoketests/full-lifecycle/task.yaml
+++ b/tests/spread/smoketests/full-lifecycle/task.yaml
@@ -33,10 +33,10 @@ execute: |
   cd charm
   charmcraft pack --verbose
   ~/.local/bin/tox run
-  test -f charm*.charm
+  test -f *.charm
   # Charmcraft 3.0 uses the craft-parts standard prime keyword that only
   # includes the specifically mentioned files
-  unzip -c charm*.charm hello.txt | grep "^Hello, world!"
-  unzip -l charm*.charm | NOMATCH "venv/ops/charm.py"
-  unzip -l charm*.charm | MATCH extra_file.txt
-  unzip -l charm*.charm | NOMATCH secrets.txt
+  unzip -c *.charm hello.txt | grep "^Hello, world!"
+  unzip -l *.charm | NOMATCH "venv/ops/charm.py"
+  unzip -l *.charm | MATCH extra_file.txt
+  unzip -l *.charm | NOMATCH secrets.txt

--- a/tests/spread/smoketests/full-lifecycle/task.yaml
+++ b/tests/spread/smoketests/full-lifecycle/task.yaml
@@ -1,9 +1,9 @@
 summary: pack a charm that uses several lifecycle mechanisms and extra files
 
 environment:
-  TEMPLATE/simple: simple
-  TEMPLATE/machine: machine
-  TEMPLATE/kubernetes: kubernetes
+  PROFILE/simple: simple
+  PROFILE/machine: machine
+  PROFILE/kubernetes: kubernetes
 
 include:
   - tests/
@@ -11,29 +11,16 @@ include:
 kill-timeout: 30m
 
 prepare: |
-  tests.pkgs install unzip
   tests.pkgs install pipx python3-venv
   pipx install --force tox
   rm -rf charm
-  charmcraft init --project-dir=charm
+  charmcraft init --project-dir=charm --profile=${PROFILE}
+
+  cp charmcraft-${PROFILE}.yaml charm/charmcraft.yaml
+
   cd charm
   echo "ignore me" > secrets.txt
   touch extra_file.txt
-
-  cat <<- EOF >> charmcraft.yaml
-  parts:
-    charm:
-      prime:
-        - extra_file.txt
-    hello:
-      plugin: nil
-      build-packages: [hello]
-      override-build: |
-        hello > "\$CRAFT_PART_INSTALL/hello.txt"
-      override-prime: |
-        echo "Running the prime step"
-        craftctl default
-  EOF
 
 restore: |
   pushd charm
@@ -44,8 +31,8 @@ restore: |
 
 execute: |
   cd charm
-  ~/.local/bin/tox run
   charmcraft pack --verbose
+  ~/.local/bin/tox run
   test -f charm*.charm
   # Charmcraft 3.0 uses the craft-parts standard prime keyword that only
   # includes the specifically mentioned files


### PR DESCRIPTION
We're about to have a lot more variants of `charmcraft.yaml` to spread test. This makes it far more straightforward than trying to manipulate charmcraft.yaml during the prepare step.