### PR TITLE
fix(ci): fix tox ensure_version_matches

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -160,7 +160,7 @@ commands = pyclean {posargs:. --debris --erase results/* results/ --yes}
 description = Verify package version is same as Git tag
 deps =
 commands = python -c 'import os; from importlib.metadata import version; pkg, tag = os.environ["PKG_NAME"], os.environ["GIT_TAG"]; ver = version(pkg); error = f"`{ver}` != `{tag}`"; abort = f"Package version does not match the Git tag ({error}). ABORTING."; raise SystemExit(0 if ver and tag and ver == tag else abort)'
-setenv =
+set_env =
     PKG_NAME=charmcraft
     GIT_TAG={posargs}
 


### PR DESCRIPTION
Failure example: https://github.com/canonical/charmcraft/actions/runs/10062480068/job/27815089103