### PR TITLE
fix(charm_builder): force-install pip

### DIFF
--- a/charmcraft/charm_builder.py
+++ b/charmcraft/charm_builder.py
@@ -247,7 +247,9 @@ class CharmBuilder:
             # common charm dependencies (e.g. ops). Resolve this by updating to a
             # known working version of pip.
             if get_pip_version(pip_cmd) < MINIMUM_PIP_VERSION:
-                _process_run([pip_cmd, "install", f"pip@{KNOWN_GOOD_PIP_URL}"])
+                _process_run(
+                    [pip_cmd, "install", "--force-reinstall", f"pip@{KNOWN_GOOD_PIP_URL}"]
+                )
 
         with instrum.Timer("Installing all dependencies"):
             if self.strict_dependencies:

--- a/tests/test_charm_builder.py
+++ b/tests/test_charm_builder.py
@@ -615,7 +615,7 @@ def test_build_dependencies_virtualenv_simple(tmp_path, assert_output):
 
     assert mock.mock_calls == [
         call(["python3", "-m", "venv", str(tmp_path / STAGING_VENV_DIRNAME)]),
-        call([pip_cmd, "install", f"pip@{KNOWN_GOOD_PIP_URL}"]),
+        call([pip_cmd, "install", "--force-reinstall", f"pip@{KNOWN_GOOD_PIP_URL}"]),
         call([pip_cmd, "install", "--no-binary=:all:", f"--requirement={reqs_file}"]),
     ]
 
@@ -652,7 +652,7 @@ def test_build_dependencies_virtualenv_multiple(tmp_path, assert_output):
     pip_cmd = str(charm_builder._find_venv_bin(tmp_path / STAGING_VENV_DIRNAME, "pip"))
     assert mock.mock_calls == [
         call(["python3", "-m", "venv", str(tmp_path / STAGING_VENV_DIRNAME)]),
-        call([pip_cmd, "install", f"pip@{KNOWN_GOOD_PIP_URL}"]),
+        call([pip_cmd, "install", "--force-reinstall", f"pip@{KNOWN_GOOD_PIP_URL}"]),
         call(
             [
                 pip_cmd,
@@ -714,7 +714,7 @@ def test_build_dependencies_virtualenv_packages(tmp_path, assert_output):
 
     assert mock.mock_calls == [
         call(["python3", "-m", "venv", str(tmp_path / STAGING_VENV_DIRNAME)]),
-        call([pip_cmd, "install", f"pip@{KNOWN_GOOD_PIP_URL}"]),
+        call([pip_cmd, "install", "--force-reinstall", f"pip@{KNOWN_GOOD_PIP_URL}"]),
         call([pip_cmd, "install", "--no-binary=:all:", "pkg1", "pkg2"]),
     ]
 
@@ -747,7 +747,7 @@ def test_build_dependencies_virtualenv_binary_packages(tmp_path, assert_output):
 
     assert mock.mock_calls == [
         call(["python3", "-m", "venv", str(tmp_path / STAGING_VENV_DIRNAME)]),
-        call([pip_cmd, "install", f"pip@{KNOWN_GOOD_PIP_URL}"]),
+        call([pip_cmd, "install", "--force-reinstall", f"pip@{KNOWN_GOOD_PIP_URL}"]),
         call([pip_cmd, "install", "pkg1", "pkg2"]),
     ]
 
@@ -786,7 +786,7 @@ def test_build_dependencies_virtualenv_all(tmp_path, assert_output):
 
     assert mock.mock_calls == [
         call(["python3", "-m", "venv", str(tmp_path / STAGING_VENV_DIRNAME)]),
-        call([pip_cmd, "install", f"pip@{KNOWN_GOOD_PIP_URL}"]),
+        call([pip_cmd, "install", "--force-reinstall", f"pip@{KNOWN_GOOD_PIP_URL}"]),
         call(
             [
                 pip_cmd,

--- a/tests/unit/utils/test_package.py
+++ b/tests/unit/utils/test_package.py
@@ -131,7 +131,14 @@ def test_get_pip_command(
 
 @pytest.mark.parametrize(
     ("pip_cmd", "stdout", "expected"),
-    [("pip", "pip 22.0.2 from /usr/lib/python3/dist-packages/pip (python 3.10)\n", (22, 0, 2))],
+    [
+        ("pip", "pip 22.0.2 from /usr/lib/python3/dist-packages/pip (python 3.10)\n", (22, 0, 2)),
+        (
+            "venv/bin/pip",
+            "pip 20.0.2 from /root/venv/lib/python3.8/site-packages/pip (python 3.8)",
+            (20, 0, 2),
+        ),
+    ],
 )
 def test_get_pip_version_success(
     fake_process,


### PR DESCRIPTION
The previous version wasn't installing pip if it was already in the venv.

This is the hotfix for 2.x, while https://github.com/canonical/charmcraft/pull/1892 is the hotfix for 3.x

Fixes #1456
CRAFT-2538


Failing spread tests are unrelated and known on the 2.7 branch.