### PR TITLE
fix(flask): include cargo build-dep

### DIFF
--- a/charmcraft/extensions/gunicorn.py
+++ b/charmcraft/extensions/gunicorn.py
@@ -223,6 +223,12 @@ class FlaskFramework(_GunicornBase):
         """Check if the extension is in an experimental state."""
         return False
 
+    @override
+    def get_parts_snippet(self) -> dict[str, Any]:
+        """Return the parts to add to parts."""
+        # rust is needed to build pydantic-core, a dependency of flask.
+        return {"flask-framework/rust-deps": {"plugin": "nil", "build-packages": ["cargo"]}}
+
 
 class DjangoFramework(_GunicornBase):
     """Extension for 12-factor Django applications."""

--- a/tests/extensions/test_gunicorn.py
+++ b/tests/extensions/test_gunicorn.py
@@ -65,7 +65,10 @@ def flask_input_yaml_fixture():
                 "config": {
                     "options": {**FlaskFramework.options, **FlaskFramework._WEBSERVER_OPTIONS}
                 },
-                "parts": {"charm": {"plugin": "charm", "source": "."}},
+                "parts": {
+                    "charm": {"plugin": "charm", "source": "."},
+                    "flask-framework/rust-deps": {"plugin": "nil", "build-packages": ["cargo"]},
+                },
                 "peers": {"secret-storage": {"interface": "secret-storage"}},
                 "provides": {
                     "metrics-endpoint": {"interface": "prometheus_scrape"},
@@ -245,4 +248,4 @@ def test_handle_charm_part(flask_input_yaml, tmp_path):
         apply_extensions(tmp_path, flask_input_yaml)
     del flask_input_yaml["parts"]
     applied = apply_extensions(tmp_path, flask_input_yaml)
-    assert applied["parts"] == {"charm": {"plugin": "charm", "source": "."}}
+    assert applied["parts"]["charm"] == {"plugin": "charm", "source": "."}


### PR DESCRIPTION
This is needed because flask has an indirect dependency on rust-based modules.

Snap store test is unrelated (#1712)