### PR TITLE
docs: maintain Django tutorial

### DIFF
--- a/docs/tutorial/code/django/task.yaml
+++ b/docs/tutorial/code/django/task.yaml
@@ -70,7 +70,7 @@ execute: |
   cat $HOME/settings_local_run.py > $HOME/django-hello-world/django_hello_world/django_hello_world/settings.py
 
   # Run Django app locally
-  python3 manage.py runserver 0.0.0.0:8000 &
+  ./manage.py runserver 0.0.0.0:8000 &
 
   # Test the Django app
   retry -n 5 --wait 2 curl --fail localhost:8000

--- a/docs/tutorial/kubernetes-charm-django.rst
+++ b/docs/tutorial/kubernetes-charm-django.rst
@@ -138,7 +138,7 @@ Now, run the Django app to verify that it works:
 
 .. code-block:: bash
 
-    python3 manage.py runserver 0.0.0.0:8000
+    ./manage.py runserver 0.0.0.0:8000
 
 .. note::
 

--- a/docs/tutorial/kubernetes-charm-django.rst
+++ b/docs/tutorial/kubernetes-charm-django.rst
@@ -118,7 +118,7 @@ Run the Django app locally
 We will test the Django app by visiting the app in a web
 browser.
 
-Change into the ``/django_hello_world`` directory:
+Change into the ``~/django_hello_world`` directory:
 
 .. code-block:: bash
 
@@ -170,7 +170,7 @@ Pack the Django app into a rock
 First, we'll need a ``rockcraft.yaml`` file. Using the
 ``django-framework`` profile, Rockcraft will automate the creation of
 ``rockcraft.yaml`` and tailor the file for a Django app. Change
-back into the ``/django-hello-world`` directory and initialize the rock:
+back into the ``~/django-hello-world`` directory and initialize the rock:
 
 .. code-block:: bash
 
@@ -178,7 +178,7 @@ back into the ``/django-hello-world`` directory and initialize the rock:
     rockcraft init --profile django-framework
 
 The ``rockcraft.yaml`` file will automatically be created and set the
-name based on your working directory, ``/django-hello-world``.
+name based on your working directory, ``~/django-hello-world``.
 
 Check out the contents of ``rockcraft.yaml``:
 
@@ -229,7 +229,7 @@ upgrade -- and this database wouldn't be shared by all containers as the
 app is scaled. We'll use Juju later to easily deploy a database.
 
 We'll need to update the ``settings.py`` file to prepare for integrating
-the app with a database. From the ``/django-hello-world`` directory, open
+the app with a database. From the ``~/django-hello-world`` directory, open
 ``django_hello_world/django_hello_world/settings.py`` and update the
 imports to include ``json``, ``os`` and ``secrets``. The top of the
 ``settings.py`` file should look similar to the following snippet:
@@ -334,7 +334,7 @@ Copy the rock:
 Create the charm
 ----------------
 
-From the ``/django-hello-world`` directory, create a new directory for
+From the ``~/django-hello-world`` directory, create a new directory for
 the charm and change inside it:
 
 .. literalinclude:: code/django/task.yaml
@@ -543,7 +543,7 @@ In this iteration, we'll add a greeting app that returns a ``Hello, world!`` gre
 
 The generated Django app doesn't come with an app, which is why
 we had to initially enable debug mode for testing.  We will need to go back
-out to the ``/django-hello-world`` directory where the rock is and enter
+out to the ``~/django-hello-world`` directory where the rock is and enter
 into the ``/django_hello_world`` directory where the Django app
 is. Let's add a new Django app:
 
@@ -582,7 +582,7 @@ Update the rock
 ~~~~~~~~~~~~~~~
 
 Since we're changing the app we should update the version of the
-rock. Go back to the ``/django-hello-world`` directory where the rock is
+rock. Go back to the ``~/django-hello-world`` directory where the rock is
 and change the ``version`` in ``rockcraft.yaml`` to ``0.2``. The top of
 the ``rockcraft.yaml`` file should look similar to the following:
 
@@ -654,7 +654,7 @@ To demonstrate how to provide a configuration to the Django app,
 we will make the greeting configurable. We will expect this
 configuration option to be available in the Django app configuration under the
 keyword ``DJANGO_GREETING``. Go back out to the rock
-directory ``/django-hello-world`` using ``cd ..``. From there, open the
+directory ``~/django-hello-world`` using ``cd ..``. From there, open the
 ``django_hello_world/greeting/views.py`` file and replace the content
 with:
 
@@ -764,7 +764,7 @@ development process, including:
 - Adding an initial app and configuring the app
 
 If you'd like to reset your working environment, you can run the
-following in the rock directory ``/django-hello-world`` for the tutorial:
+following in the rock directory ``~/django-hello-world`` for the tutorial:
 
 .. literalinclude:: code/django/task.yaml
     :language: bash

--- a/docs/tutorial/kubernetes-charm-django.rst
+++ b/docs/tutorial/kubernetes-charm-django.rst
@@ -279,12 +279,12 @@ We will also use PostgreSQL as the database for our Django app. In
 
     DATABASES = {
        'default': {
-            'ENGINE': 'django.db.backends.postgresql',
-            'NAME': os.environ.get('POSTGRESQL_DB_NAME'),
-            'USER': os.environ.get('POSTGRESQL_DB_USERNAME'),
-            'PASSWORD': os.environ.get('POSTGRESQL_DB_PASSWORD'),
-            'HOST': os.environ.get('POSTGRESQL_DB_HOSTNAME'),
-            'PORT': os.environ.get('POSTGRESQL_DB_PORT'),
+               'ENGINE': 'django.db.backends.postgresql',
+               'NAME': os.environ.get('POSTGRESQL_DB_NAME'),
+               'USER': os.environ.get('POSTGRESQL_DB_USERNAME'),
+               'PASSWORD': os.environ.get('POSTGRESQL_DB_PASSWORD'),
+               'HOST': os.environ.get('POSTGRESQL_DB_HOSTNAME'),
+               'PORT': os.environ.get('POSTGRESQL_DB_PORT'),
         }
     }
 


### PR DESCRIPTION
Some specific fixes to the Django tutorial:
* Don't need to explicitly have `python3 manage.py`. Django developers are more used to `./manage.py` instead. I have updated the tutorial and `task.yaml` file. 
* Any reference to `/django-hello-world` in text has been updated to `~/django-hello-world`.
* Updated indentation in a code snippet that was rendering incorrectly.

Additional reviewers: @jdkandersson 