### PR TITLE
feat(extension): Block on missing required config

### DIFF
--- a/charmcraft/extensions/app.py
+++ b/charmcraft/extensions/app.py
@@ -114,6 +114,7 @@ class _AppBase(Extension):
                     f"which conflict with the {self.framework}-framework extension, "
                     "please rename or remove it"
                 )
+        invalid_non_optionals = []
         for config in self._get_nested(self.yaml_data, "config.options"):
             for reserved_config_prefix in ("webserver-", f"{self.framework}-"):
                 if config.startswith(reserved_config_prefix):
@@ -122,6 +123,19 @@ class _AppBase(Extension):
                         f" reserved configuration prefix {reserved_config_prefix!r}, "
                         "please rename or remove it"
                     )
+            config_option_dict = self._get_nested(
+                self.yaml_data, f"config.options.{config}"
+            )
+            if config_option_dict.get("optional") is False and config_option_dict.get(
+                "default"
+            ):
+                invalid_non_optionals.append(config)
+
+        if invalid_non_optionals:
+            raise ExtensionError(
+                "Non-optional configuration options can not have default values.\n"
+                f"Please either remove the default value or set optional field to true or remove it for the {', '.join(invalid_non_optionals)} configuration option(s)."
+            )
 
     def _get_root_snippet(self) -> dict[str, Any]:
         """Return the root snippet to be merged into the user charmcraft.yaml.

--- a/docs/reference/extensions/django-framework-extension.rst
+++ b/docs/reference/extensions/django-framework-extension.rst
@@ -61,7 +61,7 @@ will set the ``DJANGO_ALLOWED_HOSTS`` environment variable, the ingress
 URL or the Kubernetes service URL if there is no ingress integration,
 will be set automatically.
 
-In addition to this, you can set the configuration options to be
+In addition to this, you can set the configuration option to be
 mandatory by setting the ``optional`` key to ``false``. This will
 block the charm and stop services until the configuration is supplied. For example,
 if your application needs an ``api-token`` to function correctly you can set
@@ -69,6 +69,7 @@ if your application needs an ``api-token`` to function correctly you can set
 services until the ``api-token`` configuration is supplied.
 
 .. code-block:: yaml
+    :caption: charmcraft.yaml
 
     config:
       options:
@@ -79,9 +80,8 @@ services until the ``api-token`` configuration is supplied.
 
 .. note::
 
-    A configuration with the ``optional: false`` option cannot have a
-     ``default`` value. If you set a ``default`` value to a configuration
-     with ``optional: false`` ``charmcraft`` will fail when packing the charm.
+    A configuration with ``optional: false`` can't also have a ``default`` key.
+    If it has both, the charm will fail to pack.
 
 
 ``peers``, ``provides``, and ``requires`` keys

--- a/docs/reference/extensions/django-framework-extension.rst
+++ b/docs/reference/extensions/django-framework-extension.rst
@@ -62,11 +62,11 @@ URL or the Kubernetes service URL if there is no ingress integration,
 will be set automatically.
 
 In addition to this, you can set the configuration options to be
-``non-optional`` by setting the ``optional`` key to ``False``. This will
-block the charm and stop services until the config is supplied. For example,
+mandatory by setting the ``optional`` key to ``false``. This will
+block the charm and stop services until the configuration is supplied. For example,
 if your application needs an ``api-token`` to function correctly you can set
-it ``non-optional``, as below. This will block the charm and stop the
-services until the ``api-token`` is supplied.
+``optional``, as shown below. This will block the charm and stop the
+services until the ``api-token`` configuration is supplied.
 
 .. code-block:: yaml
 
@@ -79,9 +79,9 @@ services until the ``api-token`` is supplied.
 
 .. note::
 
-    The ``non-optional`` options can not have ``default`` values. If you
-    set a ``default`` value to a ``non-optional`` configuration option
-    ``charmcraft`` will fail when packing the charm.
+    A configuration with the ``optional: false`` option cannot have a
+     ``default`` value. If you set a ``default`` value to a configuration
+     with ``optional: false`` ``charmcraft`` will fail when packing the charm.
 
 
 ``peers``, ``provides``, and ``requires`` keys

--- a/docs/reference/extensions/django-framework-extension.rst
+++ b/docs/reference/extensions/django-framework-extension.rst
@@ -61,6 +61,28 @@ will set the ``DJANGO_ALLOWED_HOSTS`` environment variable, the ingress
 URL or the Kubernetes service URL if there is no ingress integration,
 will be set automatically.
 
+In addition to this, you can set the configuration options to be
+``non-optional`` by setting the ``optional`` key to ``False``. This will
+block the charm and stop services until the config is supplied. For example,
+if your application needs an ``api-token`` to function correctly you can set
+it ``non-optional``, as below. This will block the charm and stop the
+services until the ``api-token`` is supplied.
+
+.. code-block:: yaml
+
+    config:
+      options:
+        api-token:
+          description: The token necessary for the service to run.
+          type: string
+          optional: false
+
+.. note::
+
+    The ``non-optional`` options can not have ``default`` values. If you
+    set a ``default`` value to a ``non-optional`` configuration option
+    ``charmcraft`` will fail when packing the charm.
+
 
 ``peers``, ``provides``, and ``requires`` keys
 ----------------------------------------------

--- a/docs/reference/extensions/django-framework-extension.rst
+++ b/docs/reference/extensions/django-framework-extension.rst
@@ -61,27 +61,7 @@ will set the ``DJANGO_ALLOWED_HOSTS`` environment variable, the ingress
 URL or the Kubernetes service URL if there is no ingress integration,
 will be set automatically.
 
-In addition to this, you can set the configuration option to be
-mandatory by setting the ``optional`` key to ``false``. This will
-block the charm and stop services until the configuration is supplied. For example,
-if your application needs an ``api-token`` to function correctly you can set
-``optional``, as shown below. This will block the charm and stop the
-services until the ``api-token`` configuration is supplied.
-
-.. code-block:: yaml
-    :caption: charmcraft.yaml
-
-    config:
-      options:
-        api-token:
-          description: The token necessary for the service to run.
-          type: string
-          optional: false
-
-.. note::
-
-    A configuration with ``optional: false`` can't also have a ``default`` key.
-    If it has both, the charm will fail to pack.
+.. include:: /reuse/reference/extensions/non_optional_config.rst 
 
 
 ``peers``, ``provides``, and ``requires`` keys

--- a/docs/reference/extensions/django-framework-extension.rst
+++ b/docs/reference/extensions/django-framework-extension.rst
@@ -61,7 +61,7 @@ will set the ``DJANGO_ALLOWED_HOSTS`` environment variable, the ingress
 URL or the Kubernetes service URL if there is no ingress integration,
 will be set automatically.
 
-.. include:: /reuse/reference/extensions/non_optional_config.rst 
+.. include:: /reuse/reference/extensions/non_optional_config.rst
 
 
 ``peers``, ``provides``, and ``requires`` keys

--- a/docs/reference/extensions/fastapi-framework-extension.rst
+++ b/docs/reference/extensions/fastapi-framework-extension.rst
@@ -42,11 +42,11 @@ by running ``juju config <application> token=<token>``.
           optional: false
 
 In addition to this, you can set the configuration options to be
-``non-optional`` by setting the ``optional`` key to ``False``. This will
-block the charm and stop services until the config is supplied. For example,
+mandatory by setting the ``optional`` key to ``false``. This will
+block the charm and stop services until the configuration is supplied. For example,
 if your application needs an ``api-token`` to function correctly you can set
-it ``non-optional``, as below. This will block the charm and stop the
-services until the ``api-token`` is supplied.
+``optional``, as shown below. This will block the charm and stop the
+services until the ``api-token`` configuration is supplied.
 
 .. code-block:: yaml
 
@@ -59,9 +59,9 @@ services until the ``api-token`` is supplied.
 
 .. note::
 
-    The ``non-optional`` options can not have ``default`` values. If you
-    set a ``default`` value to a ``non-optional`` configuration option
-    ``charmcraft`` will fail when packing the charm.
+    A configuration with the ``optional: false`` option cannot have a
+     ``default`` value. If you set a ``default`` value to a configuration
+     with ``optional: false`` ``charmcraft`` will fail when packing the charm.
 
 
 ``charmcraft.yaml`` > ``peers``, ``provides``, ``requires``

--- a/docs/reference/extensions/fastapi-framework-extension.rst
+++ b/docs/reference/extensions/fastapi-framework-extension.rst
@@ -41,7 +41,7 @@ by running ``juju config <application> token=<token>``.
           type: string
           optional: false
 
-.. include:: /reuse/reference/extensions/non_optional_config.rst 
+.. include:: /reuse/reference/extensions/non_optional_config.rst
 
 
 ``charmcraft.yaml`` > ``peers``, ``provides``, ``requires``

--- a/docs/reference/extensions/fastapi-framework-extension.rst
+++ b/docs/reference/extensions/fastapi-framework-extension.rst
@@ -39,7 +39,29 @@ by running ``juju config <application> token=<token>``.
         token:
           description: The token for the service.
           type: string
-          required: true
+          optional: false
+
+In addition to this, you can set the configuration options to be
+``non-optional`` by setting the ``optional`` key to ``False``. This will
+block the charm and stop services until the config is supplied. For example,
+if your application needs an ``api-token`` to function correctly you can set
+it ``non-optional``, as below. This will block the charm and stop the
+services until the ``api-token`` is supplied.
+
+.. code-block:: yaml
+
+    config:
+      options:
+        api-token:
+          description: The token necessary for the service to run.
+          type: string
+          optional: false
+
+.. note::
+
+    The ``non-optional`` options can not have ``default`` values. If you
+    set a ``default`` value to a ``non-optional`` configuration option
+    ``charmcraft`` will fail when packing the charm.
 
 
 ``charmcraft.yaml`` > ``peers``, ``provides``, ``requires``

--- a/docs/reference/extensions/fastapi-framework-extension.rst
+++ b/docs/reference/extensions/fastapi-framework-extension.rst
@@ -41,7 +41,7 @@ by running ``juju config <application> token=<token>``.
           type: string
           optional: false
 
-In addition to this, you can set the configuration options to be
+In addition to this, you can set the configuration option to be
 mandatory by setting the ``optional`` key to ``false``. This will
 block the charm and stop services until the configuration is supplied. For example,
 if your application needs an ``api-token`` to function correctly you can set
@@ -49,6 +49,7 @@ if your application needs an ``api-token`` to function correctly you can set
 services until the ``api-token`` configuration is supplied.
 
 .. code-block:: yaml
+    :caption: charmcraft.yaml
 
     config:
       options:
@@ -59,9 +60,8 @@ services until the ``api-token`` configuration is supplied.
 
 .. note::
 
-    A configuration with the ``optional: false`` option cannot have a
-     ``default`` value. If you set a ``default`` value to a configuration
-     with ``optional: false`` ``charmcraft`` will fail when packing the charm.
+    A configuration with ``optional: false`` can't also have a ``default`` key.
+    If it has both, the charm will fail to pack.
 
 
 ``charmcraft.yaml`` > ``peers``, ``provides``, ``requires``

--- a/docs/reference/extensions/fastapi-framework-extension.rst
+++ b/docs/reference/extensions/fastapi-framework-extension.rst
@@ -41,27 +41,7 @@ by running ``juju config <application> token=<token>``.
           type: string
           optional: false
 
-In addition to this, you can set the configuration option to be
-mandatory by setting the ``optional`` key to ``false``. This will
-block the charm and stop services until the configuration is supplied. For example,
-if your application needs an ``api-token`` to function correctly you can set
-``optional``, as shown below. This will block the charm and stop the
-services until the ``api-token`` configuration is supplied.
-
-.. code-block:: yaml
-    :caption: charmcraft.yaml
-
-    config:
-      options:
-        api-token:
-          description: The token necessary for the service to run.
-          type: string
-          optional: false
-
-.. note::
-
-    A configuration with ``optional: false`` can't also have a ``default`` key.
-    If it has both, the charm will fail to pack.
+.. include:: /reuse/reference/extensions/non_optional_config.rst 
 
 
 ``charmcraft.yaml`` > ``peers``, ``provides``, ``requires``

--- a/docs/reference/extensions/flask-framework-extension.rst
+++ b/docs/reference/extensions/flask-framework-extension.rst
@@ -37,7 +37,7 @@ charm can set it by running ``juju config <application> token=<token>``.
           description: The token for the service.
           type: string
 
-In addition to this, you can set the configuration options to be
+In addition to this, you can set the configuration option to be
 mandatory by setting the ``optional`` key to ``false``. This will
 block the charm and stop services until the configuration is supplied. For example,
 if your application needs an ``api-token`` to function correctly you can set
@@ -45,6 +45,7 @@ if your application needs an ``api-token`` to function correctly you can set
 services until the ``api-token`` configuration is supplied.
 
 .. code-block:: yaml
+    :caption: charmcraft.yaml
 
     config:
       options:
@@ -55,9 +56,8 @@ services until the ``api-token`` configuration is supplied.
 
 .. note::
 
-    A configuration with the ``optional: false`` option cannot have a
-     ``default`` value. If you set a ``default`` value to a configuration
-     with ``optional: false`` ``charmcraft`` will fail when packing the charm.
+    A configuration with ``optional: false`` can't also have a ``default`` key.
+    If it has both, the charm will fail to pack.
 
 
 ``charmcraft.yaml`` > ``peers``, ``provides``, ``requires``

--- a/docs/reference/extensions/flask-framework-extension.rst
+++ b/docs/reference/extensions/flask-framework-extension.rst
@@ -37,6 +37,28 @@ charm can set it by running ``juju config <application> token=<token>``.
           description: The token for the service.
           type: string
 
+In addition to this, you can set the configuration options to be
+``non-optional`` by setting the ``optional`` key to ``False``. This will
+block the charm and stop services until the config is supplied. For example,
+if your application needs an ``api-token`` to function correctly you can set
+it ``non-optional``, as below. This will block the charm and stop the
+services until the ``api-token`` is supplied.
+
+.. code-block:: yaml
+
+    config:
+      options:
+        api-token:
+          description: The token necessary for the service to run.
+          type: string
+          optional: false
+
+.. note::
+
+    The ``non-optional`` options can not have ``default`` values. If you
+    set a ``default`` value to a ``non-optional`` configuration option
+    ``charmcraft`` will fail when packing the charm.
+
 
 ``charmcraft.yaml`` > ``peers``, ``provides``, ``requires``
 -----------------------------------------------------------

--- a/docs/reference/extensions/flask-framework-extension.rst
+++ b/docs/reference/extensions/flask-framework-extension.rst
@@ -38,11 +38,11 @@ charm can set it by running ``juju config <application> token=<token>``.
           type: string
 
 In addition to this, you can set the configuration options to be
-``non-optional`` by setting the ``optional`` key to ``False``. This will
-block the charm and stop services until the config is supplied. For example,
+mandatory by setting the ``optional`` key to ``false``. This will
+block the charm and stop services until the configuration is supplied. For example,
 if your application needs an ``api-token`` to function correctly you can set
-it ``non-optional``, as below. This will block the charm and stop the
-services until the ``api-token`` is supplied.
+``optional``, as shown below. This will block the charm and stop the
+services until the ``api-token`` configuration is supplied.
 
 .. code-block:: yaml
 
@@ -55,9 +55,9 @@ services until the ``api-token`` is supplied.
 
 .. note::
 
-    The ``non-optional`` options can not have ``default`` values. If you
-    set a ``default`` value to a ``non-optional`` configuration option
-    ``charmcraft`` will fail when packing the charm.
+    A configuration with the ``optional: false`` option cannot have a
+     ``default`` value. If you set a ``default`` value to a configuration
+     with ``optional: false`` ``charmcraft`` will fail when packing the charm.
 
 
 ``charmcraft.yaml`` > ``peers``, ``provides``, ``requires``

--- a/docs/reference/extensions/flask-framework-extension.rst
+++ b/docs/reference/extensions/flask-framework-extension.rst
@@ -37,27 +37,7 @@ charm can set it by running ``juju config <application> token=<token>``.
           description: The token for the service.
           type: string
 
-In addition to this, you can set the configuration option to be
-mandatory by setting the ``optional`` key to ``false``. This will
-block the charm and stop services until the configuration is supplied. For example,
-if your application needs an ``api-token`` to function correctly you can set
-``optional``, as shown below. This will block the charm and stop the
-services until the ``api-token`` configuration is supplied.
-
-.. code-block:: yaml
-    :caption: charmcraft.yaml
-
-    config:
-      options:
-        api-token:
-          description: The token necessary for the service to run.
-          type: string
-          optional: false
-
-.. note::
-
-    A configuration with ``optional: false`` can't also have a ``default`` key.
-    If it has both, the charm will fail to pack.
+.. include:: /reuse/reference/extensions/non_optional_config.rst 
 
 
 ``charmcraft.yaml`` > ``peers``, ``provides``, ``requires``

--- a/docs/reference/extensions/flask-framework-extension.rst
+++ b/docs/reference/extensions/flask-framework-extension.rst
@@ -37,7 +37,7 @@ charm can set it by running ``juju config <application> token=<token>``.
           description: The token for the service.
           type: string
 
-.. include:: /reuse/reference/extensions/non_optional_config.rst 
+.. include:: /reuse/reference/extensions/non_optional_config.rst
 
 
 ``charmcraft.yaml`` > ``peers``, ``provides``, ``requires``

--- a/docs/reference/extensions/go-framework-extension.rst
+++ b/docs/reference/extensions/go-framework-extension.rst
@@ -48,7 +48,7 @@ charm can set it by running ``juju config <application> token=<token>``.
           description: The token for the service.
           type: string
 
-.. include:: /reuse/reference/extensions/non_optional_config.rst 
+.. include:: /reuse/reference/extensions/non_optional_config.rst
 
 
 ``charmcraft.yaml`` > ``peers``, ``provides``, ``requires``

--- a/docs/reference/extensions/go-framework-extension.rst
+++ b/docs/reference/extensions/go-framework-extension.rst
@@ -48,6 +48,28 @@ charm can set it by running ``juju config <application> token=<token>``.
           description: The token for the service.
           type: string
 
+In addition to this, you can set the configuration options to be
+``non-optional`` by setting the ``optional`` key to ``False``. This will
+block the charm and stop services until the config is supplied. For example,
+if your application needs an ``api-token`` to function correctly you can set
+it ``non-optional``, as below. This will block the charm and stop the
+services until the ``api-token`` is supplied.
+
+.. code-block:: yaml
+
+    config:
+      options:
+        api-token:
+          description: The token necessary for the service to run.
+          type: string
+          optional: false
+
+.. note::
+
+    The ``non-optional`` options can not have ``default`` values. If you
+    set a ``default`` value to a ``non-optional`` configuration option
+    ``charmcraft`` will fail when packing the charm.
+
 
 ``charmcraft.yaml`` > ``peers``, ``provides``, ``requires``
 -----------------------------------------------------------

--- a/docs/reference/extensions/go-framework-extension.rst
+++ b/docs/reference/extensions/go-framework-extension.rst
@@ -48,7 +48,7 @@ charm can set it by running ``juju config <application> token=<token>``.
           description: The token for the service.
           type: string
 
-In addition to this, you can set the configuration options to be
+In addition to this, you can set the configuration option to be
 mandatory by setting the ``optional`` key to ``false``. This will
 block the charm and stop services until the configuration is supplied. For example,
 if your application needs an ``api-token`` to function correctly you can set
@@ -56,6 +56,7 @@ if your application needs an ``api-token`` to function correctly you can set
 services until the ``api-token`` configuration is supplied.
 
 .. code-block:: yaml
+    :caption: charmcraft.yaml
 
     config:
       options:
@@ -66,9 +67,8 @@ services until the ``api-token`` configuration is supplied.
 
 .. note::
 
-    A configuration with the ``optional: false`` option cannot have a
-     ``default`` value. If you set a ``default`` value to a configuration
-     with ``optional: false`` ``charmcraft`` will fail when packing the charm.
+    A configuration with ``optional: false`` can't also have a ``default`` key.
+    If it has both, the charm will fail to pack.
 
 
 ``charmcraft.yaml`` > ``peers``, ``provides``, ``requires``

--- a/docs/reference/extensions/go-framework-extension.rst
+++ b/docs/reference/extensions/go-framework-extension.rst
@@ -49,11 +49,11 @@ charm can set it by running ``juju config <application> token=<token>``.
           type: string
 
 In addition to this, you can set the configuration options to be
-``non-optional`` by setting the ``optional`` key to ``False``. This will
-block the charm and stop services until the config is supplied. For example,
+mandatory by setting the ``optional`` key to ``false``. This will
+block the charm and stop services until the configuration is supplied. For example,
 if your application needs an ``api-token`` to function correctly you can set
-it ``non-optional``, as below. This will block the charm and stop the
-services until the ``api-token`` is supplied.
+``optional``, as shown below. This will block the charm and stop the
+services until the ``api-token`` configuration is supplied.
 
 .. code-block:: yaml
 
@@ -66,9 +66,9 @@ services until the ``api-token`` is supplied.
 
 .. note::
 
-    The ``non-optional`` options can not have ``default`` values. If you
-    set a ``default`` value to a ``non-optional`` configuration option
-    ``charmcraft`` will fail when packing the charm.
+    A configuration with the ``optional: false`` option cannot have a
+     ``default`` value. If you set a ``default`` value to a configuration
+     with ``optional: false`` ``charmcraft`` will fail when packing the charm.
 
 
 ``charmcraft.yaml`` > ``peers``, ``provides``, ``requires``

--- a/docs/reference/extensions/go-framework-extension.rst
+++ b/docs/reference/extensions/go-framework-extension.rst
@@ -48,27 +48,7 @@ charm can set it by running ``juju config <application> token=<token>``.
           description: The token for the service.
           type: string
 
-In addition to this, you can set the configuration option to be
-mandatory by setting the ``optional`` key to ``false``. This will
-block the charm and stop services until the configuration is supplied. For example,
-if your application needs an ``api-token`` to function correctly you can set
-``optional``, as shown below. This will block the charm and stop the
-services until the ``api-token`` configuration is supplied.
-
-.. code-block:: yaml
-    :caption: charmcraft.yaml
-
-    config:
-      options:
-        api-token:
-          description: The token necessary for the service to run.
-          type: string
-          optional: false
-
-.. note::
-
-    A configuration with ``optional: false`` can't also have a ``default`` key.
-    If it has both, the charm will fail to pack.
+.. include:: /reuse/reference/extensions/non_optional_config.rst 
 
 
 ``charmcraft.yaml`` > ``peers``, ``provides``, ``requires``

--- a/docs/reuse/reference/extensions/non_optional_config.rst
+++ b/docs/reuse/reference/extensions/non_optional_config.rst
@@ -1,0 +1,22 @@
+
+In addition to this, you can set the configuration option to be
+mandatory by setting the ``optional`` key to ``false``. This will
+block the charm and stop services until the configuration is supplied. For example,
+if your application needs an ``api-token`` to function correctly you can set
+``optional``, as shown below. This will block the charm and stop the
+services until the ``api-token`` configuration is supplied.
+
+.. code-block:: yaml
+    :caption: charmcraft.yaml
+
+    config:
+      options:
+        api-token:
+          description: The token necessary for the service to run.
+          type: string
+          optional: false
+
+.. note::
+
+    A configuration with ``optional: false`` can't also have a ``default`` key.
+    If it has both, the charm will fail to pack.

--- a/tests/extensions/test_app.py
+++ b/tests/extensions/test_app.py
@@ -24,6 +24,7 @@ from charmcraft.extensions.app import (
     GoFramework,
 )
 
+NON_OPTIONAL_OPTIONS = {"options":{"non-optional-string": {"description": "Example of a non-optional string configuration option.", "type": "string", "optional": False}}}
 
 def make_flask_input_yaml():
     return {
@@ -33,6 +34,7 @@ def make_flask_input_yaml():
         "description": "test description",
         "bases": [{"name": "ubuntu", "channel": "22.04"}],
         "extensions": ["flask-framework"],
+        "config": NON_OPTIONAL_OPTIONS,
     }
 
 
@@ -69,7 +71,7 @@ def flask_input_yaml_fixture():
                     {"lib": "tempo_coordinator_k8s.tracing", "version": "0"},
                 ],
                 "config": {
-                    "options": {**FlaskFramework.options},
+                    "options": {**FlaskFramework.options, **NON_OPTIONAL_OPTIONS["options"]},
                 },
                 "parts": {
                     "charm": {
@@ -114,6 +116,7 @@ def flask_input_yaml_fixture():
                     "s390x": None,
                 },
                 "extensions": ["django-framework"],
+        "config": NON_OPTIONAL_OPTIONS,
             },
             False,
             {
@@ -146,7 +149,7 @@ def flask_input_yaml_fixture():
                     {"lib": "tempo_coordinator_k8s.tracing", "version": "0"},
                 ],
                 "config": {
-                    "options": {**DjangoFramework.options},
+                    "options": {**DjangoFramework.options, **NON_OPTIONAL_OPTIONS["options"]},
                 },
                 "parts": {
                     "charm": {
@@ -186,6 +189,7 @@ def flask_input_yaml_fixture():
                     "amd64": None,
                 },
                 "extensions": ["go-framework"],
+        "config": NON_OPTIONAL_OPTIONS,
             },
             True,
             {
@@ -213,7 +217,7 @@ def flask_input_yaml_fixture():
                     {"lib": "tempo_coordinator_k8s.tracing", "version": "0"},
                 ],
                 "config": {
-                    "options": {**GoFramework.options},
+                    "options": {**GoFramework.options, **NON_OPTIONAL_OPTIONS["options"]},
                 },
                 "parts": {
                     "charm": {
@@ -253,6 +257,7 @@ def flask_input_yaml_fixture():
                     "amd64": None,
                 },
                 "extensions": ["fastapi-framework"],
+        "config": NON_OPTIONAL_OPTIONS,
             },
             True,
             {
@@ -280,7 +285,7 @@ def flask_input_yaml_fixture():
                     {"lib": "tempo_coordinator_k8s.tracing", "version": "0"},
                 ],
                 "config": {
-                    "options": {**FastAPIFramework.options},
+                    "options": {**FastAPIFramework.options, **NON_OPTIONAL_OPTIONS["options"]},
                 },
                 "parts": {
                     "charm": {
@@ -416,7 +421,7 @@ INCOMPATIBLE_FIELDS_TEST_PARAMETERS = [
                 }
             }
         },
-        id="non-optional-config-with-defautl",
+        id="non-optional-config-with-default",
     ),
 ]
 

--- a/tests/extensions/test_app.py
+++ b/tests/extensions/test_app.py
@@ -404,6 +404,20 @@ INCOMPATIBLE_FIELDS_TEST_PARAMETERS = [
         {"config": {"options": {"flask-foobar": {"type": "string"}}}},
         id="reserved-config-prefix-flask",
     ),
+    pytest.param(
+        {
+            "config": {
+                "options": {
+                    "non-optional": {
+                        "type": "string",
+                        "optional": False,
+                        "default": "default value",
+                    }
+                }
+            }
+        },
+        id="non-optional-config-with-defautl",
+    ),
 ]
 
 

--- a/tests/extensions/test_app.py
+++ b/tests/extensions/test_app.py
@@ -24,7 +24,16 @@ from charmcraft.extensions.app import (
     GoFramework,
 )
 
-NON_OPTIONAL_OPTIONS = {"options":{"non-optional-string": {"description": "Example of a non-optional string configuration option.", "type": "string", "optional": False}}}
+NON_OPTIONAL_OPTIONS = {
+    "options": {
+        "non-optional-string": {
+            "description": "Example of a non-optional string configuration option.",
+            "type": "string",
+            "optional": False,
+        }
+    }
+}
+
 
 def make_flask_input_yaml():
     return {
@@ -71,7 +80,10 @@ def flask_input_yaml_fixture():
                     {"lib": "tempo_coordinator_k8s.tracing", "version": "0"},
                 ],
                 "config": {
-                    "options": {**FlaskFramework.options, **NON_OPTIONAL_OPTIONS["options"]},
+                    "options": {
+                        **FlaskFramework.options,
+                        **NON_OPTIONAL_OPTIONS["options"],
+                    },
                 },
                 "parts": {
                     "charm": {
@@ -116,7 +128,7 @@ def flask_input_yaml_fixture():
                     "s390x": None,
                 },
                 "extensions": ["django-framework"],
-        "config": NON_OPTIONAL_OPTIONS,
+                "config": NON_OPTIONAL_OPTIONS,
             },
             False,
             {
@@ -149,7 +161,10 @@ def flask_input_yaml_fixture():
                     {"lib": "tempo_coordinator_k8s.tracing", "version": "0"},
                 ],
                 "config": {
-                    "options": {**DjangoFramework.options, **NON_OPTIONAL_OPTIONS["options"]},
+                    "options": {
+                        **DjangoFramework.options,
+                        **NON_OPTIONAL_OPTIONS["options"],
+                    },
                 },
                 "parts": {
                     "charm": {
@@ -189,7 +204,7 @@ def flask_input_yaml_fixture():
                     "amd64": None,
                 },
                 "extensions": ["go-framework"],
-        "config": NON_OPTIONAL_OPTIONS,
+                "config": NON_OPTIONAL_OPTIONS,
             },
             True,
             {
@@ -217,7 +232,10 @@ def flask_input_yaml_fixture():
                     {"lib": "tempo_coordinator_k8s.tracing", "version": "0"},
                 ],
                 "config": {
-                    "options": {**GoFramework.options, **NON_OPTIONAL_OPTIONS["options"]},
+                    "options": {
+                        **GoFramework.options,
+                        **NON_OPTIONAL_OPTIONS["options"],
+                    },
                 },
                 "parts": {
                     "charm": {
@@ -257,7 +275,7 @@ def flask_input_yaml_fixture():
                     "amd64": None,
                 },
                 "extensions": ["fastapi-framework"],
-        "config": NON_OPTIONAL_OPTIONS,
+                "config": NON_OPTIONAL_OPTIONS,
             },
             True,
             {
@@ -285,7 +303,10 @@ def flask_input_yaml_fixture():
                     {"lib": "tempo_coordinator_k8s.tracing", "version": "0"},
                 ],
                 "config": {
-                    "options": {**FastAPIFramework.options, **NON_OPTIONAL_OPTIONS["options"]},
+                    "options": {
+                        **FastAPIFramework.options,
+                        **NON_OPTIONAL_OPTIONS["options"],
+                    },
                 },
                 "parts": {
                     "charm": {


### PR DESCRIPTION
This PR is related to 12 Factor [Block on missing required config PR](https://github.com/canonical/paas-charm/pull/42)

## Rationale

Some applications require certain config options to run and would crash if these options are not provided. To prevent this, we need to add an optional field to the config options and block the charm if a config option marked as non-optional has not been provided with a message that explains which config options are missing.

To stay backward compatible the default value for the optional field will be true.

Since it doesn’t make sense for config options that are non-optional to have a default value, charmcraft will look for this condition at pack time and error out.


## Extension Changes

Adds a check for non-optional options with default values and throws `ExtensionError` when found.
Adds documentation about the non-optional options.


Reviewers:
@jdkandersson 
@javierdelapuente 
@erinecon 