### PR TITLE
fix(2.7): allow skopeo to use an insecure policy

### DIFF
--- a/charmcraft/commands/store/__init__.py
+++ b/charmcraft/commands/store/__init__.py
@@ -1873,7 +1873,7 @@ class UploadResourceCommand(BaseCommand):
                         "Image not found locally. Passing path directly to skopeo.",
                         permanent=True,
                     )
-                    skopeo = utils.Skopeo()
+                    skopeo = utils.Skopeo(insecure_policy=True)
                     registry_url_without_https = self.config.charmhub.registry_url[8:]
                     with emit.open_stream("Running Skopeo") as stream:
                         skopeo.copy(


### PR DESCRIPTION
Fixes this error:

```
 + charmcraft upload-resource gh-ci-charmcraft-charm example-image --image=docker://hello-world@sha256:18a657d0cc1c7d0678a3fbea8b7eb4918bba25968d3e1b0adebfa71caddbc346
Uploading resource from image charm/co44x4qvu12a2ff5a1v04haywbiyhc0uv6erc/example-image @ docker://hello-world@sha256:18a657d0cc1c7d0678a3fbea8b7eb4918bba25968d3e1b0adebfa71caddbc346.
Checking if manifest is already uploaded
Remote image not found, getting its info from local registry.
Image not found locally. Passing path directly to skopeo.
Running Skopeo
:: time="2024-08-26T18:39:59Z" level=fatal msg="Error loading trust policy: open /etc/containers/policy.json: no such file or directory"
Error while running /snap/charmcraft/x1/libexec/charmcraft/skopeo (return code 1)
Full execution log: '/root/.local/state/charmcraft/log/charmcraft-20240826-183956.163959.log'
-----

```