### PR TITLE
fix(application): exclude files from charm

### DIFF
--- a/charmcraft/application/main.py
+++ b/charmcraft/application/main.py
@@ -38,6 +38,7 @@ APP_METADATA = AppMetadata(
     summary=GENERAL_SUMMARY,
     ProjectClass=models.CharmcraftProject,
     BuildPlannerClass=models.CharmcraftBuildPlanner,
+    source_ignore_patterns=["*.charm", "charmcraft.yaml"],
 )
 
 


### PR DESCRIPTION
Excludes both previous charm files and charmcraft.yaml from the output charm file.

Fixes #1791