### PR TITLE
fix: remove distutils and use craft-application.util

### DIFF
--- a/charmcraft/env.py
+++ b/charmcraft/env.py
@@ -16,11 +16,11 @@
 
 """Charmcraft environment utilities."""
 import dataclasses
-import distutils.util
 import os
 import pathlib
 
 import platformdirs
+from craft_application.util import strtobool
 
 from charmcraft import const
 
@@ -77,13 +77,13 @@ def is_charmcraft_running_from_snap():
 def is_charmcraft_running_in_developer_mode():
     """Check if Charmcraft is running under developer mode."""
     developer_flag = os.getenv(const.DEVELOPER_MODE_ENV_VAR, "n")
-    return distutils.util.strtobool(developer_flag) == 1
+    return strtobool(developer_flag)
 
 
 def is_charmcraft_running_in_managed_mode():
     """Check if charmcraft is running in a managed environment."""
     managed_flag = os.getenv(const.MANAGED_MODE_ENV_VAR, os.getenv("CRAFT_MANAGED_MODE", "n"))
-    return distutils.util.strtobool(managed_flag) == 1
+    return strtobool(managed_flag)
 
 
 @dataclasses.dataclass(frozen=True)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@ certifi==2024.2.2
 cffi==1.16.0
 charset-normalizer==3.3.2
 coverage==7.4.2
-craft-application @ git+https://github.com/canonical/craft-application@bd3ac7edcfa22617a457ef47ed0944dcb94ef5c3
+craft-application @ git+https://github.com/canonical/craft-application@main
 craft-archives==1.1.3
 craft-cli==2.5.1
 craft-grammar==1.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ attrs==23.2.0
 certifi==2024.2.2
 cffi==1.16.0
 charset-normalizer==3.3.2
-craft-application @ git+https://github.com/canonical/craft-application@bd3ac7edcfa22617a457ef47ed0944dcb94ef5c3
+craft-application @ git+https://github.com/canonical/craft-application@main
 craft-archives==1.1.3
 craft-cli==2.5.1
 craft-grammar==1.1.2


### PR DESCRIPTION
`distutils` is removed in Python 3.12, use `craft-applicaion.util` replace it.

Fixes: #1527