### PR TITLE
chore: bump craft-providers to 1.23

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ dependencies = [
     "craft-application[remote] @ git+https://github.com/canonical/craft-application@for-charmcraft",
     "craft-cli>=2.3.0",
     "craft-parts>=1.18",
-    "craft-providers",
+    "craft-providers>=1.23.0",
     "craft-store>=2.4",
     "distro>=1.3.0",
     "humanize>=2.6.0",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,7 @@ craft-archives==1.1.3
 craft-cli==2.5.1
 craft-grammar==1.1.2
 craft-parts==1.26.2
-craft-providers==1.22.0
+craft-providers==1.23.0
 craft-store==2.6.0
 cryptography==42.0.4
 Deprecated==1.2.14

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ craft-archives==1.1.3
 craft-cli==2.5.1
 craft-grammar==1.1.2
 craft-parts==1.26.2
-craft-providers==1.22.0
+craft-providers==1.23.0
 craft-store==2.6.0
 cryptography==42.0.4
 Deprecated==1.2.14


### PR DESCRIPTION
Remote build failure is fine: https://github.com/canonical/charmcraft/issues/1566