### PR TITLE
ci: separate snap build and PR publish jobs

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,52 +28,29 @@ jobs:
         with:
           name: snap
           path: ${{ steps.snapcraft.outputs.snap }}
-      - name: Get branch name
-        id: vars
+
+  snap-publish:
+    needs: [snap-build]
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' }}
+    steps:
+      - name: Download snap artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: snap
+          path: snap-artifacts
+      - name: Get snap filename
+        id: snap-name
         run: |
-          if [[ "${{ github.event_name }}" == "pull_request" ]]
-          then
-            echo "branch=pr-${{ github.event.number }}" >> "$GITHUB_OUTPUT"
-          elif [[ "${{ github.event_name }}" == "merge_group" ]]
-          then
-            echo "branch=merge" >> "$GITHUB_OUTPUT"
-          else
-            branch=$(echo ${{ github.base_ref }} | sed -e 's|feature/\(.*\)|\1|')
-            if [ -z "${branch}" ]; then
-              branch=$(echo ${{ github.ref_name }} | sed -e 's|/|_|')
-            fi
-            echo "branch=$branch" >> "$GITHUB_OUTPUT"
-          fi
-      - name: Publish feature branch to edge/${{ steps.vars.outputs.branch }}
-        if: ${{ env.SNAPCRAFT_STORE_CREDENTIALS != '' }}
+          echo "snap=$(find . -type f -name '*.snap')" >> $GITHUB_OUTPUT
+      - name: Publish feature branch to edge/pr-${{ github.event.number }}
+        if: env.SNAPCRAFT_STORE_CREDENTIALS != ''
         uses: canonical/action-publish@v1
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
         with:
-          snap: ${{ steps.snapcraft.outputs.snap }}
-          release: edge/${{ steps.vars.outputs.branch }}
-
-  # Commented out until we can provide the necessary launchpad credentials.
-  #  snap-remote-build:
-  #    runs-on: ubuntu-latest
-  #    steps:
-  #      - name: Start installing snapcraft
-  #        run: echo SNAP_JOB=$(sudo snap install --classic --no-wait snapcraft) >> $GITHUB_OUTPUT
-  #        id: install
-  #      - name: Checkout code
-  #        uses: actions/checkout@v3
-  #        with:
-  #          fetch-depth: 0
-  #      - name: Remote-build snap
-  #        id: snapcraft
-  #        run: |
-  #          sudo snap watch ${{ steps.install.outputs.SNAP_JOB }}
-  #          snapcraft remote-build --launchpad-accept-public-upload
-  #      - name: Upload snap artifacts
-  #        uses: actions/upload-artifact@v4
-  #        with:
-  #          name: snap
-  #          path: ./*.snap
+          snap: ${{ steps.snap-name.outputs.snap }}
+          release: edge/pr-${{ github.event.number }}
 
   snap-tests:
     needs: [snap-build]


### PR DESCRIPTION
This allows running snap tests while the store is still processing the snap to publish to a branch.