### PR TITLE
fix: add default charm part in flask-framework

### DIFF
--- a/charmcraft/extensions/gunicorn.py
+++ b/charmcraft/extensions/gunicorn.py
@@ -75,6 +75,12 @@ class _GunicornBase(Extension):
                 f"the '{self.framework}-framework' extension is incompatible with "
                 f"type {charm_type!r}"
             )
+        parts = self.yaml_data.get("parts")
+        if parts and "charm" in parts:
+            raise ExtensionError(
+                f"the '{self.framework}-framework' extension is incompatible with "
+                f"customized charm part"
+            )
         incompatible_fields = {"devices", "extra-bindings", "storage"} & self.yaml_data.keys()
         if incompatible_fields:
             raise ExtensionError(
@@ -138,6 +144,7 @@ class _GunicornBase(Extension):
                 "grafana-dashboard": {"interface": "grafana_dashboard"},
             },
             "config": {"options": {**self._WEBSERVER_OPTIONS, **self.options}},
+            "parts": {"charm": {"plugin": "charm", "source": "."}},
         }
 
     @override

--- a/charmcraft/templates/init-flask-framework/requirements.txt.j2
+++ b/charmcraft/templates/init-flask-framework/requirements.txt.j2
@@ -1,1 +1,1 @@
-https://github.com/canonical/xiilib/archive/v0.2.0.tar.gz
+paas-app-charmer~=0.2.1

--- a/charmcraft/templates/init-flask-framework/src/charm.py.j2
+++ b/charmcraft/templates/init-flask-framework/src/charm.py.j2
@@ -9,12 +9,12 @@ import typing
 
 import ops
 
-import xiilib.flask
+import paas_app_charmer.flask
 
 logger = logging.getLogger(__name__)
 
 
-class FlaskCharm(xiilib.flask.Charm):
+class FlaskCharm(paas_app_charmer.flask.Charm):
     """Flask Charm service."""
 
     def __init__(self, *args: typing.Any) -> None:

--- a/tests/extensions/test_gunicorn.py
+++ b/tests/extensions/test_gunicorn.py
@@ -148,3 +148,16 @@ def test_flask_incompatible_fields(modification, flask_input_yaml, tmp_path):
     flask_input_yaml.update(modification)
     with pytest.raises(ExtensionError):
         apply_extensions(tmp_path, flask_input_yaml)
+
+
+def test_handle_charm_part(flask_input_yaml, tmp_path):
+    # Currently, in the flask-framework extension, we will reject any project that
+    # includes a charm part. This is to prevent issues where a non-default charm part is
+    # incompatible with this extension. This might change in the future.
+    # For the same reason, the Flask-Framework extension will also add a default charm part.
+    flask_input_yaml["parts"] = {"charm": {}}
+    with pytest.raises(ExtensionError):
+        apply_extensions(tmp_path, flask_input_yaml)
+    del flask_input_yaml["parts"]
+    applied = apply_extensions(tmp_path, flask_input_yaml)
+    assert applied["parts"] == {"charm": {"plugin": "charm", "source": "."}}

--- a/tests/extensions/test_gunicorn.py
+++ b/tests/extensions/test_gunicorn.py
@@ -45,7 +45,7 @@ def test_flask_extension(flask_input_yaml, tmp_path):
         "description": "test description",
         "name": "test-flask",
         "config": {"options": {**FlaskFramework.options, **FlaskFramework._WEBSERVER_OPTIONS}},
-        "parts": {},
+        "parts": {"charm": {"plugin": "charm", "source": "."}},
         "peers": {"secret-storage": {"interface": "secret-storage"}},
         "provides": {
             "metrics-endpoint": {"interface": "prometheus_scrape"},


### PR DESCRIPTION
As charmcraft will not automatically add the default `charm` part if extensions are in use, the `flask-framework` extension should include the charm part. Furthermore, as the `flask-framework` extension is designed exclusively for `ops` based charms, it should incorporate a check to ensure that there is no customized charm part in `charmcraft.yaml` that could potentially conflict with the extension.

Some miscellaneous changes include the use of new library packages in the template `requirements.txt`.

Fix: https://github.com/canonical/charmcraft/issues/1616