### PR TITLE
fix(models/project): make no parts error explicit

### DIFF
--- a/charmcraft/models/project.py
+++ b/charmcraft/models/project.py
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 Canonical Ltd.
+# Copyright 2023,2025 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -420,7 +420,6 @@ class CharmcraftProject(models.Project, metaclass=abc.ABCMeta):
             f"and ${const.STORE_REGISTRY_ENV_VAR} environment variables instead."
         ),
     )
-    parts: dict[str, dict[str, Any]] = pydantic.Field(default_factory=dict)
 
     # Default project properties that Charmcraft currently does not use. Types are set
     # to be Optional[None], preventing them from being used, but allow them to be used
@@ -591,29 +590,6 @@ class CharmProject(CharmcraftProject):
     )
     description: str = pydantic.Field(  # pyright: ignore[reportGeneralTypeIssues]
         description="A multi-line summary of your charm."
-    )
-
-    parts: dict[str, dict[str, Any]] = pydantic.Field(
-        default={"charm": {"plugin": "charm", "source": "."}},
-        description=textwrap.dedent(
-            """\
-            Configures the various mechanisms to obtain, process and prepare data from
-            different sources that end up being a part of the final charm.
-
-            Keys are user-defined part names. The value of each key is a map where keys
-            are part names. Charmcraft provides 3 plugins: charm, bundle, reactive.
-
-            Example::
-
-                parts:
-                  libs:
-                    plugin: dump
-                    source: /usr/local/lib/
-                    organize:
-                      "libxxx.so*": lib/
-                    prime:
-                      - lib/""",
-        ),
     )
 
     actions: dict[str, Any] | None = pydantic.Field(
@@ -1066,6 +1042,29 @@ class BasesCharm(CharmProject):
 
     base: None = None
 
+    parts: dict[str, dict[str, Any]] = pydantic.Field(
+        default={"charm": {"plugin": "charm", "source": "."}},
+        description=textwrap.dedent(
+            """\
+            Configures the various mechanisms to obtain, process and prepare data from
+            different sources that end up being a part of the final charm.
+
+            Keys are user-defined part names. The value of each key is a map where keys
+            are part names. Charmcraft provides 3 plugins: charm, bundle, reactive.
+
+            Example::
+
+                parts:
+                  libs:
+                    plugin: dump
+                    source: /usr/local/lib/
+                    organize:
+                      "libxxx.so*": lib/
+                    prime:
+                      - lib/""",
+        ),
+    )
+
 
 class PlatformCharm(CharmProject):
     """Model for defining a charm using Platforms."""
@@ -1074,6 +1073,29 @@ class PlatformCharm(CharmProject):
     base: BaseStr | None = None
     build_base: BuildBaseStr | None = None
     platforms: dict[str, models.Platform | None]  # type: ignore[assignment]
+
+    parts: dict[str, dict[str, Any]] = pydantic.Field(
+        description=textwrap.dedent(
+            """\
+            Configures the various mechanisms to obtain, process and prepare data from
+            different sources that end up being a part of the final charm.
+
+            Keys are user-defined part names. The value of each key is a map where keys
+            are part names. Charmcraft provides 3 plugins: charm, bundle, reactive.
+
+            Example::
+
+                parts:
+                  libs:
+                    plugin: dump
+                    source: /usr/local/lib/
+                    organize:
+                      "libxxx.so*": lib/
+                    prime:
+                      - lib/""",
+        ),
+        min_length=1,
+    )
 
     @pydantic.model_validator(mode="after")
     def _validate_dev_base_needs_build_base(self) -> Self:
@@ -1106,6 +1128,10 @@ class Bundle(CharmcraftProject):
     summary: CharmcraftSummaryStr | None = None
     description: pydantic.StrictStr | None = None
     platforms: None = None  # type: ignore[assignment]
+
+    parts: dict[str, dict[str, Any]] = pydantic.Field(
+        default_factory=lambda: {"bundle": {"plugin": "bundle", "source": "."}}
+    )
 
     @pydantic.model_validator(mode="before")
     @classmethod

--- a/tests/integration/commands/test_expand_extensions.py
+++ b/tests/integration/commands/test_expand_extensions.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2023,2025 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ def fake_extensions(stub_extensions):
 @pytest.mark.parametrize(
     ("charmcraft_yaml", "expected"),
     [
-        (
+        pytest.param(
             dedent(
                 f"""
                 name: test-charm-name
@@ -60,6 +60,9 @@ def fake_extensions(stub_extensions):
                 base: ubuntu@22.04
                 platforms:
                   amd64:
+                parts:
+                  my-part:
+                    plugin: nil
                 """
             ),
             dedent(
@@ -70,13 +73,52 @@ def fake_extensions(stub_extensions):
                 base: ubuntu@22.04
                 platforms:
                   amd64: null
-                parts: {}
+                parts:
+                  my-part:
+                    plugin: nil
                 type: charm
                 terms:
                 - https://example.com/test
                 """
             ),
-        )
+            id="platforms",
+        ),
+        pytest.param(
+            dedent(
+                f"""
+                name: test-charm-name
+                type: charm
+                summary: test-summary
+                description: test-description
+                extensions: [{TestExtension.name}]
+                bases:
+                  - name: ubuntu
+                    channel: "22.04"
+                """
+            ),
+            dedent(
+                """\
+                name: test-charm-name
+                summary: test-summary
+                description: test-description
+                parts:
+                  charm:
+                    plugin: charm
+                    source: .
+                type: charm
+                terms:
+                - https://example.com/test
+                bases:
+                - build-on:
+                  - name: ubuntu
+                    channel: '22.04'
+                  run-on:
+                  - name: ubuntu
+                    channel: '22.04'
+                """
+            ),
+            id="bases",
+        ),
     ],
 )
 def test_expand_extensions_simple(

--- a/tests/integration/commands/test_pack.py
+++ b/tests/integration/commands/test_pack.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Canonical Ltd.
+# Copyright 2024-2025 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/integration/commands/test_pack.py
+++ b/tests/integration/commands/test_pack.py
@@ -97,7 +97,7 @@ def test_build_basic_bundle(monkeypatch, capsys, app, new_path, bundle_yaml, fil
                         "build-for": ["amd64"],
                     }
                 },
-                "parts": {},
+                "parts": {"my-part": {"plugin": "nil"}},
             },
             "ubuntu-22.04-amd64",
             marks=pytest.mark.skipif(
@@ -114,7 +114,7 @@ def test_build_basic_bundle(monkeypatch, capsys, app, new_path, bundle_yaml, fil
                 "description": "A charm for testing",
                 "base": "ubuntu@22.04",
                 "platforms": {util.get_host_architecture(): None},
-                "parts": {},
+                "parts": {"my-part": {"plugin": "nil"}},
             },
             util.get_host_architecture(),
             marks=pytest.mark.skipif(
@@ -132,7 +132,7 @@ def test_build_basic_bundle(monkeypatch, capsys, app, new_path, bundle_yaml, fil
                 "base": "ubuntu@24.04",
                 "build-base": "ubuntu@devel",
                 "platforms": {util.get_host_architecture(): None},
-                "parts": {},
+                "parts": {"my-part": {"plugin": "nil"}},
             },
             util.get_host_architecture(),
             marks=pytest.mark.skipif(

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Canonical Ltd.
+# Copyright 2024-2025 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -51,6 +51,7 @@ def charm_project(
         | {
             "base": f"{distro_id}@{distro_version}",
             "platforms": {util.get_host_architecture(): None},
+            "parts": {"charm": {"plugin": "charm", "source": "."}},
         },
     )
 

--- a/tests/integration/sample-charms/actions-included/charmcraft.yaml
+++ b/tests/integration/sample-charms/actions-included/charmcraft.yaml
@@ -10,6 +10,7 @@ platforms:
 parts:
   charm:
     plugin: charm
+    source: .
 
 actions:
   pause:

--- a/tests/test_infra.py
+++ b/tests/test_infra.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 Canonical Ltd.
+# Copyright 2020-2022,2025 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ def get_python_filepaths() -> list[str]:
 def test_ensure_copyright() -> None:
     """Check that all non-empty Python files have copyright somewhere in the first 5 lines."""
     issues = []
-    regex = re.compile(r"# Copyright \d{4}(-\d{4})? Canonical Ltd.$")
+    regex = re.compile(r"# Copyright \d{4}([-,]\d{4})* Canonical Ltd.$")
     for filepath in get_python_filepaths():
         if Path(filepath).stat().st_size == 0:
             continue

--- a/tests/unit/models/invalid_charms_yaml/platforms-empty-parts.yaml
+++ b/tests/unit/models/invalid_charms_yaml/platforms-empty-parts.yaml
@@ -4,12 +4,9 @@ summary: The most basic valid charm
 description: |
   The most basic possible valid charmcraft.yaml that doesn't need other files and gets returned to its own value.
   Note that this means we cannot use short-form bases here because this charm is meant to be rewritable.
-base:
-  "ubuntu@22.04"
+base: ubuntu@22.04
 platforms:
   amd64:
     build-on: [amd64]
     build-for: [amd64]
-parts:
-  my-part:
-    plugin: nil
+parts: {}

--- a/tests/unit/models/invalid_charms_yaml/platforms-no-parts.yaml
+++ b/tests/unit/models/invalid_charms_yaml/platforms-no-parts.yaml
@@ -4,12 +4,8 @@ summary: The most basic valid charm
 description: |
   The most basic possible valid charmcraft.yaml that doesn't need other files and gets returned to its own value.
   Note that this means we cannot use short-form bases here because this charm is meant to be rewritable.
-base:
-  "ubuntu@22.04"
+base: ubuntu@22.04
 platforms:
   amd64:
     build-on: [amd64]
     build-for: [amd64]
-parts:
-  my-part:
-    plugin: nil

--- a/tests/unit/services/test_package.py
+++ b/tests/unit/services/test_package.py
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 Canonical Ltd.
+# Copyright 2023-2025 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -404,7 +404,7 @@ def test_get_manifest_bases_from_platforms(
             "base": base,
             "build-base": build_base,
             "platforms": platforms,
-            "parts": {},
+            "parts": {"my-part": {"plugin": "nil"}},
         }
     )
     package_service._project = charm
@@ -427,7 +427,7 @@ def test_get_manifest_bases_from_platforms_invalid(package_service):
             "base": None,
             "build-base": None,
             "platforms": {"amd64": None},
-            "parts": {},
+            "parts": {"my-part": {"plugin": "nil"}},
         }
     )
     package_service._project = charm

--- a/tests/unit/test_preprocess.py
+++ b/tests/unit/test_preprocess.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Canonical Ltd.
+# Copyright 2024-2025 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -46,6 +46,16 @@ BASIC_BASES_CHARM = {**BASIC_CHARM, "bases": [{"name": "ubuntu", "channel": "22.
             id="empty-charm",
         ),
         pytest.param(BASIC_CHARM.copy(), BASIC_CHARM, id="basic-charm"),
+        pytest.param(
+            {"type": "charm", "platforms": {"amd64": None}},
+            {"type": "charm", "platforms": {"amd64": None}},
+            id="platforms-charm-no-base",
+        ),
+        pytest.param(
+            {"type": "charm", "base": "ubuntu@24.04"},
+            {"type": "charm", "base": "ubuntu@24.04"},
+            id="platforms-charm-no-platforms",
+        ),
     ],
 )
 def test_add_default_parts_correct(yaml_data, expected):


### PR DESCRIPTION
There were previously edge cases where a platform charm could be declared but the lack of a `parts` key wouldn't be caught. This now enforces at least one part.

Fixes #2055
CRAFT-3851