### PR TITLE
fix: lock shared cache directory

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -82,8 +82,6 @@ jobs:
           sudo apt install -y python3-pip python3-setuptools python3-wheel python3-venv libapt-pkg-dev
       - name: Setup LXD
         uses: canonical/setup-lxd@v0.1.1
-        with:
-          channel: latest/stable
         if: ${{ runner.os == 'Linux' }}
       - name: Install skopeo (mac)
         # This is only necessary for Linux until skopeo >= 1.11 is in repos.

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -80,6 +80,11 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y python3-pip python3-setuptools python3-wheel python3-venv libapt-pkg-dev
+      - name: Setup LXD
+        uses: canonical/setup-lxd@v0.1.1
+        with:
+          channel: latest/stable
+        if: ${{ runner.os == 'Linux' }}
       - name: Install skopeo (mac)
         # This is only necessary for Linux until skopeo >= 1.11 is in repos.
         # Once we're running on Noble, we can get skopeo from apt.

--- a/charmcraft/services/provider.py
+++ b/charmcraft/services/provider.py
@@ -17,7 +17,11 @@
 """Service class for creating providers."""
 from __future__ import annotations
 
-import atexit
+import contextlib
+import io
+from collections.abc import Generator
+
+from craft_application.models import BuildInfo
 
 try:
     import fcntl
@@ -27,16 +31,40 @@ import os
 import pathlib
 from typing import cast
 
+import craft_application
 import craft_providers
 from craft_application import services
 from craft_cli import emit
 from craft_providers import bases
 
-from charmcraft import env
+from charmcraft import env, models
 
 
 class ProviderService(services.ProviderService):
     """Business logic for getting providers."""
+
+    def __init__(
+        self,
+        app: craft_application.AppMetadata,
+        services: craft_application.ServiceFactory,
+        *,
+        project: models.CharmcraftProject,
+        work_dir: pathlib.Path,
+        build_plan: list[BuildInfo],
+        provider_name: str | None = None,
+        install_snap: bool = True,
+    ) -> None:
+        super().__init__(
+            app,
+            services,
+            project=project,
+            work_dir=work_dir,
+            build_plan=build_plan,
+            provider_name=provider_name,
+            install_snap=install_snap,
+        )
+        self._cache_path: pathlib.Path | None = None
+        self._lock: io.TextIOBase | None = None
 
     def setup(self) -> None:
         """Set up the provider service for Charmcraft."""
