### PR TITLE
fix(flask): use rustup snap

### DIFF
--- a/charmcraft/extensions/gunicorn.py
+++ b/charmcraft/extensions/gunicorn.py
@@ -158,7 +158,13 @@ class _GunicornBase(Extension):
                 "grafana-dashboard": {"interface": "grafana_dashboard"},
             },
             "config": {"options": {**self._WEBSERVER_OPTIONS, **self.options}},
-            "parts": {"charm": {"plugin": "charm", "source": "."}},
+            "parts": {
+                "charm": {
+                    "plugin": "charm",
+                    "source": ".",
+                    "build-snaps": ["rustup"],  # Needed to build pydantic.
+                }
+            },
         }
 
     @override
@@ -224,12 +230,6 @@ class FlaskFramework(_GunicornBase):
     def is_experimental(base: tuple[str, ...] | None) -> bool:  # noqa: ARG004
         """Check if the extension is in an experimental state."""
         return False
-
-    @override
-    def get_parts_snippet(self) -> dict[str, Any]:
-        """Return the parts to add to parts."""
-        # rust is needed to build pydantic-core, a dependency of flask.
-        return {"flask-framework/rust-deps": {"plugin": "nil", "build-packages": ["cargo"]}}
 
 
 class DjangoFramework(_GunicornBase):

--- a/tests/extensions/test_gunicorn.py
+++ b/tests/extensions/test_gunicorn.py
@@ -66,8 +66,7 @@ def flask_input_yaml_fixture():
                     "options": {**FlaskFramework.options, **FlaskFramework._WEBSERVER_OPTIONS}
                 },
                 "parts": {
-                    "charm": {"plugin": "charm", "source": "."},
-                    "flask-framework/rust-deps": {"plugin": "nil", "build-packages": ["cargo"]},
+                    "charm": {"plugin": "charm", "source": ".", "build-snaps": ["rustup"]},
                 },
                 "peers": {"secret-storage": {"interface": "secret-storage"}},
                 "provides": {
@@ -121,7 +120,7 @@ def flask_input_yaml_fixture():
                 "config": {
                     "options": {**DjangoFramework.options, **DjangoFramework._WEBSERVER_OPTIONS}
                 },
-                "parts": {"charm": {"plugin": "charm", "source": "."}},
+                "parts": {"charm": {"plugin": "charm", "source": ".", "build-snaps": ["rustup"]}},
                 "peers": {"secret-storage": {"interface": "secret-storage"}},
                 "provides": {
                     "metrics-endpoint": {"interface": "prometheus_scrape"},
@@ -255,4 +254,8 @@ def test_handle_charm_part(flask_input_yaml, tmp_path):
         apply_extensions(tmp_path, flask_input_yaml)
     del flask_input_yaml["parts"]
     applied = apply_extensions(tmp_path, flask_input_yaml)
-    assert applied["parts"]["charm"] == {"plugin": "charm", "source": "."}
+    assert applied["parts"]["charm"] == {
+        "plugin": "charm",
+        "source": ".",
+        "build-snaps": ["rustup"],
+    }

--- a/tests/spread/commands/init-flask-framework/task.yaml
+++ b/tests/spread/commands/init-flask-framework/task.yaml
@@ -1,9 +1,11 @@
 summary: test charmcraft init with flask-framework profile
+priority: 500  # This builds pydantic, so do it early
+kill-timeout: 45m  # Because it builds pydantic, it takes a long time.
+systems:
+  # We only need to run this test once, and it takes a long time.
+  - ubuntu-22.04-64
 
 execute: |
-  unset CHARMCRAFT_STORE_API_URL
-  unset CHARMCRAFT_UPLOAD_URL
-  unset CHARMCRAFT_REGISTRY_URL
   mkdir -p test-init
   cd test-init
   charmcraft init --profile flask-framework

--- a/tests/spread/commands/init-flask-framework/task.yaml
+++ b/tests/spread/commands/init-flask-framework/task.yaml
@@ -1,6 +1,6 @@
 summary: test charmcraft init with flask-framework profile
 priority: 500  # This builds pydantic, so do it early
-kill-timeout: 45m  # Because it builds pydantic, it takes a long time.
+kill-timeout: 75m  # Because it builds pydantic, it takes a long time.
 systems:
   # We only need to run this test once, and it takes a long time.
   - ubuntu-22.04-64


### PR DESCRIPTION
A new update to a flask dependency requires a more recent version of rustc than is available in the jammy repos.
This works around that by using the same rustup snap as the craft-parts rust plugin

Fixes #1743

Spread test failure is fixed in https://github.com/canonical/charmcraft/pull/1749