### PR TITLE
ci: build the snap on self-hosted runners

### DIFF
--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   snap-build:
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, amd64]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   snap-build:
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, amd64]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Ubuntu version shouldn't matter since we're spinning up a container, so we just need to ensure that it's on amd64 because the tests that use these built snaps run on amd64.