### PR TITLE
add jammy and x64 labels for self-hosted runners

### DIFF
--- a/.github/workflows/spread-large.yaml
+++ b/.github/workflows/spread-large.yaml
@@ -29,7 +29,7 @@ jobs:
           path: ${{ steps.charmcraft.outputs.snap }}
 
   pack-charm:
-    runs-on: self-hosted
+    runs-on: [self-hosted, large, jammy, x64]
     needs: [snap-build]
     strategy:
       fail-fast: false


### PR DESCRIPTION
Adds the jammy and x64 labels for the self-hosted runner workflows to ensure the workflows don't break as we add more architectures and Ubuntu OS versions.