### PR TITLE
docs: align ops links formatting

### DIFF
--- a/docs/howto/build-guides/pack-a-hooks-based-charm-with-charmcraft.rst
+++ b/docs/howto/build-guides/pack-a-hooks-based-charm-with-charmcraft.rst
@@ -5,7 +5,8 @@ How to pack a hooks-based charm with Charmcraft
 
     Introduced in Charmcraft 1.4
 
-    See first: :external+ops:ref:`turn-a-hooks-based-charm-into-an-ops-charm`
+    See first: :external+ops:ref:`Ops | Turn a hooks-based charm into an ops charm
+    <turn-a-hooks-based-charm-into-an-ops-charm>`
 
 Suppose you have a legacy hooks-only charm, for example, `tiny-bash
 <https://github.com/erik78se/tiny-bash>`_, which you can clone with:

--- a/docs/howto/manage-12-factor-app-charms.rst
+++ b/docs/howto/manage-12-factor-app-charms.rst
@@ -99,10 +99,9 @@ token for a service. Add the configuration in ``charmcraft.yaml``:
         also available in the Flask variable ``app.config`` without
         the ``FLASK_`` prefix.
 
-            See also:
-            :external+ops:ref:`How to add configuration to a charm <manage-configurations>`,
-            `Configuration Handling --
-            Flask Documentation <https://flask.palletsprojects.com/en/3.0.x/config/>`_
+            See also: :external+ops:ref:`Ops | Manage configurations
+            <manage-configurations>`, `Configuration Handling -- Flask Documentation
+            <https://flask.palletsprojects.com/en/3.0.x/config/>`_
 
     .. group-tab:: Django
 

--- a/docs/howto/manage-charms.rst
+++ b/docs/howto/manage-charms.rst
@@ -420,7 +420,7 @@ specify the ``actions`` key.
 
     See more: :ref:`recipe-key-actions`
 
-    See next: :external+ops:ref:`manage-actions`
+    See next: :external+ops:ref:`Ops | Manage actions <manage-actions>`
 
 .. _manage-configurations:
 
@@ -438,7 +438,7 @@ specify the ``config`` key.
 
     See more: :ref:`recipe-key-config`
 
-    See next: :external+ops:ref:`manage-configurations`
+    See next: :external+ops:ref:`Ops | Manage configurations <manage-configurations>`
 
 .. _manage-relations:
 
@@ -453,7 +453,7 @@ Manage relations
 
     See more: :ref:`recipe-key-peers`
 
-    See more: :external+ops:ref:`Ops | How to manage relations <manage-relations>`
+    See more: :external+ops:ref:`Ops | Manage relations <manage-relations>`
 
 
 Specify necessary libs

--- a/docs/howto/manage-libraries.rst
+++ b/docs/howto/manage-libraries.rst
@@ -36,7 +36,7 @@ Edit this file to write your library.
 
 ..
 
-    See next: :external+ops:ref:`manage-libraries`
+    See next: :external+ops:ref:`Ops | Manage libraries <manage-libraries>`
 
 
 .. _publish-a-library:

--- a/docs/howto/manage-resources.rst
+++ b/docs/howto/manage-resources.rst
@@ -15,7 +15,7 @@ its recipe.
 
     See more: :ref:`recipe-key-resources`
 
-    See next: :external+ops:ref:`manage-resources`
+    See next: :external+ops:ref:`Ops | Manage resources <manage-resources>`
 
 .. tip::
 


### PR DESCRIPTION
Corrects the remaining **See next** and **See also** link text for Ops Library targets.