### PR TITLE
fix(commands/test): add experimental notice to command

### DIFF
--- a/charmcraft/application/commands/test.py
+++ b/charmcraft/application/commands/test.py
@@ -27,7 +27,8 @@ from charmcraft.application.commands import base
 _overview = """
 Run charm tests in different back-ends.
 
-This command will run charm test suites using the spread tool. For further
+This command will run charm test suites using the spread tool. The test
+command is EXPERIMENTAL and may be changed without prior notice. For further
 information, see the spread documentation: https://github.com/snapcore/spread
 """
 
@@ -36,7 +37,7 @@ class TestCommand(base.CharmcraftCommand):
     """Initialize a directory to be a charm project."""
 
     name = "test"
-    help_msg = "Execute charm test suites"
+    help_msg = "Execute charm test suites (EXPERIMENTAL)"
     overview = _overview
     common = True
 
@@ -96,6 +97,10 @@ class TestCommand(base.CharmcraftCommand):
             else:
                 spread_tasks = ["multipass"]
 
+        emit.progress(
+            "WARNING: This is an EXPERIMENTAL command that can be changed without prior notice.",
+            permanent=True,
+        )
         try:
             with emit.pause():
                 subprocess.run([*cmd, *spread_tasks], check=True)


### PR DESCRIPTION
The test command is experimental and was not intended to reach stable
releases. Place a notice on command help and execution. This command
will be removed and replaced by the final implementation that will
exist in craft-application.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>