### PR TITLE
feat(templates): change the templates to use platforms notation

### DIFF
--- a/charmcraft/templates/init-kubernetes/charmcraft.yaml.j2
+++ b/charmcraft/templates/init-kubernetes/charmcraft.yaml.j2
@@ -1,23 +1,9 @@
 # This file configures Charmcraft.
-# See https://juju.is/docs/sdk/charmcraft-config for guidance.
-
-# (Required)
-name: {{ name }}
-
-
-# (Required)
+# See https://canonical-charmcraft.readthedocs-hosted.com/en/stable/reference/files/charmcraft-yaml-file/
 type: charm
-
-
-# (Recommended)
+name: {{ name }}
 title: Charm Template
-
-
-# (Required)
 summary: A very short one-line summary of the charm.
-
-
-# (Required)
 description: |
   A single sentence that says what the charm is, concisely and memorably.
 
@@ -27,22 +13,24 @@ description: |
 
   Finally, a paragraph that describes whom the charm is useful for.
 
+base: ubuntu@22.04
+platforms:
+  amd64:
+  arm64:
 
-# (Required for 'charm' type)
-bases:
-  - build-on:
-    - name: ubuntu
-      channel: "22.04"
-    run-on:
-    - name: ubuntu
-      channel: "22.04"
 
+parts:
+  charm:
+    plugin: charm
+    source: .
 
 # (Optional) Configuration options for the charm
 # This config section defines charm config options, and populates the Configure
 # tab on Charmhub.
-# More information on this section at https://juju.is/docs/sdk/charmcraft-yaml#heading--config
-# General configuration documentation: https://juju.is/docs/sdk/config
+# More information on this section at:
+# https://canonical-charmcraft.readthedocs-hosted.com/en/stable/reference/files/charmcraft-yaml-file/#config
+# General configuration documentation:
+# https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/configuration/#application-configuration
 config:
   options:
     # An example config option to customise the log level of the workload
@@ -55,23 +43,22 @@ config:
       type: string
 
 
-# The containers and resources metadata apply to Kubernetes charms only.
-# See https://juju.is/docs/sdk/metadata-reference for a checklist and guidance.
-
 # Your workload’s containers.
+# https://canonical-charmcraft.readthedocs-hosted.com/en/stable/reference/files/charmcraft-yaml-file/#containers
 containers:
   some-container:
     resource: some-container-image
 
 
 # This field populates the Resources tab on Charmhub.
+# https://canonical-charmcraft.readthedocs-hosted.com/en/stable/reference/files/charmcraft-yaml-file/#resources
 resources:
   # An OCI image resource for each container listed above.
   # You may remove this if your charm will run without a workload sidecar container.
   some-container-image:
     type: oci-image
     description: OCI image for the 'some-container' container
-    # The upstream-source field is ignored by Juju. It is included here as a reference
-    # so the integration testing suite knows which image to deploy during testing. This field
-    # is also used by the 'canonical/charming-actions' Github action for automated releasing.
+    # The upstream-source field is ignored by Charmcraft and Juju, but it can be
+    # useful to developers in identifying the source of the OCI image.  It is also
+    # used by the 'canonical/charming-actions' Github action for automated releases.
     upstream-source: some-repo/some-image:some-tag

--- a/charmcraft/templates/init-kubernetes/charmcraft.yaml.j2
+++ b/charmcraft/templates/init-kubernetes/charmcraft.yaml.j2
@@ -13,6 +13,8 @@ description: |
 
   Finally, a paragraph that describes whom the charm is useful for.
 
+# Documentation:
+# https://canonical-charmcraft.readthedocs-hosted.com/en/stable/howto/build-guides/select-platforms/
 base: ubuntu@22.04
 platforms:
   amd64:

--- a/charmcraft/templates/init-machine/charmcraft.yaml.j2
+++ b/charmcraft/templates/init-machine/charmcraft.yaml.j2
@@ -1,23 +1,9 @@
 # This file configures Charmcraft.
-# See https://juju.is/docs/sdk/charmcraft-config for guidance.
-
-# (Required)
-name: {{ name }}
-
-
-# (Required)
+# See https://canonical-charmcraft.readthedocs-hosted.com/en/stable/reference/files/charmcraft-yaml-file/
 type: charm
