### PR TITLE
feat: add basic sphinx docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ instance/
 docs/_build/
 # Auto-generated command reference
 /docs/reference/commands/
+/docs/reference/_autosummary/
 
 # PyBuilder
 target/

--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,8 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+# Auto-generated command reference
+/docs/reference/commands/
 
 # PyBuilder
 target/

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,29 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+---
+# Required
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.10"
+  jobs:
+    post_checkout:
+      - git fetch --tags --depth 1 # Also fetch tags
+      - git describe               # Useful for debugging
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+  builder: dirhtml
+  fail_on_warning: false
+
+# Optionally set the version of Python
+# and requirements required to build your docs
+python:
+  install:
+    - requirements: requirements-dev.txt
+    - method: pip
+      path: .[docs]

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,7 +12,7 @@ build:
   jobs:
     post_checkout:
       - git fetch --tags --depth 1 # Also fetch tags
-      - git describe               # Useful for debugging
+      - git describe --always      # Useful for debugging
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/charmcraft/application/commands/store.py
+++ b/charmcraft/application/commands/store.py
@@ -1066,7 +1066,7 @@ class StatusCommand(CharmcraftCommand):
         into a channel. This command shows the various channels for a charm
         and whether there is a charm released.
 
-        For example:
+        For example::
 
           $ charmcraft status
           Track    Base                   Channel    Version    Revision
@@ -1651,16 +1651,17 @@ class FetchLibs(CharmcraftCommand):
         For each library in the top-level `charm-libs` key, fetch the latest library
         version matching those requirements.
 
-        For example:
-        charm-libs:
-          # Fetch lib with API version 0.
-          # If `fetch-libs` is run and a newer minor version is available,
-          # it will be fetched from the store.
-          - lib: postgresql.postgres_client
-            version: "0"
-          # Always fetch precisely version 0.57.
-          - lib: mysql.client
-            version: "0.57"
+        For example::
+
+            charm-libs:
+            # Fetch lib with API version 0.
+            # If `fetch-libs` is run and a newer minor version is available,
+            # it will be fetched from the store.
+            - lib: postgresql.postgres_client
+              version: "0"
+            # Always fetch precisely version 0.57.
+            - lib: mysql.client
+              version: "0.57"
         """
     )
     format_option = True

--- a/charmcraft/format.py
+++ b/charmcraft/format.py
@@ -72,19 +72,19 @@ def printable_field_location_split(location: str) -> tuple[str, str]:
 def format_pydantic_errors(errors, *, file_name: str = const.CHARMCRAFT_FILENAME) -> str:
     """Format errors.
 
-    Example 1: Single error.
+    Example 1: Single error::
 
-    Bad charmcraft.yaml content:
-    - field: <some field>
-      reason: <some reason>
+      Bad charmcraft.yaml content:
+      - field: <some field>
+        reason: <some reason>
 
-    Example 2: Multiple errors.
+    Example 2: Multiple errors::
 
-    Bad charmcraft.yaml content:
-    - field: <some field>
-      reason: <some reason>
-    - field: <some field 2>
-      reason: <some reason 2>
+      Bad charmcraft.yaml content:
+      - field: <some field>
+        reason: <some reason>
+      - field: <some field 2>
+        reason: <some reason 2>
     """
     combined = [f"Bad {file_name} content:"]
     for error in errors:

--- a/charmcraft/instrum.py
+++ b/charmcraft/instrum.py
@@ -104,12 +104,12 @@ class Timer:
     It can work as a context manager that generates a measurement of the block of code inside
     its context, or as a decorator to get the timing of the whole decorated function.
 
-    Usage as a context manager:
+    Usage as a context manager::
 
         with timer("some message", more="stuff", answer=42):
             ...
 
-    Usage as a decorator:
+    Usage as a decorator::
 
         @timer("some message", foo="bar")
         def foo(...):
@@ -118,7 +118,7 @@ class Timer:
     In both cases the message is mandatory and the extra info optional.
 
     Also this class provides a `mark` method to sub-divide the context manager code
-    block. How to use it:
+    block. How to use it::
 
         with timer("some message") as cm:
             ...

--- a/charmcraft/jujuignore.py
+++ b/charmcraft/jujuignore.py
@@ -195,15 +195,11 @@ class JujuIgnore:
     def match(self, path: str, is_dir: bool) -> bool:
         """Check if the given path should be ignored.
 
