### PR TITLE
fix: fastapi-framework import typo

### DIFF
--- a/charmcraft/templates/init-fastapi-framework/src/charm.py.j2
+++ b/charmcraft/templates/init-fastapi-framework/src/charm.py.j2
@@ -9,7 +9,7 @@ import typing
 
 import ops
 
-import paas_charmer.fastapi
+import paas_charm.fastapi
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Fix bug in fastapi-framework. The import was incorrect, as it is `paas-charm` instead.