-
-
-# (Recommended)
+name: {{ name }}
 title: Charm Template
-
-
-# (Required)
 summary: A very short one-line summary of the charm.
-
-
-# (Required)
 description: |
   A single sentence that says what the charm is, concisely and memorably.
 
@@ -27,22 +13,24 @@ description: |
 
   Finally, a paragraph that describes whom the charm is useful for.
 
+base: ubuntu@22.04
+platforms:
+  amd64:
+  arm64:
 
-# (Required for 'charm' type)
-bases:
-  - build-on:
-    - name: ubuntu
-      channel: "22.04"
-    run-on:
-    - name: ubuntu
-      channel: "22.04"
 
+parts:
+  charm:
+    plugin: charm
+    source: .
 
 # (Optional) Configuration options for the charm
 # This config section defines charm config options, and populates the Configure
 # tab on Charmhub.
-# More information on this section at https://juju.is/docs/sdk/charmcraft-yaml#heading--config
-# General configuration documentation: https://juju.is/docs/sdk/config
+# More information on this section at:
+# https://canonical-charmcraft.readthedocs-hosted.com/en/stable/reference/files/charmcraft-yaml-file/#config
+# General configuration documentation:
+# https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/configuration/#application-configuration
 config:
   options:
     # An example config option to customise the log level of the workload

--- a/charmcraft/templates/init-machine/charmcraft.yaml.j2
+++ b/charmcraft/templates/init-machine/charmcraft.yaml.j2
@@ -13,6 +13,8 @@ description: |
 
   Finally, a paragraph that describes whom the charm is useful for.
 
+# Documentation:
+# https://canonical-charmcraft.readthedocs-hosted.com/en/stable/howto/build-guides/select-platforms/
 base: ubuntu@22.04
 platforms:
   amd64:

--- a/charmcraft/templates/init-simple/charmcraft.yaml.j2
+++ b/charmcraft/templates/init-simple/charmcraft.yaml.j2
@@ -1,26 +1,9 @@
 # This file configures Charmcraft.
-# See https://juju.is/docs/sdk/charmcraft-config for guidance.
-
-# (Required)
-# The charm package name, no spaces
-# See https://juju.is/docs/sdk/naming#heading--naming-charms for guidance.
-name: {{ name }}
-
-
-# (Required)
-# The charm type, either 'charm' or 'bundle'.
+# See https://canonical-charmcraft.readthedocs-hosted.com/en/stable/reference/files/charmcraft-yaml-file/
 type: charm
-
-
-# (Recommended)
+name: {{ name }}
 title: Charm Template
-
-
-# (Required)
 summary: A very short one-line summary of the charm.
-
-
-# (Required)
 description: |
   A single sentence that says what the charm is, concisely and memorably.
 
@@ -30,24 +13,24 @@ description: |
 
   Finally, a paragraph that describes whom the charm is useful for.
 
+base: ubuntu@22.04
+platforms:
+  amd64:
+  arm64:
 
-# (Required for 'charm' type)
-# A list of environments (OS version and architecture) where charms must be
-# built on and run on.
-bases:
-  - build-on:
-    - name: ubuntu
-      channel: "22.04"
-    run-on:
-    - name: ubuntu
-      channel: "22.04"
 
+parts:
+  charm:
+    plugin: charm
+    source: .
 
 # (Optional) Configuration options for the charm
 # This config section defines charm config options, and populates the Configure
 # tab on Charmhub.
-# More information on this section at https://juju.is/docs/sdk/charmcraft-yaml#heading--config
-# General configuration documentation: https://juju.is/docs/sdk/config
+# More information on this section at:
+# https://canonical-charmcraft.readthedocs-hosted.com/en/stable/reference/files/charmcraft-yaml-file/#config
+# General configuration documentation:
+# https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/configuration/#application-configuration
 config:
   options:
     # An example config option to customise the log level of the workload
@@ -60,26 +43,22 @@ config:
       type: string
 
 
-# The containers and resources metadata apply to Kubernetes charms only.
-# See https://juju.is/docs/sdk/metadata-reference for a checklist and guidance.
-# Remove them if not required.
-
-
 # Your workload’s containers.
+# https://canonical-charmcraft.readthedocs-hosted.com/en/stable/reference/files/charmcraft-yaml-file/#containers
 containers:
