### PR TITLE
docs: fix broken references to juju docs

### DIFF
--- a/docs/howto/manage-bundles.rst
+++ b/docs/howto/manage-bundles.rst
@@ -21,8 +21,8 @@ To create a bundle, create a ``<bundle>.yaml`` file with your desired configurat
     If you don't want to start from scratch, export the contents of your model to a
     ``<bundle>.yaml`` file via ``juju export-bundle --filename <bundle>.yaml`` or
     download the ``<bundle>.yaml`` of an existing bundle from Charmhub.
-    See more: :external+juju:ref:`Juju | How to compare and export the contents of a
-    model to a bundle <Compare-and-export-the-contents-of-a-model-to-a-bundle>`.
+    See more: :external+juju:ref:`Juju | Compare and export the contents of a model to
+    a bundle <export-model-to-bundle>`.
 
 Pack a bundle
 -------------

--- a/docs/howto/manage-resources.rst
+++ b/docs/howto/manage-resources.rst
@@ -3,7 +3,7 @@
 Manage resources
 ================
 
-    See first: :external+juju:ref:`Juju | Charm resource <resource-charm>`,
+    See first: :external+juju:ref:`Juju | Resource (charm) <charm-resource>`,
     :external+juju:ref:`Juju | Manage resources <manage-charm-resources>`
 
 

--- a/docs/reference/files/bundle-yaml-file.rst
+++ b/docs/reference/files/bundle-yaml-file.rst
@@ -748,8 +748,8 @@ The default base for deploying charms that can be deployed on multiple bases.
 
 **Purpose:** A link to a documentation cover page.
 
-    See more: :external+juju:ref:`Juju | Charm documentation
-    <charm-documentation-best-practices>`
+    See more: :external+juju:ref:`Juju | Documentation conventions
+    <documentation-conventions>`
 
 
 ``issues``

--- a/docs/reference/files/bundle-yaml-file.rst
+++ b/docs/reference/files/bundle-yaml-file.rst
@@ -749,7 +749,7 @@ The default base for deploying charms that can be deployed on multiple bases.
 **Purpose:** A link to a documentation cover page.
 
     See more: :external+juju:ref:`Juju | Documentation conventions
-    <documentation-conventions>`
+    <charm-best-practices-documentation>`
 
 
 ``issues``

--- a/docs/reference/files/charmcraft-yaml-file.rst
+++ b/docs/reference/files/charmcraft-yaml-file.rst
@@ -842,7 +842,7 @@ at least one ``requires`` integration with ``container`` scope.
 ``resources``
 -------------
 
-    See first: :external+juju:ref:`Juju | Resource (charm) <resource-charm>`
+    See first: :external+juju:ref:`Juju | Resource (charm) <charm-resource>`
 
 **Status:** Optional.
 


### PR DESCRIPTION
Depends on ~https://github.com/juju/juju/pull/18788~ https://github.com/juju/juju/pull/18790.