### PR TITLE
fix: default support to include 24.04

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -119,7 +119,8 @@ jobs:
       - name: Run tests
         shell: bash
         run: |
-          if [[ $(uname --kernel-name) == "Linux" ]]; then
+          # -s == --kernel-name, but the long form isn't available on Mac OSX
+          if [[ $(uname -s) == "Linux" ]]; then
             export XDG_RUNTIME_DIR=/run/user/$(id -u)
           fi
           tox run --skip-pkg-install --no-list-dependencies --result-json results/tox-${{ matrix.platform }}.json --colored yes -m tests

--- a/charmcraft/templates/init-kubernetes/spread.yaml.j2
+++ b/charmcraft/templates/init-kubernetes/spread.yaml.j2
@@ -59,6 +59,11 @@ backends:
       multipass delete --purge "${instance_name}"
 
     systems:
+      - ubuntu-24.04:
+          username: spread
+          password: spread
+          workers: 1
+
       - ubuntu-22.04:
           username: spread
           password: spread
@@ -97,6 +102,7 @@ suites:
 
     systems:
       - ubuntu-22.04*
+      - ubuntu-24.04*
 
     environment:
       CHARMCRAFT_CHANNEL/charmcraft_current: latest/stable

--- a/charmcraft/templates/init-machine/spread.yaml.j2
+++ b/charmcraft/templates/init-machine/spread.yaml.j2
@@ -57,6 +57,11 @@ backends:
       multipass delete --purge "${instance_name}"
 
     systems:
+      - ubuntu-24.04:
+          username: spread
+          password: spread
+          workers: 1
+
       - ubuntu-22.04:
           username: spread
           password: spread
@@ -95,6 +100,7 @@ suites:
 
     systems:
       - ubuntu-22.04*
+      - ubuntu-24.04*
 
     environment:
       CHARMCRAFT_CHANNEL/charmcraft_current: latest/stable

--- a/charmcraft/templates/init-simple/spread.yaml.j2
+++ b/charmcraft/templates/init-simple/spread.yaml.j2
@@ -59,6 +59,11 @@ backends:
       multipass delete --purge "${instance_name}"
 
     systems:
+      - ubuntu-24.04:
+          username: spread
+          password: spread
+          workers: 1
+
       - ubuntu-22.04:
           username: spread
           password: spread
@@ -96,6 +101,7 @@ suites:
     summary: Charm functionality tests
 
     systems:
+      - ubuntu-24.04*
       - ubuntu-22.04*
 
     environment:


### PR DESCRIPTION
The existing default templates generate a charm that doesn't have any tests available on Noble systems. I didn't touch the definition for github, as I'm not sure whether there are limitations of what can be run there.