### PR TITLE
Use the name variable for placeholder container, resource names

### DIFF
--- a/charmcraft/templates/init-kubernetes/charmcraft.yaml.j2
+++ b/charmcraft/templates/init-kubernetes/charmcraft.yaml.j2
@@ -60,17 +60,17 @@ config:
 
 # Your workload’s containers.
 containers:
-  some-container:
-    resource: some-container-image
+  {{ name }}:
+    resource: {{ name }}-image
 
 
 # This field populates the Resources tab on Charmhub.
 resources:
   # An OCI image resource for each container listed above.
   # You may remove this if your charm will run without a workload sidecar container.
-  some-container-image:
+  {{ name }}-image:
     type: oci-image
-    description: OCI image for the 'some-container' container
+    description: OCI image for the {{ name }} container
     # The upstream-source field is ignored by Juju. It is included here as a reference
     # so the integration testing suite knows which image to deploy during testing. This field
     # is also used by the 'canonical/charming-actions' Github action for automated releasing.


### PR DESCRIPTION
Currently, the k8s template uses `some-container` as a placeholder for container, resource names.
This PR changes the template to use the `name` variable instead.
This follows a convention many charmers happen to practice:
- container name matches the main workload's name
- resource name is the main workload's name + `-image` suffix.