### PR TITLE
fix(package): use correct legacy bases architectures

### DIFF
--- a/charmcraft/services/package.py
+++ b/charmcraft/services/package.py
@@ -34,6 +34,7 @@ from craft_providers import bases
 import charmcraft
 from charmcraft import const, errors, models, utils
 from charmcraft.models import lint
+from charmcraft.models.charmcraft import Base
 from charmcraft.models.manifest import Attribute, Manifest
 from charmcraft.models.metadata import BundleMetadata, CharmMetadata
 from charmcraft.models.project import (
@@ -193,7 +194,19 @@ class PackageService(services.PackageService):
     def get_manifest_bases(self) -> list[models.Base]:
         """Get the bases used for a charm manifest from the project."""
         if isinstance(self._project, BasesCharm):
-            return list(itertools.chain.from_iterable(base.run_on for base in self._project.bases))
+            run_on_bases = []
+            for project_base in self._project.bases:
+                for build_base in project_base.build_on:
+                    if build_base.name != self._build_plan[0].base.name:
+                        continue
+                    if build_base.channel != self._build_plan[0].base.version:
+                        continue
+                    if self._build_plan[0].build_on not in build_base.architectures:
+                        continue
+                    run_on_bases.extend(project_base.run_on)
+            if not run_on_bases:
+                raise RuntimeError("Could not determine run-on bases.")
+            return run_on_bases
         if isinstance(self._project, PlatformCharm):
             if not self._platform:
                 architectures = [util.get_host_architecture()]

--- a/charmcraft/services/package.py
+++ b/charmcraft/services/package.py
@@ -17,7 +17,6 @@
 """Service class for packing."""
 from __future__ import annotations
 
-import itertools
 import json
 import os
 import pathlib
@@ -34,7 +33,6 @@ from craft_providers import bases
 import charmcraft
 from charmcraft import const, errors, models, utils
 from charmcraft.models import lint
-from charmcraft.models.charmcraft import Base
 from charmcraft.models.manifest import Attribute, Manifest
 from charmcraft.models.metadata import BundleMetadata, CharmMetadata
 from charmcraft.models.project import (

--- a/tests/unit/services/test_package.py
+++ b/tests/unit/services/test_package.py
@@ -20,12 +20,12 @@ import pathlib
 import sys
 import zipfile
 
-from craft_application.models import BuildInfo
 import craft_cli.pytest_plugin
-from craft_providers.bases import BaseName
 import pytest
 import pytest_check
 from craft_application import util
+from craft_application.models import BuildInfo
+from craft_providers.bases import BaseName
 
 from charmcraft import const, models, services
 from charmcraft.application.main import APP_METADATA
@@ -146,7 +146,7 @@ def test_do_not_overwrite_metadata_yaml(
                 platform=util.get_host_architecture(),
                 build_for=util.get_host_architecture(),
                 build_on=util.get_host_architecture(),
-                base=BaseName("ubuntu", "20.04")
+                base=BaseName("ubuntu", "20.04"),
             ),
             [
                 {
@@ -159,17 +159,19 @@ def test_do_not_overwrite_metadata_yaml(
         (
             [
                 {
-                    "build-on": [{"name": "ubuntu", "channel": "22.04", "architectures": ["riscv64"]}],
+                    "build-on": [
+                        {"name": "ubuntu", "channel": "22.04", "architectures": ["riscv64"]}
+                    ],
                     "run-on": [
                         {"name": "ubuntu", "channel": "22.04", "architectures": ["all"]},
-                    ]
+                    ],
                 },
             ],
             BuildInfo(
                 platform="riscv64",
                 build_for="riscv64",
                 build_on="riscv64",
-                base=BaseName("ubuntu", "22.04")
+                base=BaseName("ubuntu", "22.04"),
             ),
             [
                 {"name": "ubuntu", "channel": "22.04", "architectures": ["all"]},
@@ -183,9 +185,7 @@ def test_do_not_overwrite_metadata_yaml(
                 build_for=util.get_host_architecture(),
                 base=BaseName("centos", "7"),
             ),
-            [
-                {"name": "centos", "channel": "7", "architectures": [util.get_host_architecture()]}
-            ],
+            [{"name": "centos", "channel": "7", "architectures": [util.get_host_architecture()]}],
         ),
         pytest.param(
             [
@@ -195,12 +195,11 @@ def test_do_not_overwrite_metadata_yaml(
                     "run-on": [{"name": "ubuntu", "channel": "20.04", "architectures": ["all"]}],
                 },
                 {
-                    "build-on": [{"name": "ubuntu", "channel": "22.04", "architectures": ["amd64", "arm64"]}],
-                    "run-on": [
-                        {"name": "ubuntu", "channel": "22.04", "architectures": ["arm64"]}
-                    ]
-                }
-
+                    "build-on": [
+                        {"name": "ubuntu", "channel": "22.04", "architectures": ["amd64", "arm64"]}
+                    ],
+                    "run-on": [{"name": "ubuntu", "channel": "22.04", "architectures": ["arm64"]}],
+                },
             ],
             BuildInfo(
                 platform="amd64",
@@ -208,14 +207,14 @@ def test_do_not_overwrite_metadata_yaml(
                 build_for="arm64",
                 base=BaseName("ubuntu", "22.04"),
             ),
-            [
-                {"name": "ubuntu", "channel": "22.04", "architectures": ["arm64"]}
-            ],
-            id="cross-compile"
-        )
+            [{"name": "ubuntu", "channel": "22.04", "architectures": ["arm64"]}],
+            id="cross-compile",
+        ),
     ],
 )
-def test_get_manifest_bases_from_bases(fake_path: pathlib.Path, package_service: services.PackageService, bases, build_item, expected):
+def test_get_manifest_bases_from_bases(
+    fake_path: pathlib.Path, package_service: services.PackageService, bases, build_item, expected
+):
     charm = models.BasesCharm.parse_obj(
         {
             "name": "my-charm",
@@ -227,8 +226,6 @@ def test_get_manifest_bases_from_bases(fake_path: pathlib.Path, package_service:
     )
     package_service._project = charm
     package_service._build_plan = [build_item]
-
-    # breakpoint()
 
     assert package_service.get_manifest_bases() == [models.Base.parse_obj(b) for b in expected]
 


### PR DESCRIPTION
Previous behaviour was attaching all run-on bases, where we want to only attach run-on bases that match the current build base.

Fixes #1783