### PR TITLE
docs: add cross-reference target for Flask tutorial

### DIFF
--- a/docs/tutorial/flask.rst
+++ b/docs/tutorial/flask.rst
@@ -1,3 +1,6 @@
+.. _write-your-first-kubernetes-charm-for-a-flask-app:
+
+
 =================================================
 Write your first Kubernetes charm for a Flask app
 =================================================


### PR DESCRIPTION
I'd like to put an intersphinx link from the [Ops](https://ops.readthedocs.io/en/latest/) docs to [Write your first Kubernetes charm for a Flask app](https://canonical-charmcraft.readthedocs-hosted.com/en/stable/tutorial/flask/). For me to do that, it's best if the tutorial has a cross-reference target.

This PR adds a cross-reference target similar to the other tutorials (e.g., [the target for the Django tutorial](https://github.com/canonical/charmcraft/blob/main/docs/tutorial/write-your-first-kubernetes-charm-for-a-django-app.rst?plain=1#L1)).