### PR TITLE
style: autoformat to fix for ruff 0.4

### DIFF
--- a/charmcraft/application/commands/store.py
+++ b/charmcraft/application/commands/store.py
@@ -499,21 +499,21 @@ def get_name_from_zip(filepath):
             name = yaml.safe_load(zf.read("metadata.yaml"))["name"]
         except Exception as err:
             raise CraftError(
-                "Bad 'metadata.yaml' file inside charm zip {!r}: must be a valid YAML with "
-                "a 'name' key.".format(str(filepath))
+                f"Bad 'metadata.yaml' file inside charm zip {str(filepath)!r}: must be a valid YAML with "
+                "a 'name' key."
             ) from err
     elif "bundle.yaml" in zf.namelist():
         try:
             name = yaml.safe_load(zf.read("bundle.yaml"))["name"]
         except Exception as err:
             raise CraftError(
-                "Bad 'bundle.yaml' file inside bundle zip {!r}: must be a valid YAML with "
-                "a 'name' key.".format(str(filepath))
+                f"Bad 'bundle.yaml' file inside bundle zip {str(filepath)!r}: must be a valid YAML with "
+                "a 'name' key."
             ) from err
     else:
         raise CraftError(
-            "The indicated zip file {!r} is not a charm ('metadata.yaml' not found) "
-            "nor a bundle ('bundle.yaml' not found).".format(str(filepath))
+            f"The indicated zip file {str(filepath)!r} is not a charm ('metadata.yaml' not found) "
+            "nor a bundle ('bundle.yaml' not found)."
         )
 
     return name
@@ -1385,9 +1385,7 @@ class PublishLibCommand(CharmcraftCommand):
                 )
             if lib_data.charm_name != charm_name:
                 raise CraftError(
-                    "The library {} does not belong to this charm {!r}.".format(
-                        lib_data.full_name, charm_name
-                    )
+                    f"The library {lib_data.full_name} does not belong to this charm {charm_name!r}."
                 )
             local_libs_data = [lib_data]
         else:

--- a/charmcraft/commands/store.py
+++ b/charmcraft/commands/store.py
@@ -498,21 +498,21 @@ def get_name_from_zip(filepath):
             name = yaml.safe_load(zf.read(const.METADATA_FILENAME))["name"]
         except Exception as err:
             raise CraftError(
-                "Bad 'metadata.yaml' file inside charm zip {!r}: must be a valid YAML with "
-                "a 'name' key.".format(str(filepath))
+                f"Bad 'metadata.yaml' file inside charm zip {str(filepath)!r}: must be a valid YAML with "
+                "a 'name' key."
             ) from err
     elif const.BUNDLE_FILENAME in zf.namelist():
         try:
             name = yaml.safe_load(zf.read(const.BUNDLE_FILENAME))["name"]
         except Exception as err:
             raise CraftError(
-                "Bad 'bundle.yaml' file inside bundle zip {!r}: must be a valid YAML with "
-                "a 'name' key.".format(str(filepath))
+                f"Bad 'bundle.yaml' file inside bundle zip {str(filepath)!r}: must be a valid YAML with "
+                "a 'name' key."
             ) from err
     else:
         raise CraftError(
-            "The indicated zip file {!r} is not a charm ('metadata.yaml' not found) "
-            "nor a bundle ('bundle.yaml' not found).".format(str(filepath))
+            f"The indicated zip file {str(filepath)!r} is not a charm ('metadata.yaml' not found) "
+            "nor a bundle ('bundle.yaml' not found)."
         )
 
     return name
@@ -1380,9 +1380,7 @@ class PublishLibCommand(BaseCommand):
                 )
             if lib_data.charm_name != charm_name:
                 raise CraftError(
-                    "The library {} does not belong to this charm {!r}.".format(
-                        lib_data.full_name, charm_name
-                    )
+                    f"The library {lib_data.full_name} does not belong to this charm {charm_name!r}."
                 )
             local_libs_data = [lib_data]
         else:

--- a/charmcraft/errors.py
+++ b/charmcraft/errors.py
@@ -55,8 +55,7 @@ class BadLibraryPathError(CraftError):
 
     def __init__(self, path):
         super().__init__(
-            "Charm library path {} must conform to lib/charms/<charm>/vN/<libname>.py"
-            "".format(path)
+            f"Charm library path {path} must conform to lib/charms/<charm>/vN/<libname>.py"
         )
 
 

--- a/charmcraft/store/client.py
+++ b/charmcraft/store/client.py
@@ -42,9 +42,7 @@ def build_user_agent():
     else:
         testing = " "
     os_platform = "{0.system}/{0.release} ({0.machine})".format(utils.get_os_platform())
