### PR TITLE
fix(metadata): allow long summaries in output

### DIFF
--- a/charmcraft/models/metadata.py
+++ b/charmcraft/models/metadata.py
@@ -39,7 +39,7 @@ class CharmMetadata(models.BaseMetadata):
 
     name: models.ProjectName
     display_name: models.ProjectTitle | None = None
-    summary: models.SummaryStr
+    summary: pydantic.StrictStr
     description: pydantic.StrictStr
     maintainers: list[pydantic.StrictStr] | None = None
     assumes: list[str | dict[str, list | dict]] | None = None

--- a/tests/unit/models/test_metadata.py
+++ b/tests/unit/models/test_metadata.py
@@ -22,7 +22,7 @@ from charmcraft.models import metadata, project
 
 BASIC_CHARM_METADATA_DICT = {
     "name": "test-charm",
-    "summary": "A charm for testing",
+    "summary": "A charm for testing, with a summary string that is more than seventy-eight characters long.",
     "description": "A fake charm used for testing purposes.",
 }
 BASIC_CHARM_DICT = {


### PR DESCRIPTION
Fixes #1758

More context in https://github.com/canonical/charmcraft/issues/1568