### PR TITLE
docs: add additional anchors on the "manage charms" page for linking to

### DIFF
--- a/docs/howto/manage-charms.rst
+++ b/docs/howto/manage-charms.rst
@@ -357,6 +357,7 @@ To specify device requirements, in your charm's ``charmcraft.yaml`` file specify
 
     See more: :ref:`recipe-key-devices`
 
+.. _manage-charms-storage:
 
 Specify storage requirements
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -399,6 +400,7 @@ specify the ``actions`` key.
 
     See next: :external+ops:ref:`manage-actions`
 
+.. _manage-charms-configurations:
 
 Manage configurations
 ~~~~~~~~~~~~~~~~~~~~~
@@ -416,6 +418,7 @@ specify the ``config`` key.
 
     See next: :external+ops:ref:`manage-configurations`
 
+.. _manage-charms-relations:
 
 Manage relations (integrations)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -438,6 +441,7 @@ Specify necessary libs
 
     See more: :ref:`manage-libraries`
 
+.. _manage-charms-secrets:
 
 Manage secrets
 ~~~~~~~~~~~~~~
@@ -459,6 +463,7 @@ Specify necessary parts
 
     See more: :ref:`manage-parts`
 
+.. _manage-charms-pack:
 
 Pack a charm
 ------------


### PR DESCRIPTION
From what I can tell, by default most of the headings in the "manage charms" page don't produce anchors that can be linked to with intersphinx:

```
$ intersphinx list https://canonical-charmcraft.readthedocs-hosted.com/en/stable --includes manage-charm
std:label Manage charm bundles (manage-charm-bundles)
  https://canonical-charmcraft.readthedocs-hosted.com/en/stable/howto/manage-bundles/#manage-charm-bundles
std:label Manage charm revisions (manage-charm-revisions)
  https://canonical-charmcraft.readthedocs-hosted.com/en/stable/howto/manage-revisions/#manage-charm-revisions
std:label Manage charms (manage-charms)
  https://canonical-charmcraft.readthedocs-hosted.com/en/stable/howto/manage-charms/#manage-charms
std:label Publish a charm on Charmhub (publish-a-charm)
  https://canonical-charmcraft.readthedocs-hosted.com/en/stable/howto/manage-charms/#publish-a-charm
std:doc Manage charms (howto/manage-charms)
  https://canonical-charmcraft.readthedocs-hosted.com/en/stable/howto/manage-charms/
```

We'd like to link to these individual sections from the ops docs, so the PR adds explicit anchors to link to.

Refs: https://github.com/canonical/operator/pull/1546