@@ -64,11 +92,13 @@ class ProviderService(services.ProviderService):
 
         If no cache_path is included, adds one.
         """
-        cache_path = cast(pathlib.Path, kwargs.get("cache_path", env.get_host_shared_cache_path()))
-        our_lock = _maybe_lock_cache(cache_path)
+        self._cache_path = cast(
+            pathlib.Path, kwargs.get("cache_path", env.get_host_shared_cache_path())
+        )
+        self._lock = _maybe_lock_cache(self._cache_path)
 
         # Forward the shared cache path.
-        kwargs["cache_path"] = cache_path if our_lock else None
+        kwargs["cache_path"] = self._cache_path if self._lock else None
         return super().get_base(
             base_name,
             instance_name=instance_name,
@@ -76,11 +106,31 @@ class ProviderService(services.ProviderService):
             **kwargs,  # type: ignore[arg-type]
         )
 
+    @contextlib.contextmanager
+    def instance(
+        self,
+        build_info: BuildInfo,
+        *,
+        work_dir: pathlib.Path,
+        allow_unstable: bool = True,
+        **kwargs: bool | str | None,
+    ) -> Generator[craft_providers.Executor, None, None]:
+        """Instance override for Charmcraft."""
+        with super().instance(
+            build_info, work_dir=work_dir, allow_unstable=allow_unstable, **kwargs
+        ) as instance:
+            try:
+                yield instance
+            finally:
+                if fcntl is not None and self._lock:
+                    fcntl.flock(self._lock, fcntl.LOCK_UN)
+                    self._lock.close()
 
-def _maybe_lock_cache(path: pathlib.Path) -> bool:
+
+def _maybe_lock_cache(path: pathlib.Path) -> io.TextIOBase | None:
     """Lock the cache so we only have one copy of Charmcraft using it at a time."""
     if fcntl is None:  # Don't lock on Windows - just don't cache.
-        return False
+        return None
     cache_lock_path = path / "charmcraft.lock"
 
     emit.trace("Attempting to lock the cache path")
@@ -92,14 +142,11 @@ def _maybe_lock_cache(path: pathlib.Path) -> bool:
         emit.progress(
             "Shared cache locked by another process; running without cache.", permanent=True
         )
-        return False
+        return None
     else:
         pid = str(os.getpid())
         lock_file.write(pid)
         lock_file.flush()
         os.fsync(lock_file.fileno())
         emit.trace(f"Cache path locked by this process ({pid})")
-        atexit.register(fcntl.flock, lock_file, fcntl.LOCK_UN)
-        atexit.register(cache_lock_path.unlink, missing_ok=True)
-
-        return True
+        return lock_file

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -330,6 +330,9 @@ lint.ignore = [
 # Allow Pydantic's `@validator` decorator to trigger class method treatment.
 classmethod-decorators = ["pydantic.validator"]
 
+[tool.ruff.lint.pydocstyle]
+ignore-decorators = ["overrides.overrides", "overrides.override", "typing.overload", "typing.override"]
+
 [tool.ruff.lint.per-file-ignores]
 "tests/**.py" = [  # Some things we want for the moin project are unnecessary in tests.
     "D",  # Ignore docstring rules in tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,16 +109,19 @@ def service_factory(
 
 
 @pytest.fixture
-def default_build_plan():
+def default_build_info() -> models.BuildInfo:
     arch = util.get_host_architecture()
-    return [
-        models.BuildInfo(
-            base=bases.BaseName("ubuntu", "22.04"),
-            build_on=arch,
-            build_for="arm64",
-            platform="distro-1-test64",
-        )
-    ]
+    return models.BuildInfo(
+        base=bases.BaseName("ubuntu", "22.04"),
+        build_on=arch,
+        build_for="arm64",
+        platform="distro-1-test64",
+    )
+
+
+@pytest.fixture
+def default_build_plan(default_build_info: models.BuildInfo):
+    return [default_build_info]
 
 
 @pytest.fixture

--- a/tests/integration/services/conftest.py
+++ b/tests/integration/services/conftest.py
@@ -14,10 +14,7 @@
 #
 # For further info, check https://github.com/canonical/charmcraft
 """Configuration for services integration tests."""
-import contextlib
-import sys
 
-import pyfakefs.fake_filesystem
 import pytest
 
 from charmcraft import services
@@ -25,19 +22,9 @@ from charmcraft.application.main import APP_METADATA, Charmcraft
 
 
 @pytest.fixture
-def service_factory(
-    fs: pyfakefs.fake_filesystem.FakeFilesystem, fake_path, simple_charm
-) -> services.CharmcraftServiceFactory:
-    fake_project_dir = fake_path / "project"
+def service_factory(simple_charm, new_path) -> services.CharmcraftServiceFactory:
+    fake_project_dir = new_path / "project"
     fake_project_dir.mkdir()
-
-    # Allow access to the real venv library path.
-    # This is necessary because certifi lazy-loads the certificate file.
-    for python_path in sys.path:
-        if not python_path:
-            continue
-        with contextlib.suppress(OSError):
-            fs.add_real_directory(python_path)
 
     factory = services.CharmcraftServiceFactory(app=APP_METADATA)
 

--- a/tests/integration/services/test_provider.py
+++ b/tests/integration/services/test_provider.py
@@ -1,0 +1,52 @@
+# Copyright 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For further info, check https://github.com/canonical/charmcraft
+"""Integration tests for the provider service."""
+
+import pathlib
+import sys
+
+import pytest
+from craft_application.models import BuildInfo
+from craft_cli.pytest_plugin import RecordingEmitter
+
+from charmcraft import services
+from charmcraft.services.provider import _maybe_lock_cache
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="no cache on windows")
+def test_locks_cache(
+    service_factory: services.CharmcraftServiceFactory,
+    tmp_path: pathlib.Path,
+    default_build_info: BuildInfo,
+    emitter: RecordingEmitter,
+):
+    _maybe_lock_cache(tmp_path)
+    assert (tmp_path / "charmcraft.lock").exists()
+    provider = service_factory.provider
+    provider_kwargs = {
+        "build_info": default_build_info,
+        "work_dir": pathlib.Path(__file__).parent,
+        "cache_path": tmp_path,
+    }
+
+    with provider.instance(**provider_kwargs) as instance:
+        # Because we've already locked the cache, we shouldn't see the lockfile.
+        lock_test = instance.execute_run(["test", "-f", "/root/.cache/charmcraft.lock"])
+        assert lock_test.returncode == 1
+
+        # Create a file in the cache and ensure it's not visible in the outer fs
+        instance.execute_run(["touch", "/root/.cache/cache_cached"])
+        assert not (tmp_path / "cache_cached").exists()

--- a/tests/unit/services/test_provider.py
+++ b/tests/unit/services/test_provider.py
@@ -151,16 +151,13 @@ def test_get_base_no_cache_if_locked(
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="no cache on windows")
-def test_maybe_lock_cache_locks_single_lock(tmp_path: pathlib.Path, mock_register) -> None:
-    assert _maybe_lock_cache(tmp_path) is True
-    mock_register.assert_has_calls([mock.call(fcntl.flock, mock.ANY, fcntl.LOCK_UN)])
+def test_maybe_lock_cache_locks_single_lock(tmp_path: pathlib.Path) -> None:
+    assert _maybe_lock_cache(tmp_path)
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="no cache on windows")
-def test_maybe_lock_cache_with_another_lock(tmp_path: pathlib.Path, mock_register) -> None:
-    assert _maybe_lock_cache(tmp_path) is True
-    assert _maybe_lock_cache(tmp_path) is False
-    assert mock_register.mock_calls == [
-        mock.call(fcntl.flock, mock.ANY, fcntl.LOCK_UN),
-        mock.call(mock.ANY, missing_ok=True),
-    ]
+def test_maybe_lock_cache_with_another_lock(tmp_path: pathlib.Path) -> None:
+    # Need to save the open file so it's not closed when we try a second time.
+    first_file_descriptor = _maybe_lock_cache(tmp_path)
+    assert first_file_descriptor
+    assert _maybe_lock_cache(tmp_path) is None

--- a/tests/unit/services/test_provider.py
+++ b/tests/unit/services/test_provider.py
@@ -15,12 +15,23 @@
 # For further info, check https://github.com/canonical/charmcraft
 """Unit tests for the provider service."""
 
+try:
+    import fcntl
+except ModuleNotFoundError:  # Windows
+    fcntl = None
+import functools
 import pathlib
+import sys
+from collections.abc import Iterator
+from unittest import mock
 
 import pytest
+from craft_cli.pytest_plugin import RecordingEmitter
 from craft_providers import bases
 
 from charmcraft import models, services
+from charmcraft.application.main import APP_METADATA
+from charmcraft.services.provider import _maybe_lock_cache
 
 
 @pytest.fixture
@@ -40,6 +51,17 @@ def provider_service(
     )
 
     return service_factory.provider
+
+
+@pytest.fixture
+def mock_register(monkeypatch) -> Iterator[mock.Mock]:
+    register = mock.Mock()
+    monkeypatch.setattr("atexit.register", register)
+    yield register
+
+    # Call the exit hooks as if exiting the application.
+    for hook in register.mock_calls:
+        functools.partial(*hook.args)()
 
 
 @pytest.mark.parametrize(
@@ -62,6 +84,7 @@ def provider_service(
         bases.BaseName("almalinux", "9"),
     ],
 )
+@pytest.mark.skipif(sys.platform == "win32", reason="no cache on windows")
 def test_get_base_forwards_cache(
     monkeypatch,
     provider_service: services.ProviderService,
@@ -76,3 +99,68 @@ def test_get_base_forwards_cache(
     )
 
     assert base._cache_path == fake_path / "cache"
+
+
+@pytest.mark.parametrize(
+    "base_name",
+    [
+        bases.BaseName("ubuntu", "20.04"),
+        bases.BaseName("ubuntu", "22.04"),
+        bases.BaseName("ubuntu", "24.04"),
+        bases.BaseName("ubuntu", "devel"),
+        bases.BaseName("almalinux", "9"),
+    ],
+)
+@pytest.mark.skipif(sys.platform == "win32", reason="no cache on windows")
+def test_get_base_no_cache_if_locked(
+    monkeypatch,
+    mock_register,
+    tmp_path: pathlib.Path,
+    base_name: bases.BaseName,
+    emitter: RecordingEmitter,
+):
+    cache_path = tmp_path / "cache"
+    cache_path.mkdir(exist_ok=True, parents=True)
+
+    # Make a new path object to work around caching the paths and thus getting the
+    # same file descriptor.
+    locked = _maybe_lock_cache(cache_path)
+    assert locked
+    new_cache_path = pathlib.Path(str(cache_path))
+    monkeypatch.setattr("charmcraft.env.get_host_shared_cache_path", lambda: new_cache_path)
+
+    # Can't use the fixture as pyfakefs doesn't handle locks.
+    provider_service = services.ProviderService(
+        app=APP_METADATA,
+        services=None,  # pyright: ignore[reportArgumentType]
+        project=None,  # pyright: ignore[reportArgumentType]
+        work_dir=tmp_path,
+        build_plan=[],
+    )
+
+    base = provider_service.get_base(
+        base_name=base_name,
+        instance_name="charmcraft-test-instance",
+    )
+
+    assert base._cache_path is None
+    emitter.assert_progress(
+        "Shared cache locked by another process; running without cache.",
+        permanent=True,
+    )
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="no cache on windows")
+def test_maybe_lock_cache_locks_single_lock(tmp_path: pathlib.Path, mock_register) -> None:
+    assert _maybe_lock_cache(tmp_path) is True
+    mock_register.assert_has_calls([mock.call(fcntl.flock, mock.ANY, fcntl.LOCK_UN)])
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="no cache on windows")
+def test_maybe_lock_cache_with_another_lock(tmp_path: pathlib.Path, mock_register) -> None:
+    assert _maybe_lock_cache(tmp_path) is True
+    assert _maybe_lock_cache(tmp_path) is False
+    assert mock_register.mock_calls == [
+        mock.call(fcntl.flock, mock.ANY, fcntl.LOCK_UN),
+        mock.call(mock.ANY, missing_ok=True),
+    ]


### PR DESCRIPTION
Locks the shared cache directory to prevent concurrency issues.

Fixes #1845

CRAFT-3313