### PR TITLE
docs(how-to): add how-to migrate to uv

### DIFF
--- a/docs/howto/manage-libraries.rst
+++ b/docs/howto/manage-libraries.rst
@@ -9,7 +9,7 @@ Initialise a library
 
    See also: :ref:`ref_commands_create-lib`
 
-In your charm's root directory, run ``charmcraft create-lib``. In this example we ues
+In your charm's root directory, run ``charmcraft create-lib``. In this example we use
 the name ``demo``.
 
 .. code-block:: bash

--- a/docs/howto/migrate-plugins/charm-to-uv.rst
+++ b/docs/howto/migrate-plugins/charm-to-uv.rst
@@ -41,6 +41,7 @@ To find these dependencies, check each loaded library file for its ``PYDEPS`` by
 the following command at the root of the charm project:
 
 .. code-block:: bash
+
     find lib -name "*.py" -exec awk '/PYDEPS = \[/,/\]/' {} +
 
 Next, in ``pyproject.toml``, list them in a ``charmlibs`` dependency group.
@@ -61,11 +62,8 @@ Add dependency groups
 ---------------------
 
 If the charm has dependency groups that should be included when creating the virtual
-environment, such as one for charm libraries, the ``uv-groups`` key can be set to
-include them.
-
-Including this dependency group in your charm is as easy as adding it to
-``charmcraft.yaml``:
+environment, such as one for charm libraries, the
+:ref:`uv plugin's <craft_parts_uv_plugin>` ``uv-groups`` key can be set to include them:
 
 .. code-block:: yaml
     :caption: charmcraft.yaml
@@ -77,6 +75,9 @@ Including this dependency group in your charm is as easy as adding it to
         source: .
         uv-groups:
           - charmlibs
+
+Likewise, optional dependencies under the ``pyproject.toml`` key
+``project.optional-dependencies`` can be added with the ``uv-extras`` key.
 
 Include extra files
 -------------------

--- a/docs/howto/migrate-plugins/charm-to-uv.rst
+++ b/docs/howto/migrate-plugins/charm-to-uv.rst
@@ -1,0 +1,107 @@
+.. _howto-migrate-to-uv:
+
+Migrate from the Charm plugin to the uv plugin
+==============================================
+
+For charms that use `uv`_, Charmcraft has a :ref:`craft_parts_uv_plugin`. Migrating
+from the Charm plugin provides some benefits, such as using uv during the build
+process not having to maintain a separate ``requirements.txt`` file. If the
+charm to be migrated does not currently use uv, refer to the
+`uv documentation <https://docs.astral.sh/uv/guides/projects/>`_ for instructions
+on how to use uv for a Python project.
+
+Update the project file
+-----------------------
+
+The first step is to update the project file to include the correct parts definition.
+Depending on the history of a specific charm, it may not have an explicitly-included
+``parts`` section determining how to build the charm. In this case, a ``parts`` section
+can be created as follows:
+
+.. code-block:: yaml
+    :caption: charmcraft.yaml
+
+    parts:
+      my-charm:  # This can be named anything you want
+        plugin: uv
+        source: .
+
+Add optional dependency groups
+------------------------------
+
+If the charm has `dependency groups`_ that should be included when creating the virtual
+environment, the ``uv-groups`` key can be used to include those groups when creating
+the virtual environment.
+
+.. note::
+    This is useful and encouraged, though not mandatory, for keeping track of
+    library dependencies, as covered in the next section.
+
+Include charm library dependencies
+----------------------------------
+
+Unlike the Charm plugin, the uv plugin does not install the dependencies for
+included charmlibs. If any of the charm libraries used have ``PYDEPS``, these will
+need to be added to the charm's dependencies, potentially as their own
+`dependency group <dependency groups_>`_.
+
+To find these dependencies, check each library file for its ``PYDEPS``. A command
+that can find these is::
+
+    find lib -name "*.py" -exec awk '/PYDEPS = \[/,/\]/' {} +
+
+If run from the base directory of a charm, this will show all the PYDEPS declarations
+from all loaded charm libs. These can then be included in ``pyproject.toml``.
+
+.. code-block:: toml
+    :caption: pyproject.toml
+
+    [dependency-groups]
+    # Dependencies brought from libraries the charm uses.
+    charmlibs = [
+        "cosl",
+        "pydantic",
+        "cryptography",
+        "ops>=2.0.0",
+    ]
+
+Including this dependency group is as easy as adding it to ``charmcraft.yaml``:
+
+.. code-block:: yaml
+    :caption: charmcraft.yaml
+    :emphasize-lines: 5-6
+
+    parts:
+      my-charm:
+        plugin: uv
+        source: .
+        uv-groups:
+          - charmlibs
+
+Include extra files
+-------------------
+
+The uv plugin only includes the contents of the ``src`` and ``lib`` directories
+as well as the generated virtual environment. If other files were previously included
+from the main directory, they can be included again using the
+:ref:`craft_parts_dump_plugin`:
+
+.. code-block:: yaml
+    :caption: charmcraft.yaml
+    :emphasize-lines: 7-11
+
+    parts:
+      my-charm:
+        plugin: uv
+        source: .
+        uv-groups:
+          - charmlibs
+      version-file:
+        plugin: dump
+        source: .
+        stage:
+          - charm_version
+
+
+.. _dependency groups: https://docs.astral.sh/uv/concepts/projects/dependencies/#dependency-groups
+.. _uv: https://docs.astral.sh/uv

