### PR TITLE
fix(pip): set `--no-binary=:all:` if possible

### DIFF
--- a/tests/test_charm_builder.py
+++ b/tests/test_charm_builder.py
@@ -616,7 +616,7 @@ def test_build_dependencies_virtualenv_simple(tmp_path, assert_output):
     assert mock.mock_calls == [
         call(["python3", "-m", "venv", str(tmp_path / STAGING_VENV_DIRNAME)]),
         call([pip_cmd, "install", f"pip@{KNOWN_GOOD_PIP_URL}"]),
-        call([pip_cmd, "install", f"--requirement={reqs_file}"]),
+        call([pip_cmd, "install", "--no-binary=:all:", f"--requirement={reqs_file}"]),
     ]
 
     site_packages_dir = charm_builder._find_venv_site_packages(pathlib.Path(STAGING_VENV_DIRNAME))
@@ -657,6 +657,7 @@ def test_build_dependencies_virtualenv_multiple(tmp_path, assert_output):
             [
                 pip_cmd,
                 "install",
+                "--no-binary=:all:",
                 f"--requirement={reqs_file_1}",
                 f"--requirement={reqs_file_2}",
             ]
@@ -714,7 +715,7 @@ def test_build_dependencies_virtualenv_packages(tmp_path, assert_output):
     assert mock.mock_calls == [
         call(["python3", "-m", "venv", str(tmp_path / STAGING_VENV_DIRNAME)]),
         call([pip_cmd, "install", f"pip@{KNOWN_GOOD_PIP_URL}"]),
-        call([pip_cmd, "install", "--no-binary=pkg1,pkg2", "pkg1", "pkg2"]),
+        call([pip_cmd, "install", "--no-binary=:all:", "pkg1", "pkg2"]),
     ]
 
     site_packages_dir = charm_builder._find_venv_site_packages(pathlib.Path(STAGING_VENV_DIRNAME))

--- a/tests/unit/test_charm_builder.py
+++ b/tests/unit/test_charm_builder.py
@@ -98,16 +98,12 @@ def test_install_strict_dependencies_success(
     fs: FakeFilesystem, fake_process: FakeProcess, builder, requirements
 ):
     fs.create_file("requirements.txt", contents=requirements)
-    no_binary_packages = utils.get_package_names(requirements.splitlines(keepends=False))
-    no_binary_packages_str = ",".join(sorted(no_binary_packages))
-    fake_process.register(
-        [
-            "/pip",
-            "install",
-            *([f"--no-binary={no_binary_packages_str}"] if no_binary_packages else []),
-            "--requirement=requirements.txt",
-        ],
-        returncode=0,
-    )
+    expected_command = [
+        "/pip",
+        "install",
+        "--no-binary=:all:",
+        "--requirement=requirements.txt",
+    ]
+    fake_process.register(expected_command, returncode=0)
 
     builder._install_strict_dependencies("/pip")

--- a/tests/unit/utils/test_package.py
+++ b/tests/unit/utils/test_package.py
@@ -109,6 +109,8 @@ def test_get_requirements_file_package_names(tmp_path, file_contents, expected):
             "--no-binary=abc,ghi",
             ["ghi", "jkl"],
         ),
+        (["abc==1.0.0", "def>=1.2.3"], [], [], "--no-binary=:all:", []),
+        ([], ["abc==1.0.0", "def>=1.2.3"], [], "--no-binary=:all:", ["abc==1.0.0", "def>=1.2.3"]),
     ],
 )
 @pytest.mark.parametrize("prefix", [["/bin/pip"], ["/some/path/to/pip3"], ["pip", "--some-param"]])


### PR DESCRIPTION
This reduces the chances of having pip install binary packages as indirect dependencies.

Partial fix for #1473 