### PR TITLE
fix: use the same cache directory in providers

### DIFF
--- a/charmcraft/services/provider.py
+++ b/charmcraft/services/provider.py
@@ -124,6 +124,13 @@ class ProviderService(services.ProviderService):
             **kwargs,  # type: ignore[arg-type]
         ) as instance:
             try:
+                # Use /root/.cache even if we're in the snap.
+                instance.execute_run(
+                    ["rm", "-rf", "/root/snap/charmcraft/common/cache"]
+                )
+                instance.execute_run(
+                    ["ln", "-s", "/root/.cache", "/root/snap/charmcraft/common/cache"]
+                )
                 yield instance
             finally:
                 if fcntl is not None and self._lock:


### PR DESCRIPTION
Without this, the snap's `XDG_CACHE_DIR` environment variable will override the use of `/root/.cache` for caching in a provider. Work around this by just making them the same directory.

Fixes #1993

CRAFT-3698