### PR TITLE
feat: add "cargo" to deb build dependencies for charm plugin

### DIFF
--- a/charmcraft/parts/plugins/_charm.py
+++ b/charmcraft/parts/plugins/_charm.py
@@ -194,6 +194,7 @@ class CharmPlugin(plugins.Plugin):
                 "python3-venv",
                 "python3-wheel",
                 "libyaml-dev",
+                "cargo",
             }
         elif platform.is_yum_based():
             try:


### PR DESCRIPTION
This PR adds `"cargo"` to the charm plugin build dependencies for deb based charms.

I don't know if a similar fix is needed for `yum` and `dnf` systems -- review appreciated here.

This will prevent various charm-libs from needing to document that including them requires adding `cargo` to `build-packages` in `charmcraft.yaml`, and prevent charmers from having to do this, since `cargo` will be included be default, and python packages requiring a rust compiler to build (e.g. `pydantic`) will work out of the box.

See issue:
- #2004