### PR TITLE
feat(docs): add feedback button

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -185,9 +185,3 @@ common_docs_path = pathlib.Path(__file__).parent / "common"
 craft_parts_docs_path = pathlib.Path(craft_parts_docs.__file__).parent / "craft-parts"
 (common_docs_path / "craft-parts").unlink(missing_ok=True)
 (common_docs_path / "craft-parts").symlink_to(craft_parts_docs_path, target_is_directory=True)
-
-# Workaround to enable extra scripts in page template
-html_js_files = [
-    'header-nav.js', # "More links" onclick events from canonical-sphinx-extensions
-    'github_issue_links.js', # Feedback button from canonical-sphinx-extensions
-]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,6 +45,7 @@ ogp_image = "https://assets.ubuntu.com/v1/253da317-image-document-ubuntudocs.svg
 html_context = {
     "product_page": "github.com/canonical/charmcraft",
     "github_url": "https://github.com/canonical/charmcraft",
+    "github_issues": "https://github.com/canonical/charmcraft/issues",
     "discourse": "https://discourse.charmhub.io",
 }
 
@@ -184,3 +185,11 @@ common_docs_path = pathlib.Path(__file__).parent / "common"
 craft_parts_docs_path = pathlib.Path(craft_parts_docs.__file__).parent / "craft-parts"
 (common_docs_path / "craft-parts").unlink(missing_ok=True)
 (common_docs_path / "craft-parts").symlink_to(craft_parts_docs_path, target_is_directory=True)
+
+# By default, the documentation includes a feedback button at the top.
+# You can disable it by setting the following configuration to True.
+disable_feedback_button = False
+
+html_js_files = ['header-nav.js']
+if 'github_issues' in html_context and html_context['github_issues'] and not disable_feedback_button:
+    html_js_files.append('github_issue_links.js')

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -186,10 +186,8 @@ craft_parts_docs_path = pathlib.Path(craft_parts_docs.__file__).parent / "craft-
 (common_docs_path / "craft-parts").unlink(missing_ok=True)
 (common_docs_path / "craft-parts").symlink_to(craft_parts_docs_path, target_is_directory=True)
 
-# By default, the documentation includes a feedback button at the top.
-# You can disable it by setting the following configuration to True.
-disable_feedback_button = False
-
-html_js_files = ['header-nav.js']
-if 'github_issues' in html_context and html_context['github_issues'] and not disable_feedback_button:
-    html_js_files.append('github_issue_links.js')
+# Workaround to enable extra scripts in page template
+html_js_files = [
+    'header-nav.js', # "More links" onclick events from canonical-sphinx-extensions
+    'github_issue_links.js', # Feedback button from canonical-sphinx-extensions
+]


### PR DESCRIPTION
Add a "Give feedback" button to the top of the RTD site that links the user to a GitHub issue form to describe any feedback they have about a particular docs page.