### PR TITLE
fix(snap): check if LXD is actually installed

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -17,13 +17,11 @@ remote image version: core22 -----------------------------------------------
 """
 
 import json
-import platform
 import re
 import subprocess
 import sys
 
 from datetime import datetime
-from pathlib import Path
 
 from charmcraft import snap
 
@@ -76,21 +74,7 @@ def _delete_lxd_instance(instance: dict) -> None:
 
 
 def _has_lxd() -> bool:
-    try:
-        lxc_binary = subprocess.check_output(["which", "lxc"])
-    except subprocess.CalledProcessError:
-        return False
-
-    if lxc_binary == b"/usr/sbin/lxc":
-        # In Ubuntu, /usr/sbin/lxc is a wrapper that might install LXD, which we
-        # *don't* want to do
-        is_ubuntu = "ubuntu" in platform.uname().version.lower()
-        if is_ubuntu:
-            # /usr/sbin/lxc will only install LXD if /snap/bin/lxc doesn't exist
-            return Path("/snap/bin/lxc").exists()
-
-    # In all other cases the result of "which lxc" should be valid
-    return True
+    return subprocess.run(["snap", "list", "lxd"]).returncode == 0
 
 
 def configure_hook_main():

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -17,11 +17,13 @@ remote image version: core22 -----------------------------------------------
 """
 
 import json
+import platform
 import re
 import subprocess
 import sys
 
 from datetime import datetime
+from pathlib import Path
 
 from charmcraft import snap
 
@@ -73,6 +75,24 @@ def _delete_lxd_instance(instance: dict) -> None:
         print(f"Failed to remove LXD instance {instance['name']}.", file=sys.stderr)
 
 
+def _has_lxd() -> bool:
+    try:
+        lxc_binary = subprocess.check_output(["which", "lxc"])
+    except subprocess.CalledProcessError:
+        return False
+
+    if lxc_binary == b"/usr/sbin/lxc":
+        # In Ubuntu, /usr/sbin/lxc is a wrapper that might install LXD, which we
+        # *don't* want to do
+        is_ubuntu = "ubuntu" in platform.uname().version.lower()
+        if is_ubuntu:
+            # /usr/sbin/lxc will only install LXD if /snap/bin/lxc doesn't exist
+            return Path("/snap/bin/lxc").exists()
+
+    # In all other cases the result of "which lxc" should be valid
+    return True
+
+
 def configure_hook_main():
     # Unique valid base instances directory to prevent duplication.
     image_slots = {}
@@ -84,6 +104,10 @@ def configure_hook_main():
         reason = str(error)
         print(f"Unsupported snap configuration: {reason}.", file=sys.stderr)
         sys.exit(1)
+
+    if not _has_lxd():
+        print("LXD is not installed.", file=sys.stderr)
+        return
 
     # Remove only base images in LXD related project
     try:

--- a/snap/hooks/remove
+++ b/snap/hooks/remove
@@ -3,30 +3,14 @@
 """Remove all related LXD images and instances when removing the snap."""
 
 import json
-import platform
 import subprocess
 import sys
-from pathlib import Path
 
 PROJECT_NAME = "charmcraft"
 
 
 def _has_lxd() -> bool:
-    try:
-        lxc_binary = subprocess.check_output(["which", "lxc"])
-    except subprocess.CalledProcessError:
-        return False
-
-    if lxc_binary == b"/usr/sbin/lxc":
-        # In Ubuntu, /usr/sbin/lxc is a wrapper that might install LXD, which we
-        # *don't* want to do
-        is_ubuntu = "ubuntu" in platform.uname().version.lower()
-        if is_ubuntu:
-            # /usr/sbin/lxc will only install LXD if /snap/bin/lxc doesn't exist
-            return Path("/snap/bin/lxc").exists()
-
-    # In all other cases the result of "which lxc" should be valid
-    return True
+    return subprocess.run(["snap", "list", "lxd"]).returncode == 0
 
 
 def remove_hook_main():

--- a/snap/hooks/remove
+++ b/snap/hooks/remove
@@ -3,13 +3,37 @@
 """Remove all related LXD images and instances when removing the snap."""
 
 import json
+import platform
 import subprocess
 import sys
+from pathlib import Path
 
 PROJECT_NAME = "charmcraft"
 
 
+def _has_lxd() -> bool:
+    try:
+        lxc_binary = subprocess.check_output(["which", "lxc"])
+    except subprocess.CalledProcessError:
+        return False
+
+    if lxc_binary == b"/usr/sbin/lxc":
+        # In Ubuntu, /usr/sbin/lxc is a wrapper that might install LXD, which we
+        # *don't* want to do
+        is_ubuntu = "ubuntu" in platform.uname().version.lower()
+        if is_ubuntu:
+            # /usr/sbin/lxc will only install LXD if /snap/bin/lxc doesn't exist
+            return Path("/snap/bin/lxc").exists()
+
+    # In all other cases the result of "which lxc" should be valid
+    return True
+
+
 def remove_hook_main():
+    if not _has_lxd():
+        print("LXD is not installed.", file=sys.stderr)
+        return
+
     # Remove all images in LXD related project
     try:
         lxd_images_json = subprocess.check_output(


### PR DESCRIPTION
On recent Ubuntu systems, "lxc" might be "/usr/sbin/lxc", which is provided by the "lxd-installer" package and will install the LXD snap if it's not installed. This installation can then take a long time if the store is having issues.

For the purposes of the configure and remove hooks we *don't* want to install LXD just to check that it has no stale images, so update the hooks to do some early detection and bail out if LXD is not installed.

Fixes #1982