### PR TITLE
Change poetry plugin keep bins default to True

### DIFF
--- a/charmcraft/parts/plugins/_poetry.py
+++ b/charmcraft/parts/plugins/_poetry.py
@@ -25,7 +25,7 @@ from charmcraft import utils
 
 
 class PoetryPluginProperties(poetry_plugin.PoetryPluginProperties, frozen=True):
-    poetry_keep_bins: bool = False
+    poetry_keep_bins: bool = True
     """Keep the virtual environment's 'bin' directory."""
 
 


### PR DESCRIPTION
Including `bin/activate` in the virtual environment by default will make debugging much easier (charm developers can easily run Python code using the charm's virtual environment to debug issues)

@lengau to confirm, this won't have negative side effects of including a symlink to the python binary or copying the python binary itself into the *.charm artifact?