### PR TITLE
Fix & always include bin/activate in python & poetry plugin

### DIFF
--- a/tests/unit/parts/plugins/test_poetry.py
+++ b/tests/unit/parts/plugins/test_poetry.py
@@ -97,7 +97,10 @@ def test_get_package_install_commands(
 def test_get_rm_command(
     poetry_plugin: plugins.PoetryPlugin, install_path: pathlib.Path
 ):
-    assert f"rm -rf {install_path / 'venv/bin'}" in poetry_plugin.get_build_commands()
+    assert (
+        f"rm -rf {install_path / 'venv/bin'}/!(activate)"
+        in poetry_plugin.get_build_commands()
+    )
 
 
 def test_no_get_rm_command(
@@ -110,5 +113,6 @@ def test_no_get_rm_command(
     }
     poetry_plugin._options = plugins.PoetryPluginProperties.unmarshal(spec)
     assert (
-        f"rm -rf {install_path / 'venv/bin'}" not in poetry_plugin.get_build_commands()
+        f"rm -rf {install_path / 'venv/bin'}/!(activate)"
+        not in poetry_plugin.get_build_commands()
     )

--- a/tests/unit/parts/plugins/test_python.py
+++ b/tests/unit/parts/plugins/test_python.py
@@ -106,7 +106,10 @@ def test_get_package_install_commands(
 def test_get_rm_command(
     python_plugin: plugins.PythonPlugin, install_path: pathlib.Path
 ):
-    assert f"rm -rf {install_path / 'venv/bin'}" in python_plugin.get_build_commands()
+    assert (
+        f"rm -rf {install_path / 'venv/bin'}/!(activate)"
+        in python_plugin.get_build_commands()
+    )
 
 
 def test_no_get_rm_command(
@@ -119,5 +122,6 @@ def test_no_get_rm_command(
     }
     python_plugin._options = plugins.PythonPluginProperties.unmarshal(spec)
     assert (
-        f"rm -rf {install_path / 'venv/bin'}" not in python_plugin.get_build_commands()
+        f"rm -rf {install_path / 'venv/bin'}/!(activate)"
+        not in python_plugin.get_build_commands()
     )


### PR DESCRIPTION
Including `bin/activate` in the virtual environment will make debugging much easier (charm developers can easily run Python code using the charm's virtual environment to debug issues)