--- a/docs/howto/migrate-plugins/charm-to-uv.rst
+++ b/docs/howto/migrate-plugins/charm-to-uv.rst
@@ -3,12 +3,16 @@
 Migrate from the Charm plugin to the uv plugin
 ==============================================
 
-For charms that use `uv`_, Charmcraft has a :ref:`craft_parts_uv_plugin`. Migrating
-from the Charm plugin provides some benefits, such as using uv during the build
-process not having to maintain a separate ``requirements.txt`` file. If the
-charm to be migrated does not currently use uv, refer to the
-`uv documentation <https://docs.astral.sh/uv/guides/projects/>`_ for instructions
-on how to use uv for a Python project.
+For charms that use `uv`_, Charmcraft has a :ref:`craft_parts_uv_plugin`. This guide
+shows how to migrate from the default Charm plugin to the uv plugin.
+
+Migrating from the Charm plugin provides some benefits, not having to maintain a
+separate ``requirements.txt`` file and using the much faster ``uv`` for package
+management rather than ``pip``.
+
+If the charm to be migrated does not currently use uv, refer to the
+`uv documentation <https://docs.astral.sh/uv/guides/projects/>`_ for instructions on
+how to use uv for a Python project.
 
 Update the project file
 -----------------------
@@ -26,17 +30,6 @@ can be created as follows:
         plugin: uv
         source: .
 
-Add optional dependency groups
-------------------------------
-
-If the charm has `dependency groups`_ that should be included when creating the virtual
-environment, the ``uv-groups`` key can be used to include those groups when creating
-the virtual environment.
-
-.. note::
-    This is useful and encouraged, though not mandatory, for keeping track of
-    library dependencies, as covered in the next section.
-
 Include charm library dependencies
 ----------------------------------
 
@@ -45,13 +38,13 @@ included charmlibs. If any of the charm libraries used have ``PYDEPS``, these wi
 need to be added to the charm's dependencies, potentially as their own
 `dependency group <dependency groups_>`_.
 
-To find these dependencies, check each library file for its ``PYDEPS``. A command
-that can find these is::
+To find these dependencies, check each loaded library file for its ``PYDEPS`` by running
+the following command at the root of the charm project:
 
+.. code-block:: bash
     find lib -name "*.py" -exec awk '/PYDEPS = \[/,/\]/' {} +
 
-If run from the base directory of a charm, this will show all the PYDEPS declarations
-from all loaded charm libs. These can then be included in ``pyproject.toml``.
+Next, in ``pyproject.toml``, list them in a ``charmlibs`` dependency group.
 
 .. code-block:: toml
     :caption: pyproject.toml
@@ -65,7 +58,15 @@ from all loaded charm libs. These can then be included in ``pyproject.toml``.
         "ops>=2.0.0",
     ]
 
-Including this dependency group is as easy as adding it to ``charmcraft.yaml``:
+Add dependency groups
+---------------------
+
+If the charm has dependency groups, such as one for charm libraries, that should be
+included when creating the virtual environment, the ``uv-groups`` key can be used to
+include those groups when creating the virtual environment.
+
+Including this dependency group in your charm is as easy as adding it to
+``charmcraft.yaml``:
 
 .. code-block:: yaml
     :caption: charmcraft.yaml

--- a/docs/howto/migrate-plugins/charm-to-uv.rst
+++ b/docs/howto/migrate-plugins/charm-to-uv.rst
@@ -6,9 +6,8 @@ Migrate from the Charm plugin to the uv plugin
 For charms that use `uv`_, Charmcraft has a :ref:`craft_parts_uv_plugin`. This guide
 shows how to migrate from the default Charm plugin to the uv plugin.
 
-Migrating from the Charm plugin provides some benefits, not having to maintain a
-separate ``requirements.txt`` file and using the much faster ``uv`` for package
-management rather than ``pip``.
+Migrating from the Charm plugin provides some benefits, notably not having to maintain a
+separate ``requirements.txt`` file. For package management, uv is much faster than pip.
 
 If the charm to be migrated does not currently use uv, refer to the
 `uv documentation <https://docs.astral.sh/uv/guides/projects/>`_ for instructions on
@@ -61,9 +60,9 @@ Next, in ``pyproject.toml``, list them in a ``charmlibs`` dependency group.
 Add dependency groups
 ---------------------
 
-If the charm has dependency groups, such as one for charm libraries, that should be
-included when creating the virtual environment, the ``uv-groups`` key can be used to
-include those groups when creating the virtual environment.
+If the charm has dependency groups that should be included when creating the virtual
+environment, such as one for charm libraries, the ``uv-groups`` key can be set to
+include them.
 
 Including this dependency group in your charm is as easy as adding it to
 ``charmcraft.yaml``:

--- a/docs/howto/migrate-plugins/index.rst
+++ b/docs/howto/migrate-plugins/index.rst
@@ -8,3 +8,4 @@ Migrate to other plugins
 
    Migrate to poetry <charm-to-poetry>
    Migrate to python <charm-to-python>
+   Migrate to uv <charm-to-uv>

--- a/docs/reference/plugins/uv_plugin.rst
+++ b/docs/reference/plugins/uv_plugin.rst
@@ -3,6 +3,8 @@
 uv plugin
 =========
 
+    See also: :ref:`howto-migrate-to-uv`
+
 The uv plugin is designed for Python charms that use `uv`_ as the build system
 and are written with the `Operator framework`_.
 


### PR DESCRIPTION
Adds a how-to for migrating to the uv plugin. It's based on the poetry plugin page.

Drive-by: typo fix

https://canonical-charmcraft--2156.com.readthedocs.build/en/2156/howto/migrate-plugins/charm-to-uv/