### PR TITLE
fix(test): parse test command arguments

### DIFF
--- a/charmcraft/application/commands/test.py
+++ b/charmcraft/application/commands/test.py
@@ -72,7 +72,7 @@ class TestCommand(base.CharmcraftCommand):
             nargs=argparse.REMAINDER,
             help=(
                 "Spread tasks to run, in backend:system:suite/task:variant "
-                "format. All fields are optional.",
+                "format. All fields are optional."
             ),
         )
 

--- a/charmcraft/application/commands/test.py
+++ b/charmcraft/application/commands/test.py
@@ -40,7 +40,6 @@ class TestCommand(base.CharmcraftCommand):
     overview = _overview
     common = True
 
-
     def fill_parser(self, parser: argparse.ArgumentParser) -> None:
         """Specify the parameters for this command."""
         group = parser.add_mutually_exclusive_group()
@@ -48,7 +47,7 @@ class TestCommand(base.CharmcraftCommand):
             "--shell",
             action="store_true",
             help="Shell into the environment in lieu of the step to run.",
-         )
+        )
         group.add_argument(
             "--shell-after",
             action="store_true",
@@ -74,7 +73,7 @@ class TestCommand(base.CharmcraftCommand):
             help=(
                 "Spread tasks to run, in backend:system:suite/task:variant "
                 "format. All fields are optional.",
-            )
+            ),
         )
 
     def run(self, parsed_args: argparse.Namespace):

--- a/charmcraft/templates/init-kubernetes/spread.yaml.j2
+++ b/charmcraft/templates/init-kubernetes/spread.yaml.j2
@@ -15,7 +15,7 @@ environment:
   # important to ensure adhoc and linode/qemu behave the same
   SUDO_USER: ""
   SUDO_UID: ""
-  
+
   LANG: "C.UTF-8"
   LANGUAGE: "en"
 
@@ -96,7 +96,7 @@ suites:
     summary: Charm functionality tests
 
     systems:
-      - ubuntu-22.04
+      - ubuntu-22.04*
 
     environment:
       CHARMCRAFT_CHANNEL/charmcraft_current: latest/stable

--- a/charmcraft/templates/init-machine/spread.yaml.j2
+++ b/charmcraft/templates/init-machine/spread.yaml.j2
@@ -13,7 +13,7 @@ environment:
   # important to ensure adhoc and linode/qemu behave the same
   SUDO_USER: ""
   SUDO_UID: ""
-  
+
   LANG: "C.UTF-8"
   LANGUAGE: "en"
 
@@ -94,7 +94,7 @@ suites:
     summary: Charm functionality tests
 
     systems:
-      - ubuntu-22.04
+      - ubuntu-22.04*
 
     environment:
       CHARMCRAFT_CHANNEL/charmcraft_current: latest/stable

--- a/charmcraft/templates/init-simple/spread.yaml.j2
+++ b/charmcraft/templates/init-simple/spread.yaml.j2
@@ -15,7 +15,7 @@ environment:
   # important to ensure adhoc and linode/qemu behave the same
   SUDO_USER: ""
   SUDO_UID: ""
-  
+
   LANG: "C.UTF-8"
   LANGUAGE: "en"
 
@@ -96,7 +96,7 @@ suites:
     summary: Charm functionality tests
 
     systems:
-      - ubuntu-22.04
+      - ubuntu-22.04*
 
     environment:
       CHARMCRAFT_CHANNEL/charmcraft_current: latest/stable

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ target-version = ["py310", "py311"]
 line-length = 99
 
 [tool.codespell]
-ignore-words-list = "buildd,crate,keyserver,comandos,ro,dedent,dedented,tread"
+ignore-words-list = "buildd,crate,keyserver,comandos,ro,dedent,dedented,tread,socio-economic"
 skip = ".tox,.git,build,.*_cache,__pycache__,*.tar,*.snap,*.png,./node_modules,./docs/_build,.direnv,.venv,venv,.vscode,charmcraft.spec"
 quiet-level = 3
 check-filenames = true


### PR DESCRIPTION
Let the test command parse its arguments instead of forwarding them
to spread in raw form. This allows us to use consistent double-dashed
long options, and have better help messages.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>