### PR TITLE
Create scenario tests for init templates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,6 +144,7 @@ xfail_strict = true
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
 ]
+addopts = "--ignore=tests/spread"
 
 [tool.coverage.run]
 branch = true

--- a/tests/spread/commands/init-extensions/task.yaml
+++ b/tests/spread/commands/init-extensions/task.yaml
@@ -14,6 +14,7 @@ environment:
 prepare: |
   tests.pkgs install pipx python3-venv
   pipx install --force tox
+  pipx ensurepath
 
 restore: |
   pushd test-init
@@ -39,4 +40,4 @@ execute: |
   # expand charmcraft.yaml for the scenario tests to work
   charmcraft expand-extensions > charmcraft-expanded.yaml
   mv charmcraft-expanded.yaml charmcraft.yaml
-  ~/.local/bin/tox -c ../tox.ini -e unit
+  tox -c ../tox.ini -e unit

--- a/tests/spread/commands/init-extensions/task.yaml
+++ b/tests/spread/commands/init-extensions/task.yaml
@@ -14,7 +14,6 @@ environment:
 prepare: |
   tests.pkgs install pipx python3-venv
   pipx install --force tox
-  pipx ensurepath
 
 restore: |
   pushd test-init
@@ -40,4 +39,4 @@ execute: |
   # expand charmcraft.yaml for the scenario tests to work
   charmcraft expand-extensions > charmcraft-expanded.yaml
   mv charmcraft-expanded.yaml charmcraft.yaml
-  tox -c ../tox.ini -e unit
+  ~/.local/bin/tox -c ../tox.ini -e unit

--- a/tests/spread/commands/init-extensions/task.yaml
+++ b/tests/spread/commands/init-extensions/task.yaml
@@ -11,6 +11,17 @@ environment:
   PROFILE/fastapi: fastapi-framework
   CHARMCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS: "true"
 
+prepare: |
+  tests.pkgs install pipx python3-venv
+  pipx install --force tox
+
+restore: |
+  pushd test-init
+  charmcraft clean
+  popd
+
+  rm -rf test-init
+
 execute: |
   # Required for fetch-libs to succeed since the libraries are not available on
   # the staging environment
@@ -20,14 +31,12 @@ execute: |
 
   mkdir -p test-init
   cd test-init
-  charmcraft init --profile "${PROFILE}"
+  charmcraft init --profile "${PROFILE}" --name hello-world
   charmcraft fetch-libs
   charmcraft pack --verbose
   test -f *.charm
 
-restore: |
-  pushd test-init
-  charmcraft clean
-  popd
-
-  rm -rf test-init
+  # expand charmcraft.yaml for the scenario tests to work
+  charmcraft expand-extensions > charmcraft-expanded.yaml
+  mv charmcraft-expanded.yaml charmcraft.yaml
+  ~/.local/bin/tox -c ../tox.ini -e unit

--- a/tests/spread/commands/init-extensions/tests/unit/test_charm.py
+++ b/tests/spread/commands/init-extensions/tests/unit/test_charm.py
@@ -1,7 +1,7 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Smoke scenario test for Flask."""
+"""Smoke scenario test for paas-charm based init templates."""
 
 import os
 import pathlib
@@ -12,7 +12,7 @@ import scenario.errors
 
 
 def test_smoke():
-    """The only goal of this test is a smoke test, that is, that the charm does not raise."""
+    """The purpose of this test is that the charm does not raise on a handled event."""
     os.chdir(pathlib.Path(charm.__file__).parent.parent)
     ctx = scenario.Context(charm.HelloWorldCharm)
     container_name = next(iter(ctx.charm_spec.meta["containers"].keys()))

--- a/tests/spread/commands/init-extensions/tests/unit/test_charm.py
+++ b/tests/spread/commands/init-extensions/tests/unit/test_charm.py
@@ -1,0 +1,28 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Smoke scenario test for Flask."""
+
+import os
+import pathlib
+
+import charm
+import scenario
+import scenario.errors
+
+
+def test_smoke():
+    """The only goal of this test is a smoke test, that is, that the charm does not raise."""
+    os.chdir(pathlib.Path(charm.__file__).parent.parent)
+    ctx = scenario.Context(charm.HelloWorldCharm)
+    container_name = next(iter(ctx.charm_spec.meta["containers"].keys()))
+    container = scenario.Container(
+        name=container_name,
+        can_connect=True,
+    )
+    state_in = scenario.State(containers={container})
+    out = ctx.run(
+        ctx.on.pebble_ready(container),
+        state_in,
+    )
+    assert type(out.unit_status) in (scenario.WaitingStatus, scenario.BlockedStatus)

--- a/tests/spread/commands/init-extensions/tox.ini
+++ b/tests/spread/commands/init-extensions/tox.ini
@@ -3,8 +3,7 @@
 
 [tox]
 no_package = True
-skip_missing_interpreters = True
-env_list = format, lint, static
+env_list = unit
 min_version = 4.0.0
 
 [vars]
@@ -18,7 +17,6 @@ set_env =
     PY_COLORS=1
 pass_env =
     PYTHONPATH
-    CHARM_BUILD_DIR
 
 [testenv:unit]
 description = Run unit tests

--- a/tests/spread/commands/init-extensions/tox.ini
+++ b/tests/spread/commands/init-extensions/tox.ini
@@ -1,0 +1,36 @@
+# Copyright 2024 Canonical
+# See LICENSE file for licensing details.
+
+[tox]
+no_package = True
+skip_missing_interpreters = True
+env_list = format, lint, static
+min_version = 4.0.0
+
+[vars]
+src_path = {tox_root}/test-init/src
+tests_path = {tox_root}/tests
+
+[testenv]
+set_env =
+    PYTHONPATH = {tox_root}/test-init/lib:{[vars]src_path}
+    PYTHONBREAKPOINT=pdb.set_trace
+    PY_COLORS=1
+pass_env =
+    PYTHONPATH
+    CHARM_BUILD_DIR
+
+[testenv:unit]
+description = Run unit tests
+deps =
+    pytest
+    ops-scenario
+    -r {tox_root}/test-init/requirements.txt
+commands =
+    pytest \
+        --tb native \
+        -v \
+        -s \
+	--confcutdir={tox_root} \
+        {posargs} \
+        {[vars]tests_path}/unit


### PR DESCRIPTION
To avoid issues like https://github.com/canonical/charmcraft/pull/1970, a scenario test has been added to the spread test for the `{go,flask,fastapi,django}-framework` init profiles.

This test is a [scenario test (unit test)](https://juju.is/docs/sdk/write-a-functional-test-for-a-charm-with-scenario), that uses the `paas-charm` library and runs a pebble ready event. The real goal of the test is that there are no syntax errors or wrong imports in the init template.