### PR TITLE
style: update to ruff 0.9.0 formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
       - id: fix-byte-order-marker
       - id: mixed-line-ending
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.8.1"
+    rev: "v0.9.0"
     hooks:
       # Run the linter
       - id: ruff

--- a/charmcraft/utils/platform.py
+++ b/charmcraft/utils/platform.py
@@ -1,3 +1,4 @@
+# noqa: A005 (This module shadows the stdlib platform module.)
 # Copyright 2023 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -258,8 +258,8 @@ lint.select = [  # Base linting rule selections.
     "RSE",  # Errors on pytest raises.
     "RET",  # Simpler logic after return, raise, continue or break
     "SIM",  # Code simplification
-    "TCH004",  # Remove imports from type-checking guard blocks if used at runtime
-    "TCH005",  # Delete empty type-checking blocks
+    "TC004",  # Remove imports from type-checking guard blocks if used at runtime
+    "TC005",  # Delete empty type-checking blocks
     "ARG",  # Unused arguments
     "PTH",  # Migrate to pathlib
     "ERA",  # Don't check in commented out code
@@ -293,7 +293,6 @@ lint.extend-select = [
     "RUF100",  # #noqa directive that doesn't flag anything
 ]
 lint.ignore = [
-    "ANN10",  # Type annotations for `self` and `cls`
     #"E203",  # Whitespace before ":"  -- Commented because ruff doesn't currently check E203
     "E501",  # Line too long (reason: black will automatically fix this for us)
     "D105",  # Missing docstring in magic method (reason: magic methods already have definitions)
@@ -351,7 +350,7 @@ ignore-decorators = [  # Functions with these decorators don't have to have docs
 
     # Charmcraft-specific ignores, to be removed as we modernise the code.
     "A001", "A002",
-    "PT004", "PT012",
+    "PT012",
     "S105", "S106",
 ]
 # isort leaves init files alone by default, this makes ruff ignore them too.

--- a/tests/test_jujuignore.py
+++ b/tests/test_jujuignore.py
@@ -347,9 +347,9 @@ def assert_matched_and_non_matched(globs, matched, unmatched, skip_git=False):
             text=True,
         )
     matched_out = p.stdout.splitlines()
-    assert sorted(matched) == sorted(
-        matched_out
-    ), f"expected exactly {matched} to match not {matched_out}"
+    assert sorted(matched) == sorted(matched_out), (
+        f"expected exactly {matched} to match not {matched_out}"
+    )
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Windows not [yet] supported")


### PR DESCRIPTION
This handles the cases where lint starts failing with ruff 0.9.0.