### PR TITLE
feat(linter): add additional-files linter

### DIFF
--- a/charmcraft/linters.py
+++ b/charmcraft/linters.py
@@ -518,20 +518,20 @@ class Entrypoint(Linter):
 class AdditionalFiles(Linter):
     """Check that the charm does not contain any additional files in the prime directory.
 
-    A few generated files are ignored.
+    A few generated files and basic charm files are ignored.
     """
 
     name = "additional-files"
     text = "No additional files found in the charm."
     url = "https://juju.is/docs/sdk/include-extra-files-in-a-charm"
 
-    INGNORE_FILES: set[pathlib.Path] = {
-        pathlib.Path(const.BUNDLE_FILENAME),
-        pathlib.Path(const.CHARMCRAFT_FILENAME),
-        pathlib.Path(const.MANIFEST_FILENAME),
-        pathlib.Path(const.METADATA_FILENAME),
-        pathlib.Path(const.JUJU_ACTIONS_FILENAME),
-        pathlib.Path(const.JUJU_CONFIG_FILENAME),
+    IGNORE_FILES: set[pathlib.Path] = {
+        pathlib.Path(f)
+        for f in (
+            {const.BUNDLE_FILENAME, const.CHARMCRAFT_FILENAME, const.MANIFEST_FILENAME}
+            | const.CHARM_MANDATORY_FILES
+            | const.CHARM_OPTIONAL_FILES
+        )
     }
 
     def _check_additional_files(self, stage_dir: pathlib.Path, prime_dir: pathlib.Path) -> str:
@@ -543,7 +543,7 @@ class AdditionalFiles(Linter):
         stage_files = {f.relative_to(stage_dir) for f in stage_dir.rglob("*")}
         prime_files = {f.relative_to(prime_dir) for f in prime_dir.rglob("*")}
 
-        prime_files = prime_files - self.INGNORE_FILES
+        prime_files = prime_files - self.IGNORE_FILES
 
         for prime_file in prime_files:
             if prime_file not in stage_files:

--- a/charmcraft/linters.py
+++ b/charmcraft/linters.py
@@ -523,7 +523,7 @@ class AdditionalFiles(Linter):
 
     name = "additional-files"
     text = "No additional files found in the charm."
-    url = "xxxxxx"
+    url = "https://juju.is/docs/sdk/include-extra-files-in-a-charm"
 
     INGNORE_FILES: set[pathlib.Path] = {
         pathlib.Path(const.BUNDLE_FILENAME),

--- a/charmcraft/linters.py
+++ b/charmcraft/linters.py
@@ -515,6 +515,57 @@ class Entrypoint(Linter):
         return self.Result.OK
 
 
+class AdditionalFiles(Linter):
+    """Check that the charm does not contain any additional files in the prime directory.
+
+    A few generated files are ignored.
+    """
+
+    name = "additional-files"
+    text = "No additional files found in the charm."
+    url = "xxxxxx"
+
+    INGNORE_FILES: set[pathlib.Path] = {
+        pathlib.Path(const.BUNDLE_FILENAME),
+        pathlib.Path(const.CHARMCRAFT_FILENAME),
+        pathlib.Path(const.MANIFEST_FILENAME),
+        pathlib.Path(const.METADATA_FILENAME),
+        pathlib.Path(const.JUJU_ACTIONS_FILENAME),
+        pathlib.Path(const.JUJU_CONFIG_FILENAME),
+    }
+
+    def _check_additional_files(self, stage_dir: pathlib.Path, prime_dir: pathlib.Path) -> str:
+        """Compare the staged files with the prime files."""
+        errors: list[str] = []
+        stage_dir = stage_dir.absolute()
+        prime_dir = prime_dir.absolute()
+
+        stage_files = {f.relative_to(stage_dir) for f in stage_dir.rglob("*")}
+        prime_files = {f.relative_to(prime_dir) for f in prime_dir.rglob("*")}
+
+        prime_files = prime_files - self.INGNORE_FILES
+
+        for prime_file in prime_files:
+            if prime_file not in stage_files:
+                errors.append(f"File '{prime_file}' is not staged but in the charm.")
+
+        if errors:
+            self.text = "Error: Additional files found in the charm:\n" + "\n".join(errors)
+            return self.Result.ERROR
+
+        return self.Result.OK
+
+    def run(self, basedir: pathlib.Path) -> str:
+        """Run the proper verifications."""
+        stage_dir = basedir.parent / "stage"
+        if not stage_dir.exists() or not stage_dir.is_dir():
+            # Does not work without the build environment
+            self.text = "Additional files check not applicable without a build environment."
+            return self.Result.NONAPPLICABLE
+
+        return self._check_additional_files(stage_dir, basedir)
+
+
 # all checkers to run; the order here is important, as some checkers depend on the
 # results from others
 CHECKERS: list[type[BaseChecker]] = [
@@ -525,6 +576,7 @@ CHECKERS: list[type[BaseChecker]] = [
     NamingConventions,
     Framework,
     Entrypoint,
+    AdditionalFiles,
 ]
 
 

--- a/charmcraft/parts/charm.py
+++ b/charmcraft/parts/charm.py
@@ -201,8 +201,7 @@ class CharmPlugin(plugins.Plugin):
         dependency resolution will be used, requiring all dependencies, including
         library dependencies, to be defined in provided requirements files.
 
-    Extra files to be included in the charm payload must be listed under
-    the ``prime`` file filter.
+    Extra files to be included in the charm payload must use the ``dump`` plugin.
     """
 
     properties_class = CharmPluginProperties

--- a/tests/test_linters.py
+++ b/tests/test_linters.py
@@ -1257,6 +1257,8 @@ def test_additional_files_checker_not_applicable(tmp_path):
         (pathlib.Path(const.METADATA_FILENAME)),
         (pathlib.Path(const.JUJU_ACTIONS_FILENAME)),
         (pathlib.Path(const.JUJU_CONFIG_FILENAME)),
+        (pathlib.Path(const.HOOKS_DIRNAME)),
+        (pathlib.Path("README.md")),
     ],
 )
 def test_additional_files_checker_generated_ignore(tmp_path, file):

--- a/tests/test_linters.py
+++ b/tests/test_linters.py
@@ -26,6 +26,7 @@ import pytest
 from charmcraft import const
 from charmcraft.linters import (
     CHECKERS,
+    AdditionalFiles,
     BaseChecker,
     CheckType,
     Entrypoint,
@@ -1187,3 +1188,95 @@ def test_entrypoint_non_exec(tmp_path):
         result = linter.run(tmp_path)
     assert result == Entrypoint.Result.ERROR
     assert linter.text == f"The entrypoint file is not executable: {str(entrypoint)!r}"
+
+
+# --- tests for Additional Files checker
+
+
+def test_additional_files_checker(tmp_path):
+    """The additional files checker can find additional files."""
+    stage_dir = tmp_path / "stage"
+    stage_dir.mkdir()
+    prime_dir = tmp_path / "prime"
+    prime_dir.mkdir()
+
+    file_added = prime_dir / "file_added"
+    file_added.write_text("")
+
+    linter = AdditionalFiles()
+    result = linter.run(prime_dir)
+
+    assert result == LintResult.ERROR
+    assert linter.text == (
+        "Error: Additional files found in the charm:\n"
+        "File 'file_added' is not staged but in the charm."
+    )
+
+
+def test_additional_files_checker_ok(tmp_path):
+    """The additional files checker OK with same file list."""
+    stage_dir = tmp_path / "stage"
+    stage_dir.mkdir()
+    prime_dir = tmp_path / "prime"
+    prime_dir.mkdir()
+
+    file_added = prime_dir / "file_added"
+    file_added.write_text("")
+
+    file_added = stage_dir / "file_added"
+    file_added.write_text("")
+
+    linter = AdditionalFiles()
+    result = linter.run(prime_dir)
+
+    assert result == LintResult.OK
+    assert linter.text == "No additional files found in the charm."
+
+
+def test_additional_files_checker_not_applicable(tmp_path):
+    """The additional files checker cannot work without a stage dir."""
+    prime_dir = tmp_path / "prime"
+    prime_dir.mkdir()
+
+    file_added = prime_dir / "file_added"
+    file_added.write_text("")
+
+    linter = AdditionalFiles()
+    result = linter.run(prime_dir)
+
+    assert result == LintResult.NONAPPLICABLE
+    assert linter.text == "Additional files check not applicable without a build environment."
+
+
+@pytest.mark.parametrize(
+    "file",
+    [
+        (pathlib.Path(const.BUNDLE_FILENAME)),
+        (pathlib.Path(const.CHARMCRAFT_FILENAME)),
+        (pathlib.Path(const.MANIFEST_FILENAME)),
+        (pathlib.Path(const.METADATA_FILENAME)),
+        (pathlib.Path(const.JUJU_ACTIONS_FILENAME)),
+        (pathlib.Path(const.JUJU_CONFIG_FILENAME)),
+    ],
+)
+def test_additional_files_checker_generated_ignore(tmp_path, file):
+    """The additional files checker OK with generated files."""
+    stage_dir = tmp_path / "stage"
+    stage_dir.mkdir()
+    prime_dir = tmp_path / "prime"
+    prime_dir.mkdir()
+
+    file_added = prime_dir / "file_added"
+    file_added.write_text("")
+
+    file_added = stage_dir / "file_added"
+    file_added.write_text("")
+
+    file_added = prime_dir / file
+    file_added.write_text("")
+
+    linter = AdditionalFiles()
+    result = linter.run(prime_dir)
+
+    assert result == LintResult.OK
+    assert linter.text == "No additional files found in the charm."


### PR DESCRIPTION
Add extra files should use the dump plugin, not use the prime keywords.

This will errors any extra files added without using the proper ways.