-  httpbin:
-    resource: httpbin-image
+  some-container:
+    resource: some-container-image
 
 
 # This field populates the Resources tab on Charmhub.
+# https://canonical-charmcraft.readthedocs-hosted.com/en/stable/reference/files/charmcraft-yaml-file/#resources
 resources:
   # An OCI image resource for each container listed above.
   # You may remove this if your charm will run without a workload sidecar container.
-  httpbin-image:
+  some-container-image:
     type: oci-image
-    description: OCI image for httpbin
-    # The upstream-source field is ignored by Juju. It is included here as a
-    # reference so the integration testing suite knows which image to deploy
-    # during testing. This field is also used by the 'canonical/charming-actions'
-    # Github action for automated releasing.
-    upstream-source: kennethreitz/httpbin
+    description: OCI image for the 'some-container' container
+    # The upstream-source field is ignored by Charmcraft and Juju, but it can be
+    # useful to developers in identifying the source of the OCI image.  It is also
+    # used by the 'canonical/charming-actions' Github action for automated releases.
+    upstream-source: some-repo/some-image:some-tag

--- a/charmcraft/templates/init-simple/charmcraft.yaml.j2
+++ b/charmcraft/templates/init-simple/charmcraft.yaml.j2
@@ -13,6 +13,8 @@ description: |
 
   Finally, a paragraph that describes whom the charm is useful for.
 
+# Documentation:
+# https://canonical-charmcraft.readthedocs-hosted.com/en/stable/howto/build-guides/select-platforms/
 base: ubuntu@22.04
 platforms:
   amd64:

--- a/tests/spread/smoketests/different-dependencies/task.yaml
+++ b/tests/spread/smoketests/different-dependencies/task.yaml
@@ -5,17 +5,14 @@ include:
 
 prepare: |
   tests.pkgs install unzip
+  snap install --devmode --channel=v4/stable yq
   charmcraft init --project-dir=charm
   cd charm
   echo "bump2version" > req.txt
-
-  cat <<- EOF >> charmcraft.yaml
-  parts:
-    charm:
-      charm-binary-python-packages: [pytest]
-      charm-python-packages: [fades]
-      charm-requirements: [req.txt]
-  EOF
+  yq '.parts.charm = {"charm-binary-python-packages": ["pytest"], "charm-python-packages": ["fades"], "charm-requirements": ["req.txt"]}' \
+    < charmcraft.yaml > charmcraft-2.yaml
+  rm charmcraft.yaml
+  mv charmcraft-2.yaml charmcraft.yaml
 
 restore: |
   pushd charm

--- a/tests/spread/smoketests/pinned-dependencies/task.yaml
+++ b/tests/spread/smoketests/pinned-dependencies/task.yaml
@@ -8,11 +8,11 @@ prepare: |
   charmcraft init --project-dir=charm
   cd charm
   echo "ops==2.0.0" > requirements.txt
-  cat <<- EOF >> charmcraft.yaml
-  parts:
-    charm:
-      charm-requirements: [requirements.txt]
-  EOF
+  # cat <<- EOF >> charmcraft.yaml
+  # parts:
+  #   charm:
+  #     charm-requirements: [requirements.txt]
+  # EOF
   mkdir -p lib/charms/charm/v0/
   cat <<- EOF > lib/charms/charm/v0/my_lib.py
   PYDEPS = ["ops"]

--- a/tests/spread/smoketests/pinned-dependencies/task.yaml
+++ b/tests/spread/smoketests/pinned-dependencies/task.yaml
@@ -8,11 +8,6 @@ prepare: |
   charmcraft init --project-dir=charm
   cd charm
   echo "ops==2.0.0" > requirements.txt
-  # cat <<- EOF >> charmcraft.yaml
-  # parts:
-  #   charm:
-  #     charm-requirements: [requirements.txt]
-  # EOF
   mkdir -p lib/charms/charm/v0/
   cat <<- EOF > lib/charms/charm/v0/my_lib.py
   PYDEPS = ["ops"]


### PR DESCRIPTION
This updates the templates to use the `platforms` notation rather than `bases`. It keeps them building on Jammy for the timebeing though.

CRAFT-4150

Fixes #2167 