### PR TITLE
docs(changelog): add 2.7.4 to changelog

### DIFF
--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -86,6 +86,12 @@ Command line
 The pack command now updates charm the libs in the project directory if they don't meet
 the requirements in the ``charm-libs`` key of ``charmcraft.yaml``.
 
+2.7.4 (2024-10-07)
+------------------
+
+This release bumps some dependencies to fix a security issue with requests.
+
+For a complete list of commits, see the `2.7.4`_ release on GitHub.
 
 2.7.3 (2024-09-16)
 ------------------
@@ -101,6 +107,8 @@ charm
 
 The charm plugin now force-reinstalls pip when necessary, guaranteeing a correct
 version of pip.
+
+For a complete list of commits, see the `2.7.3`_ release on GitHub.
 
 2.7.2 (2024-09-09)
 ------------------
@@ -333,6 +341,8 @@ page.
 .. _2.7.0: https://github.com/canonical/charmcraft/releases/tag/2.7.0
 .. _2.7.1: https://github.com/canonical/charmcraft/releases/tag/2.7.1
 .. _2.7.2: https://github.com/canonical/charmcraft/releases/tag/2.7.2
+.. _2.7.3: https://github.com/canonical/charmcraft/releases/tag/2.7.3
+.. _2.7.4: https://github.com/canonical/charmcraft/releases/tag/2.7.4
 .. _3.0.0: https://github.com/canonical/charmcraft/releases/tag/3.0.0
 .. _3.1.0: https://github.com/canonical/charmcraft/releases/tag/3.1.0
 .. _3.1.1: https://github.com/canonical/charmcraft/releases/tag/3.1.1


### PR DESCRIPTION
Quick link to the changelog: https://canonical-charmcraft--1942.com.readthedocs.build/en/1942/reference/changelog/#id1