### PR TITLE
remove experimental flag for flask-framework extension

### DIFF
--- a/charmcraft/extensions/gunicorn.py
+++ b/charmcraft/extensions/gunicorn.py
@@ -55,7 +55,7 @@ class _GunicornBase(Extension):
     @override
     def is_experimental(base: tuple[str, ...] | None) -> bool:  # noqa: ARG004
         """Check if the extension is in an experimental state."""
-        return True
+        return False
 
     framework: str
     actions: dict

--- a/charmcraft/extensions/gunicorn.py
+++ b/charmcraft/extensions/gunicorn.py
@@ -55,7 +55,7 @@ class _GunicornBase(Extension):
     @override
     def is_experimental(base: tuple[str, ...] | None) -> bool:  # noqa: ARG004
         """Check if the extension is in an experimental state."""
-        return False
+        return True
 
     framework: str
     actions: dict
@@ -204,3 +204,9 @@ class FlaskFramework(_GunicornBase):
             "description": "Set the secure attribute in the Flask application cookies. This configuration will set the FLASK_SESSION_COOKIE_SECURE environment variable. Run `app.config.from_prefixed_env()` in your Flask application in order to receive this configuration.",
         },
     }
+
+    @staticmethod
+    @override
+    def is_experimental(base: tuple[str, ...] | None) -> bool:  # noqa: ARG004
+        """Check if the extension is in an experimental state."""
+        return False

--- a/charmcraft/templates/init-flask-framework/requirements.txt.j2
+++ b/charmcraft/templates/init-flask-framework/requirements.txt.j2
@@ -1,1 +1,1 @@
-paas-app-charmer~=0.2.1
+paas-app-charmer==1.*

--- a/tests/extensions/test_gunicorn.py
+++ b/tests/extensions/test_gunicorn.py
@@ -21,8 +21,7 @@ from charmcraft.extensions.gunicorn import FlaskFramework
 
 
 @pytest.fixture(name="flask_input_yaml")
-def flask_input_yaml_fixture(monkeypatch, tmp_path):
-    monkeypatch.setenv("CHARMCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS", "1")
+def flask_input_yaml_fixture(tmp_path):
     return {
         "type": "charm",
         "name": "test-flask",

--- a/tests/spread/commands/init-flask-framework/task.yaml
+++ b/tests/spread/commands/init-flask-framework/task.yaml
@@ -1,8 +1,5 @@
 summary: test charmcraft init with flask-framework profile
 
-environment:
-  CHARMCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS: "true"
-
 execute: |
   unset CHARMCRAFT_STORE_API_URL
   unset CHARMCRAFT_UPLOAD_URL


### PR DESCRIPTION
We have now tested the extension with the web team and they are happy with. This means we're ready to move the `flask-framework` extension to be stable.