### PR TITLE
fix: replace colons with hyphens in charm names

### DIFF
--- a/charmcraft/services/package.py
+++ b/charmcraft/services/package.py
@@ -122,19 +122,23 @@ class PackageService(services.PackageService):
     def get_charm_path(self, dest_dir: pathlib.Path) -> pathlib.Path:
         """Get a charm file name for the appropriate set of run-on bases."""
         if self._platform:
-            return dest_dir / f"{self._project.name}_{self._platform}.charm"
+            platform = self._platform.replace(":", "-")
+            return dest_dir / f"{self._project.name}_{platform}.charm"
         build_plan = models.CharmcraftBuildPlanner.model_validate(
             self._project.marshal()
         ).get_build_plan()
-        platform = utils.get_os_platform()
-        build_on_base = bases.BaseName(name=platform.system, version=platform.release)
+        host_platform = utils.get_os_platform()
+        build_on_base = bases.BaseName(
+            name=host_platform.system, version=host_platform.release
+        )
         host_arch = util.get_host_architecture()
         for build_info in build_plan:
             print(build_info)
             if build_info.build_on != host_arch:
                 continue
             if build_info.base == build_on_base:
-                return dest_dir / f"{self._project.name}_{build_info.platform}.charm"
+                platform = build_info.platform.replace(":", "-")
+                return dest_dir / f"{self._project.name}_{platform}.charm"
 
         raise errors.CraftError(
             "Current machine is not a valid build platform for this charm.",

--- a/charmcraft/services/package.py
+++ b/charmcraft/services/package.py
@@ -28,9 +28,8 @@ from typing import TYPE_CHECKING, cast
 import craft_application
 import craft_platforms
 import yaml
-from craft_application import services, util
+from craft_application import services
 from craft_cli import emit
-from craft_providers import bases
 
 import charmcraft
 from charmcraft import const, errors, models, utils
@@ -121,28 +120,8 @@ class PackageService(services.PackageService):
 
     def get_charm_path(self, dest_dir: pathlib.Path) -> pathlib.Path:
         """Get a charm file name for the appropriate set of run-on bases."""
-        if self._platform:
-            platform = self._platform.replace(":", "-")
-            return dest_dir / f"{self._project.name}_{platform}.charm"
-        build_plan = models.CharmcraftBuildPlanner.model_validate(
-            self._project.marshal()
-        ).get_build_plan()
-        host_platform = utils.get_os_platform()
-        build_on_base = bases.BaseName(
-            name=host_platform.system, version=host_platform.release
-        )
-        host_arch = util.get_host_architecture()
-        for build_info in build_plan:
-            print(build_info)
-            if build_info.build_on != host_arch:
-                continue
-            if build_info.base == build_on_base:
-                platform = build_info.platform.replace(":", "-")
-                return dest_dir / f"{self._project.name}_{platform}.charm"
-
-        raise errors.CraftError(
-            "Current machine is not a valid build platform for this charm.",
-        )
+        platform = self._platform.replace(":", "-")
+        return dest_dir / f"{self._project.name}_{platform}.charm"
 
     @property
     def metadata(self) -> BundleMetadata | CharmMetadata:

--- a/tests/spread/smoketests/multi-base/basic/expected-charms.txt
+++ b/tests/spread/smoketests/multi-base/basic/expected-charms.txt
@@ -1,3 +1,3 @@
-test-charm_ubuntu@20.04:amd64.charm
-test-charm_ubuntu@22.04:amd64.charm
+test-charm_ubuntu@20.04-amd64.charm
+test-charm_ubuntu@22.04-amd64.charm
 test-charm_noble-amd64.charm

--- a/tests/spread/smoketests/multi-base/one-platform/expected-charms.txt
+++ b/tests/spread/smoketests/multi-base/one-platform/expected-charms.txt
@@ -1,1 +1,1 @@
-test-charm_ubuntu@22.04:amd64.charm
+test-charm_ubuntu@22.04-amd64.charm

--- a/tests/unit/services/test_package.py
+++ b/tests/unit/services/test_package.py
@@ -86,16 +86,39 @@ def test_get_metadata(package_service, simple_charm: BasesCharm, metadata):
 
 
 @pytest.mark.parametrize(
-    ("bases", "expected_name"),
+    ("build_plan", "expected_name"),
     [
-        (
-            [SIMPLE_BUILD_BASE],
+        pytest.param(
+            [
+                BuildInfo(
+                    platform="distro-1-test64",
+                    build_on="riscv64",
+                    build_for="riscv64",
+                    base=BaseName("ubuntu", "24.04"),
+                )
+            ],
             "charmy-mccharmface_distro-1-test64.charm",
+            id="simple",
+        ),
+        pytest.param(
+            [
+                BuildInfo(
+                    platform="ubuntu@24.04:riscv64",
+                    build_on="riscv64",
+                    build_for="riscv64",
+                    base=BaseName("ubuntu", "24.04"),
+                )
+            ],
+            "charmy-mccharmface_ubuntu@24.04-riscv64.charm",
+            id="multi-base",
         ),
     ],
 )
-def test_get_charm_path(fake_path, package_service, bases, expected_name):
+def test_get_charm_path(fake_path, package_service, build_plan, expected_name):
     fake_prime_dir = fake_path / "prime"
+    package_service._build_plan = build_plan
+    package_service._platform = build_plan[0].platform
+
     charm_path = package_service.get_charm_path(fake_prime_dir)
 
     assert charm_path == fake_prime_dir / expected_name


### PR DESCRIPTION
Multi-base charms may have colons in their platform name. These get converted to hyphens because some environments don't allow colons in filenames.

Fixes #2057 