### PR TITLE
build(deps): update craft-parts

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,7 +12,7 @@ craft-application==4.4.0
 craft-archives==2.0.1
 craft-cli==2.10.1
 craft-grammar==2.0.1
-craft-parts==2.1.3
+craft-parts==2.1.4
 craft-platforms==0.4.0
 craft-providers==2.0.4
 craft-store==3.0.2


### PR DESCRIPTION
Fixes the poetry plugin

NOTE: main removed `requirements.txt`, but `requirements-dev.txt` still exists for some workflows. `uv.lock` already has the correct craft-parts.