-        Args:
-        ----
-            path: A local path (eg /foo/bar or foo/bar) from the root directory of the project.
-            is_dir: Indicate whether the given path is a directory (because of special handling
+        :param path: A local path (eg /foo/bar or foo/bar) from the root directory of the project.
+        :param is_dir: Indicate whether the given path is a directory (because of special handling
             from ignore files when the path ends with a '/')
 
-        Return:
-        ------
-            A boolean indicating whether the ignore rules matched the given path (thus the path
+        :returns: A boolean indicating whether the ignore rules matched the given path (thus the path
             should be ignored).
 
         """

--- a/charmcraft/metafiles/actions.py
+++ b/charmcraft/metafiles/actions.py
@@ -23,13 +23,13 @@ import shutil
 import typing
 from typing import TYPE_CHECKING, Literal
 
+from craft_application import util
 import pydantic
 import yaml
 from craft_cli import CraftError, emit
 
 from charmcraft import const
 from charmcraft.format import format_pydantic_errors
-from charmcraft.metafiles import read_yaml
 from charmcraft.models.actions import JujuActions
 
 if TYPE_CHECKING:
@@ -60,7 +60,8 @@ def parse_actions_yaml(charm_dir, allow_broken=False):
     :raises: CraftError if actions.yaml is not valid.
     """
     try:
-        actions = read_yaml(charm_dir / const.JUJU_ACTIONS_FILENAME)
+        with (charm_dir / const.JUJU_ACTIONS_FILENAME).open() as file:
+            actions = util.safe_load_yaml(file)
     except FileNotFoundError:
         return None
     except OSError as exc:

--- a/charmcraft/metafiles/actions.py
+++ b/charmcraft/metafiles/actions.py
@@ -23,9 +23,9 @@ import shutil
 import typing
 from typing import TYPE_CHECKING, Literal
 
-from craft_application import util
 import pydantic
 import yaml
+from craft_application import util
 from craft_cli import CraftError, emit
 
 from charmcraft import const

--- a/charmcraft/metafiles/actions.py
+++ b/charmcraft/metafiles/actions.py
@@ -61,7 +61,7 @@ def parse_actions_yaml(charm_dir, allow_broken=False):
     """
     try:
         with (charm_dir / const.JUJU_ACTIONS_FILENAME).open() as file:
-            actions = util.safe_load_yaml(file)
+            actions = util.safe_yaml_load(file)
     except FileNotFoundError:
         return None
     except OSError as exc:

--- a/charmcraft/models/__init__.py
+++ b/charmcraft/models/__init__.py
@@ -33,6 +33,7 @@ from .project import (
 )
 
 __all__ = [
+    "actions",
     "config",
     "metadata",
     "Base",

--- a/charmcraft/models/__init__.py
+++ b/charmcraft/models/__init__.py
@@ -16,7 +16,7 @@
 
 """Charmcraft pydantic models."""
 
-from . import config, metadata
+from . import actions, config, metadata
 from .charmcraft import Base
 from .lint import CheckResult, CheckType, LintResult, ResultLevel
 from .manifest import Attribute, Manifest

--- a/charmcraft/models/charmcraft.py
+++ b/charmcraft/models/charmcraft.py
@@ -74,7 +74,23 @@ class BasesConfiguration(
     alias_generator=lambda s: s.replace("_", "-"),
     frozen=True,
 ):
-    """Definition of build-on/run-on combinations."""
+    """Definition of build-on/run-on combinations.
+
+    Example::
+
+        bases:
+          - build-on:
+              - name: ubuntu
+                channel: "20.04"
+                architectures: [amd64, arm64]
+            run-on:
+              - name: ubuntu
+                channel: "20.04"
+                architectures: [amd64, arm64]
+              - name: ubuntu
+                channel: "22.04"
+                architectures: [amd64, arm64]
+    """
 
     build_on: list[Base]
     run_on: list[Base]
@@ -110,10 +126,15 @@ class Links(ModelConfigDefaults, frozen=True):
     """Definition of `links` in metadata."""
 
     contact: pydantic.StrictStr | list[pydantic.StrictStr] | None
+    """Instructions for contacting the owner of the charm."""
     documentation: pydantic.AnyHttpUrl | None
+    """The URL of the documentation for this charm."""
     issues: pydantic.AnyHttpUrl | list[pydantic.AnyHttpUrl] | None
+    """A link to the issue tracker for this charm."""
     source: pydantic.AnyHttpUrl | list[pydantic.AnyHttpUrl] | None
+    """Where to find this charm's source code."""
     website: pydantic.AnyHttpUrl | list[pydantic.AnyHttpUrl] | None
+    """The website for this charm."""
 
 
 class CharmcraftConfig(

--- a/charmcraft/models/project.py
+++ b/charmcraft/models/project.py
@@ -19,7 +19,9 @@ import datetime
 import pathlib
 import re
 from collections.abc import Iterable, Iterator
+import textwrap
 from typing import (
+    Annotated,
     Any,
     Literal,
     cast,
@@ -440,8 +442,19 @@ class CharmcraftProject(models.Project, metaclass=abc.ABCMeta):
     summary: CharmcraftSummaryStr | None
     description: str | None
 
-    analysis: AnalysisConfig | None
-    charmhub: CharmhubConfig | None
+    analysis: AnalysisConfig | None = pydantic.Field(
+        default=None,
+        description=textwrap.dedent(
+            """\
+            How analysis done on the charm will behave.
+
+            Currently the only options are to ignore attributes or linters."""
+        ),
+    )
+    charmhub: CharmhubConfig | None = pydantic.Field(
+        default=None,
+        description="(DEPRECATED): Configuration for accessing charmhub."
+    )
     parts: dict[str, dict[str, Any]] = pydantic.Field(default_factory=dict)
 
     # Default project properties that Charmcraft currently does not use. Types are set
@@ -568,36 +581,443 @@ class CharmcraftProject(models.Project, metaclass=abc.ABCMeta):
 
 
 class BasesCharm(CharmcraftProject):
-    """Model for defining a charm."""
+    """A charm using the deprecated ``bases`` keyword.
+
+    This type of charm only supports the following bases:
+        - Ubuntu 18.04
+        - Ubuntu 20.04
+        - Ubuntu 22.04
+        - CentOS 7
+        - Alma Linux 9
+    """
 
     type: Literal["charm"]
-    name: models.ProjectName
-    summary: CharmcraftSummaryStr
-    description: str
+    """The type of project. Must be the string ``charm``."""
+    name: models.ProjectName = pydantic.Field(
+        description=textwrap.dedent(
+            """\
+            The name of the project on Charmhub.
+
+            This value will be used both in the URL of the charm on Charmhub and when
+            deploying the charm with juju.
+
+            Charms should follow the
+            `charm naming guidelines <https://juju.is/docs/sdk/naming>`_."""
+        ),
+        examples=[
+            "mysql",
+            "mysql-k8s",
+        ]
+    )
+    summary: CharmcraftSummaryStr = pydantic.Field(
+        description="A brief (one-line) summary of your charm.",
+    )
+    description: str = pydantic.Field(
+        description="A multi-line summary of your charm."
+    )
 
     # This is defined this way because using conlist makes mypy sad and using
-    # a ConstrainedList child class has pydontic issues. This appears to be
+    # a ConstrainedList child class has pydantic issues. This appears to be
     # solved with Pydantic 2.
     bases: list[BasesConfiguration] = pydantic.Field(min_items=1)
 
     base: None = None
 
-    parts: dict[str, dict[str, Any]] = {"charm": {"plugin": "charm", "source": "."}}
+    parts: dict[str, dict[str, Any]] = pydantic.Field(
+        default={"charm": {"plugin": "charm", "source": "."}},
+        description=textwrap.dedent(
+            """\
+            Configures the various mechanisms to obtain, process and prepare data from
+            different sources that end up being a part of the final charm.
 
-    actions: dict[str, Any] | None
-    assumes: list[str | dict[str, list | dict]] | None
-    containers: dict[str, Any] | None
-    devices: dict[str, Any] | None
-    extra_bindings: dict[str, Any] | None
-    peers: dict[str, Any] | None
-    provides: dict[str, Any] | None
-    requires: dict[str, Any] | None
-    resources: dict[str, Any] | None
-    storage: dict[str, Any] | None
-    subordinate: bool | None
-    terms: list[str] | None
-    links: Links | None
-    config: dict[str, Any] | None
+            Keys are user-defined part names. The value of each key is a map where keys
+            are part names. Charmcraft provides 3 plugins: charm, bundle, reactive.
+
+            Example::
+
+                parts:
+                  libs:
+                    plugin: dump
+                    source: /usr/local/lib/
+                    organize:
+                      "libxxx.so*": lib/
+                    prime:
+                      - lib/""",
+        ),
+    )
+
+    actions: dict[str, Any] | None = pydantic.Field(
+        default=None,
+        description=textwrap.dedent(
+            """\
+            Defines one or more actions.
+
+            This key is equivalent to the
+            `actions.yaml file <https://juju.is/docs/sdk/actions-yaml>`_."""
+        )
+    )
+    assumes: list[str | dict[str, list | dict]] | None = pydantic.Field(
+        default=None,
+        description=textwrap.dedent(
+            """\
+            Explicitly state features a Juju model must be able to provide for a
+            successful deployment of this charm. When a charm includes such
+            requirements, Juju performs a pre-deployment check and displays
+            user-friendly error messages if a feature requirement cannot be met by the
+            model that the user is trying to deploy the charm to. If the assumes
+            section of the charm metadata is omitted, Juju will make a best-effort
+            attempt to deploy the charm, and users must rely on the output of
+            ``juju status`` to figure out whether the deployment was successful.
+
+            The key consists of a list of features that can be given either directly
+            or, depending on the complexity of the condition you want to enforce,
+            nested under one or both of the boolean expressions any-of or all-of,
+            as shown below. In order for a charm to be deployed, all entries in the
+            assumes block must be satisfied.
+
+            Structure::
+
+                assumes:
+                  - <feature-1>
+                  - any-of:
+                    - <feature-2>
+                    - <feature-3>
+                  - all-of:
+                    - <feature-4>
+                    - <feature-5>
+
+            Juju version requirements can be specified with a string such as
+            ``juju >= 3.5`` or ``juju < 4.0``. A full list of supported features
+            can be found in the
+            `Juju documentation <https://juju.is/docs/juju/supported-features>`_.
+            """
+        )
+    )
+    containers: dict[str, Any] | None = pydantic.Field(
+        default=None,
+        description=textwrap.dedent(
+            """\
+            Define a map of containers to be created adjacent to the charm (as a
+            sidecar, in the same pod).
+
+            This is required for Kubernetes charms.
+
+            This key consists of a dictionary mapping container names to their
+            specifications. Each container can be specified in terms of ``resource``,
+            ``bases`` and ``mounts``, where one of either the ``resource`` or the
+            ``bases`` subkeys must be defined and ``mounts`` is optional.
+
+            - ``resource`` is the name of an OCI image resource used to create the
+              container (that you will then define further in the resources block).
+            - ``bases`` is a list of bases to be used for resolving a container image,
+              in descending order of preference. To use it, specify a base name (for
+              example, ``ubuntu`` or ``centos``), a ``channel`` and an
+              ``architecture``.
+            - ``mounts`` is a list of mounted storage volumes for this container. To
+              use it, specify the name of the storage to mount from the charm
+              storage and, optionally, the location where to mount the storage.
+
+            Structure::
+
+                containers:
+                  <container name>:
+                    resource: <resource name>
+                    bases:
+                      - name: <base name>
+                        channel: <track[/risk][/branch]>
+                        architectures:
+                          - <architecture>
+                    mounts:
+                      - storage: <storage name>
+                        location: <path>"""
+        ),
+        examples=[
+            {
+                "super-app": {
+                    "resource": "super-app-image",
+                    "mounts": [{"storage": "logs", "location": "/logs"}],
+                }
+            }
+        ],
+    )
+    devices: dict[str, Any] | None = pydantic.Field(
+        default=None,
+        description=textwrap.dedent(
+            """\
+            Devices the charm needs.
+
+            Structure::
+
+                devices:
+                  <device name>:
+                    type: gpu | nvidia.com/gpu | amd.com/gpu
+                    description: <Optional description>
+                    countmin: <Optional minimum number requested>
+                    countmax: <Optional maximum number requested>"""
+        ),
+        examples=[
+            {
+                "amd-gpu": {
+                    "type": "amd.com/gpu",
+                    "description": "Some sweet AMD GPU",
+                    "countmin": 1,
+                    "countmax": 100,
+                },
+                "nvidia-gpu": {
+                    "type": "nvidia.com/gpu",
+                    "description": "Some NVIDIA GPUs",
+                    "countmin": 20
+                },
+            },
+            {
+                "gpus": {
+                    "type": "gpu",
+                    "description": "A bunch of GPUs",
+                    "countmin": 2,
+                    "countmax": 40,
+                }
+            }
+        ],
+    )
+    extra_bindings: dict[str, Any] | None = pydantic.Field(
+        default=None,
+        description="A key-only mapping representing extra bindings needed."
+    )
+    peers: dict[str, Any] | None = pydantic.Field(
+        default=None,
+        description=textwrap.dedent(
+            """\
+            A map of peer relations.
+
+            Structure::
+
+                peers:
+                  <endpoint name>:
+                    interface: <Required interface name>
+                    limit: <Optional: maximum number of supported connections
+                    optional: <Informational only - whether the relation is required.>
+                    scope: <"global" or "container" - the relation scope.>
+
+            For more information, see
+            `the Juju documentation <https://juju.is/docs/juju/relation>`_."""
+        ),
+        examples=[
+            {
+                "friend": {
+                    "interface": "life",
+                    "limit": 150,
+                    "optional": True,
+                    "scope": "container",
+                }
+            }
+        ],
+    )
+    provides: dict[str, Any] | None = pydantic.Field(
+        default=None,
+        description=textwrap.dedent(
+            """\
+            A map of interfaces this charm provides.
+
+            Structure::
+
+                provides:
+                  <endpoint name>:
+                    interface: <Required interface name>
+                    limit: <Optional: maximum number of supported connections
+                    optional: <Informational only - whether the relation is required.>
+                    scope: <"global" or "container" - the relation scope.>
+
+            For more information, see
+            `the Juju documentation <https://juju.is/docs/juju/relation>`_."""
+        ),
+        examples=[{"self": {"interface": "identity"}}],
+    )
+    requires: dict[str, Any] | None = pydantic.Field(
+        default=None,
+        description=textwrap.dedent(
+            """\
+            A map of relations this charm requires.
+
+            Structure::
+
+                requires:
+                  <endpoint name>:
+                    interface: <Required interface name>
+                    limit: <Optional: maximum number of supported connections
+                    optional: <Informational only - whether the relation is required.>
+                    scope: <"global" or "container" - the relation scope.>
+
+            For more information, see
+            `the Juju documentation <https://juju.is/docs/juju/relation>`_."""
+        ),
+        examples=[
+            {
+                "parent": {
+                    "interface": "birth",
+                    "limit": 2,
+                    "optional": False,
+                    "scope": "global",
+                }
+            }
+        ],
+    )
+    resources: dict[str, Any] | None = pydantic.Field(
+        default=None,
+        description=textwrap.dedent(
+            """\
+            A mapping of resources that accompany the charm.
+
+            See first: `Juju | Charm resource <https://juju.is/docs/juju/charm-resource>`_
+
+            Each resource is made available when the charm is deployed. NOTE:
+            Kubernetes charms must declare an ``oci-image`` type resource for each
+            container declared in ``containers``.
+
+            Structure::
+
+                # (Optional) Additional resources that accompany the charm
+                resources:
+                  <resource name>:
+                    # (Required) The type of the resource
+                    type: file | oci-image
+
+                    # (Optional) Description of the resource and its purpose
+                    description: <description>
+
+                    # (Required: when type:file) The filename of the resource as it
+                    # should appear in the filesystem.
+                    filename: <filename>"""
+        ),
+        examples=[
+            {"water": {"type": "file", "filename": "/dev/h2o"}},
+            {"super-app-image": {"type": "oci-image", "description": "My app!"}},
+        ]
+    )
+    storage: dict[str, Any] | None = pydantic.Field(
+        default=None,
+        description=textwrap.dedent(
+            """\
+            Storage devices requested by the charm.
+
+            Structure::
+
+                storage:
+                  # Each key represents the name of the storage
+                  <storage name>:
+
+                    # (Required) Type of the requested storage
+                    type: filesystem | block
+
+                    # (Optional) Description of the storage requested
+                    description: <description>
+
+                    # (Optional) The mount location for filesystem stores. For
+                    # multi-stores the location acts as the parent directory for each
+                    # mounted store.
+                    location: <location>
+
+                    # Indicates if all units of the application share the storage.
+                    # Defaults to false
+                    shared: true | false
+
+                    # Indicates if the storage should be made read-only (where
+                    # possible). Defaults to false
+                    read-only: true | false
+
+                    # (Optional) The number of storage instances to be requested
+                    multiple:
+                      range: <n> | <n>-<m> | <n>- | <n>+
+
+                    # (Optional) Minimum size of requested storage in forms G, GiB, GB.
+                    # Size multipliers are M, G, T, P, E, Z or Y. With no multiplier
+                    # supplied, M is implied.
+                    minimum-size: <n> | <n><multiplier>
+
+                    # (Optional) List of properties, only supported value is "transient"
+                    properties:
+                      - transient
+            """
+        ),
+        examples=[
+            {
+                "jbod": {
+                    "type": "block",
+                    "description": "A block storage to use as swap space",
+                    "shared": False,
+                    "properties": ["transient"],
+                },
+            },
+        ],
+    )
+    subordinate: bool | None = pydantic.Field(
+        default=None,
+        description="Optional boolean to declare the charm subordinate.",
+        examples = [True],
+    )
+    terms: list[str] | None = pydantic.Field(
+        default = None,
+        description=textwrap.dedent(
+            """\
+            A list of terms to which the user agree by using the charm.
+            These terms are not enforced by the charm, Juju or Canonical."""
+        ),
+        examples=[
+            "Post cat pictures on Mastodon",
+            "Tag your cat pictures with #caturday",
+        ],
+    )
+    links: Links | None = pydantic.Field(
+        default=None,
+        description=textwrap.dedent(
+            """\
+            (Recommended) Links to various additional information used by Charmhub."""
+        ),
+        examples=[
+            {
+                "contact": "Please send your answer to Old Pink, care of the Funny Farm, Chalfont",
+                "documentation": "https://discourse.charmhub.io/t/traefik-k8s-docs-index/10778",
+                "issues": "https://github.com/canonical/traefik-k8s-operator/issues",
+                "source": "https://github.com/canonical/traefik-k8s-operator",
+                "website": "https://charmed-kubeflow.io/",
+            }
+        ],
+    )
+    config: dict[str, Any] | None = pydantic.Field(
+        default=None,
+        description=textwrap.dedent(
+            """\
+            One or more configuration options for your charm.
+
+            Structure::
+
+                config:
+                  options:
+                    # Each option name is the name by which the charm will query the option.
+                    <option name>:
+                      # (Required) The type of the option
+                      type: string | int | float | boolean | secret
+                      # (Optional) The default value of the option
+                      default: <a reasonable default value of the same type as the option>
+                      # (Optional): A string describing the option. Also appears on charmhub.io
+                      description: <description string>"""
+        ),
+        examples=[
+            {
+                "options": {
+                    "name": {
+                        "default": "Wiki",
+                        "description": "The name or title of the Wiki",
+                        "type": "string"
+                    },
+                    "skin":{
+                        "default": "vector",
+                        "description": "Skin to use for the wiki",
+                        "type": "string",
+                    }
+                },
+            },
+        ]
+    )
 
     @pydantic.validator("bases", pre=True, each_item=True, allow_reuse=True)
     def _validate_base(cls, base: BaseDict | LongFormBasesDict) -> LongFormBasesDict:

--- a/charmcraft/models/project.py
+++ b/charmcraft/models/project.py
@@ -18,10 +18,9 @@ import abc
 import datetime
 import pathlib
 import re
-from collections.abc import Iterable, Iterator
 import textwrap
+from collections.abc import Iterable, Iterator
 from typing import (
-    Annotated,
     Any,
     Literal,
     cast,
@@ -452,8 +451,7 @@ class CharmcraftProject(models.Project, metaclass=abc.ABCMeta):
         ),
     )
     charmhub: CharmhubConfig | None = pydantic.Field(
-        default=None,
-        description="(DEPRECATED): Configuration for accessing charmhub."
+        default=None, description="(DEPRECATED): Configuration for accessing charmhub."
     )
     parts: dict[str, dict[str, Any]] = pydantic.Field(default_factory=dict)
 
@@ -607,14 +605,12 @@ class BasesCharm(CharmcraftProject):
         examples=[
             "mysql",
             "mysql-k8s",
-        ]
+        ],
     )
     summary: CharmcraftSummaryStr = pydantic.Field(
         description="A brief (one-line) summary of your charm.",
     )
-    description: str = pydantic.Field(
-        description="A multi-line summary of your charm."
-    )
+    description: str = pydantic.Field(description="A multi-line summary of your charm.")
 
     # This is defined this way because using conlist makes mypy sad and using
     # a ConstrainedList child class has pydantic issues. This appears to be
@@ -654,7 +650,7 @@ class BasesCharm(CharmcraftProject):
 
             This key is equivalent to the
             `actions.yaml file <https://juju.is/docs/sdk/actions-yaml>`_."""
-        )
+        ),
     )
     assumes: list[str | dict[str, list | dict]] | None = pydantic.Field(
         default=None,
@@ -691,7 +687,7 @@ class BasesCharm(CharmcraftProject):
             can be found in the
             `Juju documentation <https://juju.is/docs/juju/supported-features>`_.
             """
-        )
+        ),
     )
     containers: dict[str, Any] | None = pydantic.Field(
         default=None,
@@ -766,7 +762,7 @@ class BasesCharm(CharmcraftProject):
                 "nvidia-gpu": {
                     "type": "nvidia.com/gpu",
                     "description": "Some NVIDIA GPUs",
-                    "countmin": 20
+                    "countmin": 20,
                 },
             },
             {
@@ -776,12 +772,11 @@ class BasesCharm(CharmcraftProject):
                     "countmin": 2,
                     "countmax": 40,
                 }
