### PR TITLE
fix(charm_builder): force-install pip

### DIFF
--- a/charmcraft/charm_builder.py
+++ b/charmcraft/charm_builder.py
@@ -243,6 +243,7 @@ class CharmBuilder:
                     [
                         pip_cmd,
                         "install",
+                        "--force-reinstall",
                         f"pip@{KNOWN_GOOD_PIP_URL}",
                     ]
                 )

--- a/tests/test_charm_builder.py
+++ b/tests/test_charm_builder.py
@@ -732,7 +732,7 @@ def test_build_dependencies_virtualenv(
 
     assert mock.mock_calls == [
         call(["python3", "-m", "venv", str(tmp_path / const.STAGING_VENV_DIRNAME)]),
-        call([pip_cmd, "install", f"pip@{KNOWN_GOOD_PIP_URL}"]),
+        call([pip_cmd, "install", "--force-reinstall", f"pip@{KNOWN_GOOD_PIP_URL}"]),
         *extra_pip_calls,
     ]
 
@@ -771,7 +771,7 @@ def test_build_dependencies_virtualenv_multiple(tmp_path, assert_output):
     pip_cmd = str(charm_builder._find_venv_bin(tmp_path / const.STAGING_VENV_DIRNAME, "pip"))
     assert mock.mock_calls == [
         call(["python3", "-m", "venv", str(tmp_path / const.STAGING_VENV_DIRNAME)]),
-        call([pip_cmd, "install", f"pip@{KNOWN_GOOD_PIP_URL}"]),
+        call([pip_cmd, "install", "--force-reinstall", f"pip@{KNOWN_GOOD_PIP_URL}"]),
         call(
             [
                 pip_cmd,

--- a/tests/unit/utils/test_package.py
+++ b/tests/unit/utils/test_package.py
@@ -131,7 +131,14 @@ def test_get_pip_command(
 
 @pytest.mark.parametrize(
     ("pip_cmd", "stdout", "expected"),
-    [("pip", "pip 22.0.2 from /usr/lib/python3/dist-packages/pip (python 3.10)\n", (22, 0, 2))],
+    [
+        ("pip", "pip 22.0.2 from /usr/lib/python3/dist-packages/pip (python 3.10)\n", (22, 0, 2)),
+        (
+            "venv/bin/pip",
+            "pip 20.0.2 from /root/venv/lib/python3.8/site-packages/pip (python 3.8)",
+            (20, 0, 2),
+        ),
+    ],
 )
 def test_get_pip_version_success(
     fake_process,


### PR DESCRIPTION
The previous version wasn't installing pip if it was already in the venv.

This is the hotfix for 3.x, while https://github.com/canonical/charmcraft/pull/1891 is the hotfix for 2.x.

Fixes #1456
CRAFT-2538