### PR TITLE
fix: include libffi-dev in charm part build-packages

### DIFF
--- a/charmcraft/parts/plugins/_charm.py
+++ b/charmcraft/parts/plugins/_charm.py
@@ -193,6 +193,7 @@ class CharmPlugin(plugins.Plugin):
                 "python3-setuptools",
                 "python3-venv",
                 "python3-wheel",
+                "libffi-dev",
                 "libyaml-dev",
             }
         elif platform.is_yum_based():

--- a/tests/unit/parts/plugins/test_charm.py
+++ b/tests/unit/parts/plugins/test_charm.py
@@ -38,6 +38,7 @@ def test_charmplugin_get_build_package_deb_based(charm_plugin):
             "python3-wheel",
             "python3-venv",
             "python3-dev",
+            "libffi-dev",
             "libyaml-dev",
         }
 


### PR DESCRIPTION
This isn't needed for Red Hat based distributions as python3-devel includes the necessary packages

Fixes #2023
CRAFT-3788