-            }
+            },
         ],
     )
     extra_bindings: dict[str, Any] | None = pydantic.Field(
-        default=None,
-        description="A key-only mapping representing extra bindings needed."
+        default=None, description="A key-only mapping representing extra bindings needed."
     )
     peers: dict[str, Any] | None = pydantic.Field(
         default=None,
@@ -891,7 +886,7 @@ class BasesCharm(CharmcraftProject):
         examples=[
             {"water": {"type": "file", "filename": "/dev/h2o"}},
             {"super-app-image": {"type": "oci-image", "description": "My app!"}},
-        ]
+        ],
     )
     storage: dict[str, Any] | None = pydantic.Field(
         default=None,
@@ -952,10 +947,10 @@ class BasesCharm(CharmcraftProject):
     subordinate: bool | None = pydantic.Field(
         default=None,
         description="Optional boolean to declare the charm subordinate.",
-        examples = [True],
+        examples=[True],
     )
     terms: list[str] | None = pydantic.Field(
-        default = None,
+        default=None,
         description=textwrap.dedent(
             """\
             A list of terms to which the user agree by using the charm.
@@ -1007,16 +1002,16 @@ class BasesCharm(CharmcraftProject):
                     "name": {
                         "default": "Wiki",
                         "description": "The name or title of the Wiki",
-                        "type": "string"
+                        "type": "string",
                     },
-                    "skin":{
+                    "skin": {
                         "default": "vector",
                         "description": "Skin to use for the wiki",
                         "type": "string",
-                    }
+                    },
                 },
             },
-        ]
+        ],
     )
 
     @pydantic.validator("bases", pre=True, each_item=True, allow_reuse=True)

--- a/charmcraft/providers.py
+++ b/charmcraft/providers.py
@@ -221,8 +221,8 @@ def ensure_provider_is_available(provider: "Provider") -> None:
     If the provider is not installed, the user is prompted to install it.
 
     :param instance: the provider to ensure is available
-    :raises ProviderError: if provider is not available, or if the user
-    chooses not to install the provider.
+    :raises ProviderError: if provider is not available, or if the user chooses not
+        to install the provider.
     """
     # TODO: add provider.name and provider.install_recommendations to craft-providers
     confirm_msg = (
@@ -283,10 +283,8 @@ def get_provider():
     If platform is not Linux, use Multipass.
 
     If platform is Linux:
-    (1) use provider specified with CHARMCRAFT_PROVIDER if running
-        in developer mode,
-    (2) use provider specified with snap configuration if running
-        as snap,
+    (1) use provider specified with CHARMCRAFT_PROVIDER if running in developer mode,
+    (2) use provider specified with snap configuration if running as a snap,
     (3) default to platform default (LXD on Linux).
 
     :return: Provider instance.

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -1,0 +1,28 @@
+@import url('https://fonts.googleapis.com/css2?family=Ubuntu:ital@0;1&display=swap');
+
+body {
+    font-family: Ubuntu, "times new roman", times, roman, serif;
+}
+
+div .toctree-wrapper {
+    column-count: 2;
+}
+
+div .toctree-wrapper>ul {
+    margin: 0;
+}
+
+ul .toctree-l1 {
+    margin: 0;
+    -webkit-column-break-inside: avoid;
+    page-break-inside: avoid;
+    break-inside: avoid-column;
+}
+
+.wy-nav-content {
+    max-width: none;
+}
+
+.log-snippets {
+    color: rgb(141, 141, 141);
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -108,12 +108,10 @@ html_domain_indices = True
 #     craft_parts_docs_path, target_is_directory=True
 # )
 
+
 def generate_cli_docs(nil):
     gen_cli_docs_path = (project_dir / "tools" / "gen_cli_docs.py").resolve()
-    subprocess.run(
-        [sys.executable, gen_cli_docs_path, project_dir / "docs"],
-        check=True
-    )
+    subprocess.run([sys.executable, gen_cli_docs_path, project_dir / "docs"], check=True)
 
 
 def setup(app):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,6 +45,7 @@ ogp_image = "https://assets.ubuntu.com/v1/253da317-image-document-ubuntudocs.svg
 html_context = {
     "product_page": "github.com/canonical/charmcraft",
     "github_url": "https://github.com/canonical/charmcraft",
+    "discourse": "https://discourse.charmhub.io",
 }
 
 extensions = [

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,7 +68,7 @@ extensions.extend(
         "sphinx_autodoc_typehints",  # must be loaded after napoleon
         "sphinxcontrib.details.directive",
         "sphinx_toolbox.collapse",
-
+        "sphinxcontrib.autodoc_pydantic",
     ]
 )
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,95 @@
+# This file is part of charmcraft.
+#
+# Copyright 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For further info, check https://github.com/canonical/charmcraft
+
+import datetime
+import pathlib
+import craft_parts_docs
+
+project = "Charmcraft"
+author = "Canonical"
+
+copyright = "2023-%s, %s" % (datetime.date.today().year, author)
+
+# region Configuration for canonical-sphinx
+ogp_site_url = "https://canonical-charmcraft.readthedocs-hosted.com/"
+ogp_site_name = project
+ogp_image = "https://assets.ubuntu.com/v1/253da317-image-document-ubuntudocs.svg"
+
+html_context = {
+    "product_page": "github.com/canonical/charmcraft",
+    "github_url": "https://github.com/canonical/charmcraft",
+}
+
+extensions = [
+    "canonical_sphinx",
+]
+# endregion
+
+# region General configuration
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions.extend(
+    [
+        "sphinx.ext.intersphinx",
+        "sphinx.ext.viewcode",
+        "sphinx.ext.coverage",
+        "sphinx.ext.doctest",
+        "sphinx-pydantic",
+        "sphinx_toolbox",
+        "sphinx_toolbox.more_autodoc",
+        "sphinx.ext.autodoc",  # Must be loaded after more_autodoc
+        "sphinx_autodoc_typehints",  # must be loaded after napoleon
+        "sphinxcontrib.details.directive",
+        "sphinx_toolbox.collapse",
+
+    ]
+)
+
+# endregion
+
+# region Options for extensions
+# Intersphinx extension
+# https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#configuration
+
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+    "craft-parts": ("https://canonical-craft-parts.readthedocs-hosted.com/en/latest/", None),
+}
+# See also:
+# https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#confval-intersphinx_disabled_reftypes
+intersphinx_disabled_reftypes = ["*"]
+
+# Type hints configuration
+set_type_checking_flag = True
+typehints_fully_qualified = False
+always_document_param_types = True
+
+# Github config
+github_username = "canonical"
+github_repository = "charmcraft"
+
+# endregion
+
+# Setup libraries documentation snippets for use in charmcraft docs.
+# TODO: This needs a craft-parts update first.
+# common_docs_path = pathlib.Path(__file__).parent / "common"
+# craft_parts_docs_path = pathlib.Path(craft_parts_docs.__file__).parent / "craft-parts"
+# (common_docs_path / "craft-parts").unlink(missing_ok=True)
+# (common_docs_path / "craft-parts").symlink_to(
+#     craft_parts_docs_path, target_is_directory=True
+# )

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,11 +17,23 @@
 # For further info, check https://github.com/canonical/charmcraft
 
 import datetime
+import os
 import pathlib
+import subprocess
+import sys
+
 import craft_parts_docs
+
+import charmcraft
+
+project_dir = pathlib.Path(__file__).parents[1].resolve()
 
 project = "Charmcraft"
 author = "Canonical"
+release = charmcraft.__version__
+if ".post" in release:
+    # The commit hash in the dev release version confuses the spellchecker
+    release = "dev"
 
 copyright = "2023-%s, %s" % (datetime.date.today().year, author)
 
@@ -83,6 +95,8 @@ always_document_param_types = True
 github_username = "canonical"
 github_repository = "charmcraft"
 
+html_domain_indices = True
+
 # endregion
 
 # Setup libraries documentation snippets for use in charmcraft docs.
@@ -93,3 +107,14 @@ github_repository = "charmcraft"
 # (common_docs_path / "craft-parts").symlink_to(
 #     craft_parts_docs_path, target_is_directory=True
 # )
+
+def generate_cli_docs(nil):
+    gen_cli_docs_path = (project_dir / "tools" / "gen_cli_docs.py").resolve()
+    subprocess.run(
+        [sys.executable, gen_cli_docs_path, project_dir / "docs"],
+        check=True
+    )
+
+
+def setup(app):
+    app.connect("builder-inited", generate_cli_docs)

--- a/docs/explanation/index.rst
+++ b/docs/explanation/index.rst
@@ -11,4 +11,4 @@ explanation is hosted on the `Charm SDK docs <https://juju.is/docs/sdk/explanati
 
 
 `Charm SDK docs <https://juju.is/docs/sdk/explanation>`_
-********************************************************
+========================================================

--- a/docs/explanation/index.rst
+++ b/docs/explanation/index.rst
@@ -1,0 +1,14 @@
+.. _explanation:
+
+Explanation
+***********
+
+As Charmcraft is a part of the `Juju Charm SDK <https://juju.is/docs/sdk>`_, most
+explanation is hosted on the `Charm SDK docs <https://juju.is/docs/sdk/explanation>`_.
+
+.. toctree::
+   :maxdepth: 1
+
+
+`Charm SDK docs <https://juju.is/docs/sdk/explanation>`_
+********************************************************

--- a/docs/howto/index.rst
+++ b/docs/howto/index.rst
@@ -11,4 +11,4 @@ how-to guides are hosted on the `Charm SDK docs <https://juju.is/docs/sdk/how-to
 
 
 `Charm SDK docs <https://juju.is/docs/sdk/how-to>`_
-***************************************************
+===================================================

--- a/docs/howto/index.rst
+++ b/docs/howto/index.rst
@@ -1,0 +1,14 @@
+.. _howto:
+
+How-to guides
+*************
+
+As Charmcraft is a part of the `Juju Charm SDK <https://juju.is/docs/sdk>`_, most
+how-to guides are hosted on the `Charm SDK docs <https://juju.is/docs/sdk/how-to>`_.
+
+.. toctree::
+   :maxdepth: 1
+
+
+`Charm SDK docs <https://juju.is/docs/sdk/how-to>`_
+***************************************************

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -51,5 +51,4 @@ Indices and tables
 ==================
 
 * :ref:`genindex`
-* :ref:`modindex`
 * :ref:`search`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,55 @@
+.. Charmcraft documentation root file
+
+Charmcraft
+==========
+
+Charmcraft is part of the `Juju Charm SDK <https://juju.is/docs/sdk>`_.
+Most of Charmcraft's documentation is available there.
+
+.. toctree::
+   :maxdepth: 1
+   :hidden:
+
+   tutorials/index
+   howto/index
+   reference/index
+   explanation/index
+
+.. grid:: 1 1 2 2
+
+   .. grid-item-card:: :ref:`Tutorial <tutorial>`
+
+      **Get started** with a hands-on introduction to Charmcraft
+
+   .. grid-item-card:: :ref:`How-to guides <howto>`
+
+      **Step-by-step guides** covering key operations and common tasks
+
+.. grid:: 1 1 2 2
+   :reverse:
+
+   .. grid-item-card:: :ref:`Reference <reference>`
+
+      **Technical information** about Charmcraft
+
+   .. grid-item-card:: :ref:`Explanation <explanation>`
+
+      **Discussion and clarification** of key topics
+
+Project and community
+=====================
+
+Charmcraft is a member of the Canonical family. It's an open source project
+that warmly welcomes community projects, contributions, suggestions, fixes
+and constructive feedback.
+
+* `Ubuntu Code of Conduct <https://ubuntu.com/community/code-of-conduct>`_.
+* `Canonical contributor licenses agreement
+  <https://ubuntu.com/legal/contributors>`_.
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/reference/commands.rst
+++ b/docs/reference/commands.rst
@@ -39,7 +39,12 @@ Library Commands
 
 .. include:: commands/store (libraries)-commands.rst
 
+Extensions-related Commands
+===========================
+
+.. include:: commands/extensions-commands.rst
+
 Other Commands
---------------
+==============
 
 .. include:: commands/other-commands.rst

--- a/docs/reference/commands.rst
+++ b/docs/reference/commands.rst
@@ -1,0 +1,45 @@
+.. _commands:
+
+Commands
+********
+
+.. Use a hidden table of contents to ensure that documentation is read.
+
+.. include:: commands/toc.rst
+
+Charmcraft has several commands used for managing the building, uploading and releasing
+of a charm.
+
+.. include:: commands/basic-commands.rst
+
+
+Lifecycle Commands
+==================
+
+.. include:: commands/lifecycle-commands.rst
+
+
+Store Commands
+==============
+
+Store commands fall into several categories, depending on the particular command.
+
+Account Commands
+----------------
+
+.. include:: commands/store (account)-commands.rst
+
+Charm or Bundle Commands
+------------------------
+
+.. include:: commands/store (charm or bundle)-commands.rst
+
+Library Commands
+----------------
+
+.. include:: commands/store (libraries)-commands.rst
+
+Other Commands
+--------------
+
+.. include:: commands/other-commands.rst

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -1,0 +1,18 @@
+.. _reference:
+
+Reference
+*********
+
+Charmcraft is a part of the `Juju Charm SDK <https://juju.is/docs/sdk>`_. This
+documentation only contains references about Charmcraft itself. Overall SDK reference
+data can be found in the `Charm SDK docs <https://juju.is/docs/sdk/reference>`_.
+
+.. toctree::
+   :maxdepth: 1
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -12,4 +12,3 @@ data can be found in the `Charm SDK docs <https://juju.is/docs/sdk/reference>`_.
 
     commands
     models/index
-    /modindex

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -11,4 +11,5 @@ data can be found in the `Charm SDK docs <https://juju.is/docs/sdk/reference>`_.
     :maxdepth: 2
 
     commands
+    models/index
     /modindex

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -8,11 +8,7 @@ documentation only contains references about Charmcraft itself. Overall SDK refe
 data can be found in the `Charm SDK docs <https://juju.is/docs/sdk/reference>`_.
 
 .. toctree::
-   :maxdepth: 1
+    :maxdepth: 2
 
-
-Indices and tables
-==================
-
-* :ref:`genindex`
-* :ref:`modindex`
+    commands
+    /modindex

--- a/docs/reference/models/bases-charm.rst
+++ b/docs/reference/models/bases-charm.rst
@@ -1,0 +1,43 @@
+.. _bases_charm:
+
+Charm with the ``bases`` keyword
+********************************
+
+.. currentmodule:: charmcraft.models.project
+
+.. autopydantic_model:: BasesCharm
+    :model-show-config-summary: False
+    :model-show-field-summary: False
+    :model-show-validator-summary: False
+    :model-show-validator-members: False
+    :model-summary-list-order: bysource
+    :member-order: bysource
+    :field-list-validators: False
+    :exclude-members: base, version, license, contact, issues, source-code
+
+.. autopydantic_model:: BasesConfiguration
+    :model-show-config-summary: False
+    :model-show-field-summary: False
+    :model-show-validator-summary: False
+    :model-show-validator-members: False
+    :model-summary-list-order: bysource
+    :member-order: bysource
+    :field-list-validators: False
+
+.. autopydantic_model:: charmcraft.models.charmcraft.Base
+    :model-show-config-summary: False
+    :model-show-field-summary: False
+    :model-show-validator-summary: False
+    :model-show-validator-members: False
+    :model-summary-list-order: bysource
+    :member-order: bysource
+    :field-list-validators: False
+
+.. autopydantic_model:: Links
+    :model-show-config-summary: False
+    :model-show-field-summary: False
+    :model-show-validator-summary: False
+    :model-show-validator-members: False
+    :model-summary-list-order: bysource
+    :member-order: bysource
+    :field-list-validators: False

--- a/docs/reference/models/index.rst
+++ b/docs/reference/models/index.rst
@@ -1,0 +1,9 @@
+.. _models:
+
+Data Models
+***********
+
+.. toctree::
+    :maxdepth: 2
+
+    bases-charm

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -1,0 +1,14 @@
+.. _tutorial:
+
+Tutorials
+*********
+
+As Charmcraft is a part of the `Juju Charm SDK <https://juju.is/docs/sdk>`_, most
+tutorials are hosted on the `Charm SDK docs <https://juju.is/docs/sdk/tutorials>`_.
+
+.. toctree::
+   :maxdepth: 1
+
+
+`Charm SDK docs <https://juju.is/docs/sdk/tutorials>`_
+******************************************************

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -11,4 +11,4 @@ tutorials are hosted on the `Charm SDK docs <https://juju.is/docs/sdk/tutorials>
 
 
 `Charm SDK docs <https://juju.is/docs/sdk/tutorials>`_
-******************************************************
+======================================================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,15 @@ types = [
 apt = [
     "python-apt>=2.4.0;sys_platform=='linux'"
 ]
+docs = [
+    "canonical-sphinx~=0.1",
+    "pyspelling",
+    "sphinx-autobuild~=2024.2",
+    "sphinx-pydantic==0.1.1",
+    "sphinx-toolbox~=3.5",
+    "sphinx-lint==0.9.1",
+    "sphinxcontrib-details-directive",
+]
 
 [build-system]
 requires = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ apt = [
 docs = [
     "canonical-sphinx~=0.1",
     "pyspelling",
+    "autodoc-pydantic<=2.0",
     "sphinx-autobuild~=2024.2",
     "sphinx-pydantic==0.1.1",
     "sphinx-toolbox~=3.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,10 +80,11 @@ docs = [
     "pyspelling",
     "autodoc-pydantic<=2.0",
     "sphinx-autobuild~=2024.2",
-    "sphinx-pydantic==0.1.1",
+    "sphinx-pydantic~=0.1",
     "sphinx-toolbox~=3.5",
-    "sphinx-lint==0.9.1",
+    "sphinx-lint~=0.9",
     "sphinxcontrib-details-directive",
+    "matplotlib",
 ]
 
 [build-system]

--- a/tools/gen_cli_docs.py
+++ b/tools/gen_cli_docs.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import pathlib
+import sys
+
+from craft_cli.dispatcher import Dispatcher, _CustomArgumentParser
+
+this_dir = pathlib.Path(os.path.split(__file__)[0])
+sys.path.insert(0, str((this_dir / "..").absolute()))
+
+from charmcraft import application, services
+
+
+def command_page_header(cmd, options_str, required_str):
+    underline = "=" * len(cmd.name)
+    overview = fix_spelling(cmd.overview)
+    return f"""
+.. _ref_commands_{cmd.name}:
+
+{cmd.name}
+{underline}
+{overview}
+
+Usage
+-----
+
+:command:`charmcraft {cmd.name}{options_str}{required_str}`
+
+"""
+
+
+# Temporary fix for spelling checks.
+def fix_spelling(t):
+    for old, new in [("artifact", "artefact"), ("Initialize", "Initialise")]:
+        t = t.replace(old, new)
+    return t
+
+
+def make_sentence(t):
+    return t[:1].upper() + t[1:].rstrip(".") + "."
+
+
+def not_none(*args):
+    return [x for x in args if x != None]
+
+
+def make_section(title, items):
+    s = ""
+    if items:
+        underline = "-" * len(title)
+        s = f"{title}\n{underline}\n\n"
+
+    for dest, (names, help_str) in sorted(items):
+        names = " or ".join([f"``{name}``" for name in names])
+        description = make_sentence(fix_spelling(help_str))
+        s += f"{names}\n   {description}\n"
+
+    s += "\n"
+    return s
+
+
+def main(docs_dir):
+    """Generate reference documentation for the command line interface,
+    creating pages in the docs/reference/commands directory and creating the
+    directory itself if necessary."""
+
+    # Create the directory for the commands reference.
+    commands_ref_dir = docs_dir / "reference" / "commands"
+    if not commands_ref_dir.exists():
+        commands_ref_dir.mkdir()
+
+    # Create a dispatcher like Charmcraft does to get access to the same options.
+    charmcraft_services = services.CharmcraftServiceFactory(app=application.APP_METADATA)
+    app = application.Charmcraft(app=application.APP_METADATA, services=charmcraft_services)
+    application.commands.fill_command_groups(app)
+    command_groups = app.command_groups
+
+    dispatcher = Dispatcher(
+        app.app.name,
+        command_groups,
+        summary=str(app.app.summary),
+        extra_global_args=app._global_arguments,
+    )
+
+    help_builder = dispatcher._help_builder
+
+    global_options = {}
+    for arg in dispatcher.global_arguments:
+        opts = not_none(arg.short_option, arg.long_option)
+        global_options[arg.name] = (opts, arg.help_message)
+
+    toc = []
+
+    for group in command_groups:
+        group_name = group.name.lower() + "-commands" + os.extsep + "rst"
+        group_path = commands_ref_dir / group_name
+        g = group_path.open("w")
+
+        for cmd_class in group.commands:
+            if cmd_class.hidden:
+                continue
+            cmd = cmd_class({"app": {}, "services": {}})
+            p = _CustomArgumentParser(help_builder)
+            cmd.fill_parser(p)
+
+            options = {}
+            required = []
+            options_str = " "
+
+            for action in sorted(p._actions, key=lambda a: a.dest):
+                if action.required:
+                    required.append((action.dest, ([action.metavar], action.help)))
+                elif action.option_strings and action.dest not in global_options:
+                    options[action.dest] = (action.option_strings, action.help)
+
+            cmd_path = commands_ref_dir / (cmd.name + os.extsep + "rst")
+
+            if options or global_options:
+                options_str += "[options]"
+            required_str = "".join([(" <%s>" % vl[0]) for d, (vl, h) in required])
+
+            f = cmd_path.open("w")
+            f.write(command_page_header(cmd, options_str, required_str))
+            f.write(make_section("Required", required))
+            f.write(make_section("Options", options.items()))
+            f.write(make_section("Global options", global_options.items()))
+
+            # Add a section for the command to be included in the group reference.
+            g.write(f":ref:`ref_commands_{cmd.name}`\n")
+            g.write(
+                "   "
+                + make_sentence(fix_spelling(cmd.help_msg)).replace("\n", "\n   ")
+                + "\n\n"
+            )
+
+            # Add an entry in the table of contents.
+            toc.append(cmd.name)
+
+    toc_path = commands_ref_dir / "toc.rst"
+    f = toc_path.open("w")
+    f.write(".. toctree::\n   :hidden:\n\n")
+    for name in sorted(toc):
+        f.write(f"   /reference/commands/{name}\n")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) == 2:
+        main(pathlib.Path(sys.argv[1]))

--- a/tools/gen_cli_docs.py
+++ b/tools/gen_cli_docs.py
@@ -130,9 +130,7 @@ def main(docs_dir):
             # Add a section for the command to be included in the group reference.
             g.write(f":ref:`ref_commands_{cmd.name}`\n")
             g.write(
-                "   "
-                + make_sentence(fix_spelling(cmd.help_msg)).replace("\n", "\n   ")
-                + "\n\n"
+                "   " + make_sentence(fix_spelling(cmd.help_msg)).replace("\n", "\n   ") + "\n\n"
             )
 
             # Add an entry in the table of contents.

--- a/tox.ini
+++ b/tox.ini
@@ -120,6 +120,7 @@ commands = pre-commit {posargs:run}
 extras = docs
 package = editable
 no_package = true
+env_dir = {work_dir}/docs
 runner = ignore_env_name_mismatch
 source_dir = {tox_root}/{project_name}
 

--- a/tox.ini
+++ b/tox.ini
@@ -120,7 +120,6 @@ commands = pre-commit {posargs:run}
 extras = docs
 package = editable
 no_package = true
-env_dir = {work_dir}
 runner = ignore_env_name_mismatch
 source_dir = {tox_root}/{project_name}
 
@@ -130,12 +129,12 @@ base = docs
 allowlist_externals = bash
 commands_pre = bash -c 'if [[ ! -e docs ]];then echo "No docs directory. Run `tox run -e sphinx-quickstart` to create one.;";return 1;fi'
 # "-W" is to treat warnings as errors
-commands = sphinx-build {posargs:-b html} -W {tox_root}/docs {tox_root}/docs/_build
+commands = sphinx-build {posargs:-b html} {tox_root}/docs {tox_root}/docs/_build
 
 [testenv:autobuild-docs]
 description = Build documentation with an autoupdating server
 base = docs
-commands = sphinx-autobuild {posargs:-b html --open-browser --port 8080} -W --watch {tox_root} --re-ignore ".*.kate-swp" {tox_root}/docs {tox_root}/docs/_build
+commands = sphinx-autobuild {posargs:-b html --open-browser --port 8080} --watch {tox_root} --re-ignore ".*.kate-swp" --re-ignore "docs/reference/commands/" {tox_root}/docs {tox_root}/docs/_build
 
 [lint-docs]
 find = git ls-files

--- a/tox.ini
+++ b/tox.ini
@@ -130,7 +130,9 @@ base = docs
 allowlist_externals = bash
 commands_pre = bash -c 'if [[ ! -e docs ]];then echo "No docs directory. Run `tox run -e sphinx-quickstart` to create one.;";return 1;fi'
 # "-W" is to treat warnings as errors
-commands = sphinx-build {posargs:-b html} -W {tox_root}/docs {tox_root}/docs/_build
+commands =
+;     sphinx-apidoc -o docs/reference/_autogen charmcraft
+    sphinx-build {posargs:-b html} -W {tox_root}/docs {tox_root}/docs/_build
 
 [testenv:autobuild-docs]
 description = Build documentation with an autoupdating server

--- a/tox.ini
+++ b/tox.ini
@@ -115,3 +115,35 @@ env_dir = {work_dir}/pre-commit
 runner = ignore_env_name_mismatch
 description = Run pre-commit on staged files or arbitrary pre-commit commands (tox run -e pre-commit -- [args])
 commands = pre-commit {posargs:run}
+
+[docs]  # Sphinx documentation configuration
+extras = docs
+package = editable
+no_package = true
+env_dir = {work_dir}
+runner = ignore_env_name_mismatch
+source_dir = {tox_root}/{project_name}
+
+[testenv:build-docs]
+description = Build sphinx documentation
+base = docs
+allowlist_externals = bash
+commands_pre = bash -c 'if [[ ! -e docs ]];then echo "No docs directory. Run `tox run -e sphinx-quickstart` to create one.;";return 1;fi'
+# "-W" is to treat warnings as errors
+commands = sphinx-build {posargs:-b html} -W {tox_root}/docs {tox_root}/docs/_build
+
+[testenv:autobuild-docs]
+description = Build documentation with an autoupdating server
+base = docs
+commands = sphinx-autobuild {posargs:-b html --open-browser --port 8080} -W --watch {tox_root} --re-ignore ".*.kate-swp" {tox_root}/docs {tox_root}/docs/_build
+
+[lint-docs]
+find = git ls-files
+
+[testenv:lint-docs]
+description = Lint the documentation with sphinx-lint
+base = docs
+labels = lint
+allowlist_externals = bash, xargs
+commands_pre = bash -c '{[lint-docs]find} > {env_tmp_dir}/lint_docs_files'
+commands = xargs --no-run-if-empty --arg-file {env_tmp_dir}/lint_docs_files sphinx-lint --max-line-length 88 --enable all {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -130,7 +130,7 @@ base = docs
 allowlist_externals = bash
 commands_pre = bash -c 'if [[ ! -e docs ]];then echo "No docs directory. Run `tox run -e sphinx-quickstart` to create one.;";return 1;fi'
 # "-W" is to treat warnings as errors
-commands = sphinx-build {posargs:-b html} {tox_root}/docs {tox_root}/docs/_build
+commands = sphinx-build {posargs:-b html} -W {tox_root}/docs {tox_root}/docs/_build
 
 [testenv:autobuild-docs]
 description = Build documentation with an autoupdating server


### PR DESCRIPTION
Adds a Sphinx documentation project and some basic documentation. The purpose is to allow automatic generation of certain reference documentation that would otherwise need to be manually generated for juju.is.

This includes using the Starcraft standard `starbase` sphinx docs, A command documentation generator from rockcraft, and additions to some pydantic models to copy documentation out of what's on juju.is.

Fixes #1692 