### PR TITLE
build(deps): bump internal libraries

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,8 +11,8 @@ colorama==0.4.6
 coverage==7.4.1
 craft-cli==2.4.0
 craft-parts==1.25.2
-craft-providers==1.19.3
-craft-store==2.4.0
+craft-providers==1.20.3
+craft-store==2.5.0
 cryptography==41.0.7
 Deprecated==1.2.14
 distlib==0.3.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,8 @@ cffi==1.16.0
 charset-normalizer==3.3.2
 craft-cli==2.4.0
 craft-parts==1.25.2
-craft-providers==1.19.3
-craft-store==2.4.0
+craft-providers==1.20.3
+craft-store==2.5.0
 cryptography==41.0.7
 Deprecated==1.2.14
 distro==1.8.0


### PR DESCRIPTION
This bumps only craft-providers and craft-store to match the minor versions used by snapcraft 7.x