### PR TITLE
test: enable ignoring of fileglobs

### DIFF
--- a/tests/test_infra.py
+++ b/tests/test_infra.py
@@ -28,7 +28,7 @@ def get_python_filepaths() -> list[str]:
     """Helper to retrieve paths of Python files."""
     # list of directories to scan
     source_dirs = ["charmcraft", "tests"]
-    # list of source directories - always return setup.py to be safe
+    # list of source files - always return setup.py to be safe
     source_files = ["setup.py"]
 
     # Parse the globs into their matching files

--- a/tests/test_infra.py
+++ b/tests/test_infra.py
@@ -21,7 +21,7 @@ from pathlib import Path
 import pytest
 
 # A list of bash file globs to not check for
-IGNORE_GLOBS: set[str] = {"tests/spread/**/*.py"}
+IGNORE_GLOBS = frozenset({"tests/spread/**/*.py"})
 
 
 def get_python_filepaths() -> list[str]:
@@ -40,12 +40,11 @@ def get_python_filepaths() -> list[str]:
     for source_dir in source_dirs:
         # Loop over the source_dir recursively
         # This is done instead of os.walk() to take advantage of Path.resolve()
-        for file in Path(source_dir).resolve().glob("**/*"):
+        for file in Path(source_dir).resolve().glob("**/*.py"):
             if file in ignore_files:
                 continue
 
-            if file.name.endswith(".py"):
-                source_files.append(str(file))
+            source_files.append(str(file))
 
     return source_files
 


### PR DESCRIPTION
The copyright header test would scan any .py source file, but sometimes files do not need a Canonical copyright header.

As an example, in https://github.com/canonical/charmcraft/pull/2050, a spread test was added that contained a directory generated by `uv init`. This command makes a pretty minimal Python hello world, and the copyright header test was failing it.