### PR TITLE
chore(deps): Update dependencies for Jammy

### DIFF
--- a/requirements-jammy.txt
+++ b/requirements-jammy.txt
@@ -1,1 +1,1 @@
-python-apt@https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/python-apt/2.4.0ubuntu2/python-apt_2.4.0ubuntu2.tar.xz; sys_platform == "linux"
+python-apt@https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/python-apt/2.4.0ubuntu3/python-apt_2.4.0ubuntu3.tar.xz; sys_platform == "linux"


### PR DESCRIPTION
A new release of `python-apt` is available from Lauchpad.