### PR TITLE
fix(common.mk): get upstream setup-lint

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -49,7 +49,7 @@ setup-tests: install-uv install-build-deps ##- Set up a testing environment with
 	uv sync --frozen $(SETUP_TESTS_EXTRA_ARGS)
 
 .PHONY: setup-lint
-setup-lint: install-uv install-shellcheck  ##- Set up a linting-only environment
+setup-lint: install-uv install-shellcheck install-pyright install-lint-build-deps  ##- Set up a linting-only environment
 	uv sync --frozen --no-install-workspace --extra lint --extra types
 
 .PHONY: setup-docs
@@ -232,6 +232,17 @@ else ifneq ($(shell which brew),)
 	uv tool install codespell
 else
 	$(warning Codespell not installed. Please install it yourself.)
+endif
+
+.PHONY: install-pyright
+install-pyright: install-uv
+ifneq ($(shell which pyright),)
+else ifneq ($(shell which snap),)
+	sudo snap install --classic pyright
+else
+    # Workaround for a bug in npm
+	[ -d "$(HOME)/.npm/_cacache" ] && chown -R `id -u`:`id -g` "$(HOME)/.npm" || true
+	uv tool install pyright
 endif
 
 .PHONY: install-ruff


### PR DESCRIPTION
I messed this up when I removed the pyright dep from uv