### PR TITLE
fix: make tox tests succeed

### DIFF
--- a/charmcraft/templates/init-simple/src/charm.py.j2
+++ b/charmcraft/templates/init-simple/src/charm.py.j2
@@ -13,6 +13,7 @@ https://juju.is/docs/sdk/create-a-minimal-kubernetes-charm
 """
 
 import logging
+from typing import cast
 
 import ops
 
@@ -57,7 +58,7 @@ class {{ class_name }}(ops.CharmBase):
         Learn more about config at https://juju.is/docs/sdk/config
         """
         # Fetch the new config value
-        log_level = self.model.config["log-level"].lower()
+        log_level = cast(str, self.model.config["log-level"]).lower()
 
         # Do some validation of the configuration option
         if log_level in VALID_LOG_LEVELS:

--- a/tests/integration/commands/test_init.py
+++ b/tests/integration/commands/test_init.py
@@ -259,7 +259,10 @@ def test_executable_set(new_path, init_command):
 
 @pytest.mark.slow()
 @pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
-@pytest.mark.skipif(bool(os.getenv("RUNNING_TOX")), reason="does not work inside tox")
+@pytest.mark.skipif(
+    bool(os.getenv("RUNNING_TOX")) and sys.version_info < (3, 11),
+    reason="does not work inside tox in Python3.10 and below",
+)
 @pytest.mark.parametrize("profile", list(commands.init.PROFILES))
 def test_tox_success(new_path, init_command, profile):
     # fix the PYTHONPATH and PATH so the tests in the initted environment use our own

--- a/tox.ini
+++ b/tox.ini
@@ -33,6 +33,7 @@ env_tmp_dir = {user_tmp_dir:{env:XDG_RUNTIME_DIR:{work_dir}}}/tox_tmp/{env_name}
 set_env =
     TMPDIR={env_tmp_dir}
     COVERAGE_FILE={env_tmp_dir}/.coverage_{env_name}
+    RUNNING_TOX=1
 pass_env =
     CI
     CRAFT_*


### PR DESCRIPTION
Includes both a fix for the environment variable and a workaround for https://github.com/canonical/operator/issues/1212