### PR TITLE
ci: get tags for automatic publish

### DIFF
--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -14,6 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        fetch-tags: true
     - uses: actions/setup-python@v5
       with:
         python-version: '3.12'


### PR DESCRIPTION
The publish workflow is failing because it doesn't get git tags