### PR TITLE
chore: add a documentation issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,3 @@ contact_links:
   - name: Charmcraft Discourse
     url: https://discourse.charmhub.io/c/charmcraft/3
     about: Issues creating charms
-  - name: Documentation Issues
-    url: https://discourse.charmhub.io/c/doc/22
-    about: Documentation Improvements

--- a/.github/ISSUE_TEMPLATE/documentation.yaml
+++ b/.github/ISSUE_TEMPLATE/documentation.yaml
@@ -1,0 +1,27 @@
+name: Documentation
+description: Request a change to the documentation
+labels: "Documentation"
+body:
+  - type: markdown
+    attributes:
+      value: >
+        Thanks for taking the time to fill out this documentation request! Before
+        submitting your issue, please make sure there isn't already a prior issue
+        concerning this. If there is, please join that discussion instead.
+  - type: textarea
+    id: enhancement-proposal-what
+    attributes:
+      label: What needs to get done
+      description: >
+        Describe the documentation that is missing, incorrect or outdated
+    validations:
+      required: true
+  - type: textarea
+    id: enhancement-proposal-why
+    attributes:
+      label: User story
+      description: >
+        If new documentation is needed, describe what you were trying to do when you
+        found this documentation gap
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/documentation.yaml
+++ b/.github/ISSUE_TEMPLATE/documentation.yaml
@@ -1,27 +1,47 @@
 name: Documentation
-description: Request a change to the documentation
-labels: "Documentation"
+description: File a documentation request
+labels:
+  - "Documentation"
 body:
   - type: markdown
     attributes:
       value: >
-        Thanks for taking the time to fill out this documentation request! Before
-        submitting your issue, please make sure there isn't already a prior issue
-        concerning this. If there is, please join that discussion instead.
-  - type: textarea
-    id: enhancement-proposal-what
+        Thanks for taking the time to fill out this documentation
+        request! Before submitting your request, please make sure there
+        isn't already a prior issue concerning this. If there is,
+        please join that discussion instead.
+  - type: dropdown
+    id: type
     attributes:
-      label: What needs to get done
-      description: >
-        Describe the documentation that is missing, incorrect or outdated
+      label: Request type
+      description: Is this an issue that needs fixing or a request for enhancing the docs?
+      options:
+        - Fix
+        - Enhancement
     validations:
       required: true
   - type: textarea
-    id: enhancement-proposal-why
+    id: request-description
     attributes:
-      label: User story
+      label: What needs to get done
       description: >
-        If new documentation is needed, describe what you were trying to do when you
-        found this documentation gap
+        Describe the request and why it should be done
+    validations:
+      required: true
+  - type: input
+    id: page-name
+    attributes:
+      label: Documentation location
+      description: Location of the corresponding documentation page (e.g., file, section, URL), if applicable
+      placeholder: ex. https://canonical-charmcraft.readthedocs-hosted.com/en/stable/release-notes/charmcraft-3.4/
+    validations:
+      required: false
+  - type: textarea
+    id: additional-information
+    attributes:
+      label: Additional information
+      description: >
+        Include any additional context, screenshots, examples, or references that can
+        help understand the issue or improvement better
     validations:
       required: false


### PR DESCRIPTION
Replaces the documentation discourse link with an issue template to help describe documentation requests.

Fixes #2214 
CRAFT-4306