### PR TITLE
fix(provider): ensure /root/.cache exists

### DIFF
--- a/charmcraft/services/provider.py
+++ b/charmcraft/services/provider.py
@@ -126,10 +126,12 @@ class ProviderService(services.ProviderService):
             try:
                 # Use /root/.cache even if we're in the snap.
                 instance.execute_run(
-                    ["rm", "-rf", "/root/snap/charmcraft/common/cache"]
+                    ["rm", "-rf", "/root/snap/charmcraft/common/cache"], check=True
                 )
+                instance.execute_run(["mkdir", "-p", "/root/.cache"], check=True)
                 instance.execute_run(
-                    ["ln", "-s", "/root/.cache", "/root/snap/charmcraft/common/cache"]
+                    ["ln", "-s", "/root/.cache", "/root/snap/charmcraft/common/cache"],
+                    check=True,
                 )
                 yield instance
             finally:


### PR DESCRIPTION
Fixes #2125
CRAFT-4037

Test failures are unrelated. I will be putting up a separate PR to fix those. Reporter has confirmed that [the fix works for them](https://github.com/canonical/charmcraft/issues/2125#issuecomment-2630600486)

Tests will pass when I rebase on https://github.com/canonical/charmcraft/pull/2137