### PR TITLE
docs: fix build errors in craft-parts

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -113,6 +113,8 @@ exclude_patterns = [
     "common/craft-parts/reference/plugins/qmake_plugin.rst",
     "common/craft-parts/reference/plugins/rust_plugin.rst",
     "common/craft-parts/reference/plugins/scons_plugin.rst",
+    "common/craft-parts/reference/plugins/uv_plugin.rst",
+    "common/craft-parts/reference/plugins/go_use_plugin.rst",
     # Extra non-craft-parts exclusions can be added after this comment
 ]
 

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -104,7 +104,7 @@ Extensions
 Command line
 ============
 
-- The ``pack`` command now updates the charm libaries in the project directory
+- The ``pack`` command now updates the charm libraries in the project directory
   if they don't meet the requirements in the ``charm-libs`` key of
   ``charmcraft.yaml``.
 - New :ref:`ref_commands_create-track` command.
@@ -260,10 +260,9 @@ New Features
 * The new, experimental :ref:`ref_commands_test` command is also included in
   Charmcraft 3.1. Please have a go with it. Documentation is fairly minimal
   right now, as the implementation is still in flux.
-* The :ref:`ref_commands_upload-resource` command now uses
-  `skopeo`_ to upload images. Most notably,
-  this means you can enter
-  `any skopeo-supported containers-transports URL
+* The :ref:`ref_commands_upload-resource` command now uses `skopeo
+  <https://github.com/containers/skopeo>`_ to upload images. Most notably, this
+  means you can enter `any skopeo-supported containers-transports URL
   <https://manpages.ubuntu.com/manpages/noble/man5/containers-transports.5.html>`_
   to upload an OCI container to Charmhub.
 * New features to experimental

--- a/docs/reference/plugins/uv_plugin.rst
+++ b/docs/reference/plugins/uv_plugin.rst
@@ -19,7 +19,7 @@ Whether to keep Python scripts in the virtual environment's :file:`bin`
 directory.
 
 .. include:: /common/craft-parts/reference/plugins/uv_plugin.rst
-    :start-after: .. _craft_parts_poetry_plugin-environment_variables:
+    :start-after: .. _craft_parts_uv_plugin:
     :end-before: .. _uv-details-end:
 
 How it works

--- a/docs/reuse/links.txt
+++ b/docs/reuse/links.txt
@@ -12,7 +12,6 @@
 .. _Multipass: https://multipass.run/docs
 .. _`Open Container Initiative`: https://opencontainers.org/
 .. _Rockcraft: https://documentation.ubuntu.com/rockcraft/
-.. _skopeo: https://github.com/containers/skopeo
 .. _Snapcraft: https://snapcraft.io/docs/snapcraft-overview
 
 .. Potentially use a glossary to create indirect references to explanations.


### PR DESCRIPTION
Fixes ref and label build errors. Some are from the Charmcraft itself, while the rest depend on https://github.com/canonical/craft-parts/pull/965.