### PR TITLE
fix(snap): fix build on 32-bit platforms

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -152,7 +152,7 @@ parts:
       uv sync --no-dev --no-editable --no-binary
       . $CRAFT_PART_INSTALL/bin/activate
       uv pip install -r requirements-jammy.txt
-      rm $CRAFT_PART_INSTALL/lib64
+      rm -f $CRAFT_PART_INSTALL/lib64
 
       mkdir -p $CRAFT_PART_INSTALL/libexec/charmcraft
       sed -i 's|#!/bin/sh|#!/snap/charmcraft/current/bin/python3|' $CRAFT_PART_INSTALL/bin/craftctl


### PR DESCRIPTION
This should only affect armhf, so it's good if this build succeeds:

https://launchpad.net/~lengau/lengau-craft-remote-build/+snap/snapcraft-charmcraft-65ef4d96be7404bf850a3e56b29033fa/+build/2726730