-    return "charmcraft/{}{}{} python/{}".format(
-        __version__, testing, os_platform, platform.python_version()
-    )
+    return f"charmcraft/{__version__}{testing}{os_platform} python/{platform.python_version()}"
 
 
 class AnonymousClient:

--- a/charmcraft/utils/charmlibs.py
+++ b/charmcraft/utils/charmlibs.py
@@ -232,9 +232,7 @@ def get_lib_info(*, full_name=None, lib_path=None):
     # validate internal API matches with what was used in the path
     if internals.api != api_from_path:
         raise CraftError(
-            "Library {!r} metadata field LIBAPI is different from the version in the path.".format(
-                str(lib_path)
-            )
+            f"Library {str(lib_path)!r} metadata field LIBAPI is different from the version in the path."
         )
 
     return LibData(

--- a/tests/commands/test_pack.py
+++ b/tests/commands/test_pack.py
@@ -330,9 +330,7 @@ def test_bundle_missing_name_in_bundle(tmp_path, bundle_yaml, bundle_config):
         PackCommand(bundle_config).run(noargs)
     assert str(cm.value) == (
         "Invalid bundle config; "
-        "missing a 'name' field indicating the bundle's name in file '{}'.".format(
-            tmp_path / const.BUNDLE_FILENAME
-        )
+        f"missing a 'name' field indicating the bundle's name in file '{tmp_path / const.BUNDLE_FILENAME}'."
     )
 
 

--- a/tests/commands/test_store_commands.py
+++ b/tests/commands/test_store_commands.py
@@ -907,8 +907,8 @@ def test_get_name_nor_charm_nor_bundle(tmp_path):
     with pytest.raises(CraftError) as cm:
         get_name_from_zip(bad_zip)
     assert str(cm.value) == (
-        "The indicated zip file '{}' is not a charm ('metadata.yaml' not found) nor a bundle "
-        "('bundle.yaml' not found).".format(bad_zip)
+        f"The indicated zip file '{bad_zip}' is not a charm ('metadata.yaml' not found) nor a bundle "
+        "('bundle.yaml' not found)."
     )
 
 

--- a/tests/commands/test_store_registry.py
+++ b/tests/commands/test_store_registry.py
@@ -1203,16 +1203,12 @@ def test_imagehandler_uploadfromlocal_complete(emitter, tmp_path, responses, mon
             call("progress", "Extracting file 'layer1.bin' from local tar (compress=True)"),
             call(
                 "progress",
-                "Uploading layer blob 1/2, size={}, digest={}".format(
-                    u_layer1_size, u_layer1_digest
-                ),
+                f"Uploading layer blob 1/2, size={u_layer1_size}, digest={u_layer1_digest}",
             ),
             call("progress", "Extracting file 'layer2.bin' from local tar (compress=True)"),
             call(
                 "progress",
-                "Uploading layer blob 2/2, size={}, digest={}".format(
-                    u_layer2_size, u_layer2_digest
-                ),
+                f"Uploading layer blob 2/2, size={u_layer2_size}, digest={u_layer2_digest}",
             ),
         ]
     )
@@ -1295,9 +1291,7 @@ def test_imagehandler_uploadfromlocal_no_config(emitter, tmp_path, monkeypatch):
             call("progress", "Extracting file 'layer.bin' from local tar (compress=True)"),
             call(
                 "progress",
-                "Uploading layer blob 1/1, size={}, digest={}".format(
-                    u_layer_size, u_layer_digest
-                ),
+                f"Uploading layer blob 1/1, size={u_layer_size}, digest={u_layer_digest}",
             ),
         ]
     )

--- a/tests/test_jujuignore.py
+++ b/tests/test_jujuignore.py
@@ -347,9 +347,9 @@ def assert_matched_and_non_matched(globs, matched, unmatched, skip_git=False):
             text=True,
         )
     matched_out = p.stdout.splitlines()
-    assert sorted(matched) == sorted(matched_out), "expected exactly {} to match not {}".format(
-        matched, matched_out
-    )
+    assert sorted(matched) == sorted(
+        matched_out
+    ), f"expected exactly {matched} to match not {matched_out}"
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")

--- a/tests/unit/utils/test_charmlibs.py
+++ b/tests/unit/utils/test_charmlibs.py
@@ -243,9 +243,7 @@ def test_getlibinfo_metadata_api_different_path_api(tmp_path, monkeypatch):
     with pytest.raises(CraftError) as err:
         get_lib_info(lib_path=test_path)
     assert str(err.value) == (
-        "Library {!r} metadata field LIBAPI is different from the version in the path.".format(
-            str(test_path)
-        )
+        f"Library {str(test_path)!r} metadata field LIBAPI is different from the version in the path."
     )
 
 


### PR DESCRIPTION
This was created entirely by running `tox -f format` to run all the autoformatters.