### PR TITLE
docs: fix poetry-with description

### DIFF
--- a/docs/howto/charm-to-poetry.rst
+++ b/docs/howto/charm-to-poetry.rst
@@ -56,9 +56,9 @@ for charms that build on Ubuntu 22.04 or earlier:
 Add optional dependency groups
 ------------------------------
 
-If the charm has optional `dependency groups`_ that should be included when creating
-the virtual environment, the ``poetry-with`` key can be used to include those groups
-when creating the virtual environment.
+If the charm has `dependency groups`_ that should be included when creating the virtual
+environment, the ``poetry-with`` key can be used to include those groups when creating
+the virtual environment.
 
 .. note::
     This is useful and encouraged, though not mandatory, for keeping track of


### PR DESCRIPTION
--with is required for optional and non-optional dependencies

see https://github.com/python-poetry/poetry-plugin-export/pull/212 and https://github.com/python-poetry/poetry-plugin-export/issues/299

corresponding PR in https://github.com/canonical/craft-parts/pull/946