### PR TITLE
docs: 12-factor tutorial maintenance

### DIFF
--- a/docs/tutorial/kubernetes-charm-django.rst
+++ b/docs/tutorial/kubernetes-charm-django.rst
@@ -41,12 +41,12 @@ What you'll need
 What you'll do
 ~~~~~~~~~~~~~~
 
-- Create a Django app.
-- Use that to create a rock with Rockcraft.
-- Use that to create a charm with Charmcraft.
-- Use that to test, deploy, configure, etc., your Django app on a local
-  Kubernetes cloud with Juju.
-- Repeat the process, mimicking a real development process.
+#. Create a Django app.
+#. Use that to create a rock with Rockcraft.
+#. Use that to create a charm with Charmcraft.
+#. Use that to test, deploy, configure, etc., your Django app on a local
+   Kubernetes cloud with Juju.
+#. Repeat the process, mimicking a real development process.
 
 .. important::
 

--- a/docs/tutorial/kubernetes-charm-django.rst
+++ b/docs/tutorial/kubernetes-charm-django.rst
@@ -88,7 +88,7 @@ Then, open the file in a text editor using ``nano requirements.txt``,
 copy the following text into it and then save the file:
 
 .. literalinclude:: code/django/requirements.txt
-    :caption: requirements.txt
+    :caption: ~/django-hello-world/requirements.txt
 
 .. note::
 
@@ -125,7 +125,7 @@ Change into the ``~/django_hello_world`` directory:
     cd django_hello_world
 
 Open the settings file of the app located at
-``django_hello_world/settings.py``. Update the ``ALLOWED_HOSTS`` setting
+``~/django_hello_world/settings.py``. Update the ``ALLOWED_HOSTS`` setting
 to allow all traffic:
 
 .. code-block:: python
@@ -189,7 +189,7 @@ Check out the contents of ``rockcraft.yaml``:
 The top of the file should look similar to the following snippet:
 
 .. code-block:: yaml
-    :caption: rockcraft.yaml
+    :caption: ~/django-hello-world/rockcraft.yaml
 
     name: django-hello-world
     # see https://documentation.ubuntu.com/rockcraft/en/1.6.0/explanation/bases/
@@ -544,7 +544,7 @@ In this iteration, we'll add a greeting app that returns a ``Hello, world!`` gre
 The generated Django app doesn't come with an app, which is why
 we had to initially enable debug mode for testing.  We will need to go back
 out to the ``~/django-hello-world`` directory where the rock is and enter
-into the ``/django_hello_world`` directory where the Django app
+into the ``./django_hello_world`` directory where the Django app
 is. Let's add a new Django app:
 
 .. literalinclude:: code/django/task.yaml
@@ -587,7 +587,7 @@ and change the ``version`` in ``rockcraft.yaml`` to ``0.2``. The top of
 the ``rockcraft.yaml`` file should look similar to the following:
 
 .. code-block:: yaml
-    :caption: rockcraft.yaml
+    :caption: ~/django-hello-world/rockcraft.yaml
     :emphasize-lines: 5
 
     name: django-hello-world
@@ -623,7 +623,7 @@ Redeploy the charm
 
 We'll redeploy the new version with ``juju refresh``.
 
-In the ``/charm`` directory, run:
+In the ``./charm`` directory, run:
 
 .. literalinclude:: code/django/task.yaml
     :language: bash
@@ -655,7 +655,7 @@ we will make the greeting configurable. We will expect this
 configuration option to be available in the Django app configuration under the
 keyword ``DJANGO_GREETING``. Go back out to the rock
 directory ``~/django-hello-world`` using ``cd ..``. From there, open the
-``django_hello_world/greeting/views.py`` file and replace the content
+``./django_hello_world/greeting/views.py`` file and replace the content
 with:
 
 .. literalinclude:: code/django/views_greeting_configuration.py
@@ -669,7 +669,7 @@ Increment the ``version`` in ``rockcraft.yaml`` to ``0.3`` such that the
 top of the ``rockcraft.yaml`` file looks similar to the following:
 
 .. code-block:: yaml
-    :caption: rockcraft.yaml
+    :caption: ~/django-hello-world/rockcraft.yaml
     :emphasize-lines: 5
 
     name: django-hello-world

--- a/docs/tutorial/kubernetes-charm-fastapi.rst
+++ b/docs/tutorial/kubernetes-charm-fastapi.rst
@@ -140,7 +140,7 @@ Pack the FastAPI app into a rock
 First, we'll need a ``rockcraft.yaml`` file. Using the
 ``fastapi-framework`` profile, Rockcraft will automate the creation of
 ``rockcraft.yaml`` and tailor the file for a FastAPI app.
-From the ``/fastapi-hello-world`` directory, initialize the rock:
+From the ``~/fastapi-hello-world`` directory, initialize the rock:
 
 .. literalinclude:: code/fastapi/task.yaml
     :language: bash
@@ -655,7 +655,7 @@ development process, including:
 - Integrating the app with a database
 
 If you'd like to reset your working environment, you can run the following
-in the rock directory ``/fastapi-hello-world`` for the tutorial:
+in the rock directory ``~/fastapi-hello-world`` for the tutorial:
 
 .. literalinclude:: code/fastapi/task.yaml
     :language: bash

--- a/docs/tutorial/kubernetes-charm-fastapi.rst
+++ b/docs/tutorial/kubernetes-charm-fastapi.rst
@@ -38,12 +38,12 @@ What you'll need
 What you'll do
 --------------
 
-- Create a FastAPI app.
-- Use that to create a rock with Rockcraft.
-- Use that to create a charm with Charmcraft.
-- Use that to test, deploy, configure, etc., your FastAPI app on a local
-  Kubernetes cloud with Juju.
-- Repeat the process, mimicking a real development process.
+#. Create a FastAPI app.
+#. Use that to create a rock with Rockcraft.
+#. Use that to create a charm with Charmcraft.
+#. Use that to test, deploy, configure, etc., your FastAPI app on a local
+   Kubernetes cloud with Juju.
+#. Repeat the process, mimicking a real development process.
 
 .. important::
 

--- a/docs/tutorial/kubernetes-charm-fastapi.rst
+++ b/docs/tutorial/kubernetes-charm-fastapi.rst
@@ -85,7 +85,7 @@ Then, open the file in a text editor using ``nano requirements.txt``,
 copy the following text into it and then save the file:
 
 .. literalinclude:: code/fastapi/requirements.txt
-    :caption: requirements.txt
+    :caption: ~/fastapi-hello-world/requirements.txt
 
 .. note::
 
@@ -104,6 +104,7 @@ In the same directory, create a file called ``app.py``.
 Then copy and save the following code into the file:
 
 .. literalinclude:: code/fastapi/app.py
+    :caption: ~/fastapi-hello-world/app.py
     :language: python
 
 
@@ -159,7 +160,7 @@ Check out the contents of ``rockcraft.yaml``:
 The top of the file should look similar to the following snippet:
 
 .. code-block:: yaml
-    :caption: rockcraft.yaml
+    :caption: ~/fastapi-hello-world/rockcraft.yaml
 
     name: fastapi-hello-world
     # see https://documentation.ubuntu.com/rockcraft/en/latest/explanation/bases/
@@ -236,7 +237,7 @@ Copy the rock:
 Create the charm
 ----------------
 
-From the ``/fastapi-hello-world`` direcotyr, let's create a new directory
+From the ``~/fastapi-hello-world`` directory, let's create a new directory
 for the charm and change inside it:
 
 .. literalinclude:: code/fastapi/task.yaml
@@ -270,7 +271,7 @@ Check out the contents of ``charmcraft.yaml``:
 The top of the file should look similar to the following snippet:
 
 .. code-block:: yaml
-    :caption: charmcraft.yaml
+    :caption: ~/fastapi-hello-world/charm/charmcraft.yaml
 
     # This file configures Charmcraft.
     # See https://juju.is/docs/sdk/charmcraft-config for guidance.
@@ -299,7 +300,7 @@ includes the architecture of your host. If your host uses the ARM architecture,
 open ``charmcraft.yaml`` in a text editor and include ``arm64``
 in ``platforms``.
 
-Let's pack the charm
+Let's pack the charm:
 
 .. literalinclude:: code/fastapi/task.yaml
     :language: bash
@@ -430,17 +431,18 @@ Configure the FastAPI app
 To demonstrate how to provide a configuration to the FastAPI app,
 we will make the greeting configurable. We will expect this
 configuration option to be available in the FastAPI app configuration under the
-keyword ``APP_GREETING``. Change back to the ``/fastapi-hello-world`` directory
+keyword ``APP_GREETING``. Change back to the ``~/fastapi-hello-world`` directory
 using ``cd ..`` and copy the following code into ``app.py``:
 
 .. literalinclude:: code/fastapi/greeting_app.py
+    :caption: ~/fastapi-hello-world/app.py
     :language: python
 
 Increment the ``version`` in ``rockcraft.yaml`` to ``0.2`` such that the
 top of the ``rockcraft.yaml`` file looks similar to the following:
 
 .. code-block:: yaml
-    :caption: rockcraft.yaml
+    :caption: ~/fastapi-hello-world/rockcraft.yaml
     :emphasize-lines: 5
 
     name: fastapi-hello-world
@@ -535,11 +537,12 @@ The charm created by the ``fastapi-framework`` extension will execute the
 database is initialized and ready to be used by the app. We will
 create a ``migrate.py`` file containing this logic.
 
-Go back out to the ``/fastapi-hello-world`` directory using ``cd ..``,
+Go back out to the ``~/fastapi-hello-world`` directory using ``cd ..``,
 create the ``migrate.py`` file, open the file using a text editor
 and paste the following code into it:
 
 .. literalinclude:: code/fastapi/visitors_migrate.py
+    :caption: ~/fastapi-hello-world/migrate.py
     :language: python
 
 .. note::
@@ -552,7 +555,7 @@ Increment the ``version`` in ``rockcraft.yaml`` to ``0.3`` such that the
 top of the ``rockcraft.yaml`` file looks similar to the following:
 
 .. code-block:: yaml
-    :caption: rockcraft.yaml
+    :caption: ~/fastapi-hello-world/rockcraft.yaml
     :emphasize-lines: 5
 
     name: fastapi-hello-world
@@ -579,7 +582,7 @@ and to include a new endpoint to retrieve the number of visitors to the
 app. Open ``app.py`` in a text editor and replace its contents with the
 following code:
 
-.. collapse:: visitors_app.py
+.. collapse:: app.py
 
   .. literalinclude:: code/fastapi/visitors_app.py
       :language: python

--- a/docs/tutorial/kubernetes-charm-flask.rst
+++ b/docs/tutorial/kubernetes-charm-flask.rst
@@ -84,7 +84,7 @@ Then, open the file in a text editor using ``nano requirements.txt``,
 copy the following text into it and then save the file:
 
 .. literalinclude:: code/flask/requirements.txt
-    :caption: requirements.txt
+    :caption: ~/flask-hello-world/requirements.txt
 
 .. note::
 
@@ -103,6 +103,7 @@ In the same directory, create a file called ``app.py``.
 Then copy and save the following code into the file:
 
 .. literalinclude:: code/flask/app.py
+    :caption: ~/flask-hello-world/app.py
     :language: python
 
 
@@ -138,7 +139,7 @@ Pack the Flask app into a rock
 First, we'll need a ``rockcraft.yaml`` file. Using the
 ``flask-framework`` profile, Rockcraft will automate the creation of
 ``rockcraft.yaml`` and tailor the file for a Flask app.
-From the ``/flask-hello-world`` directory, initialize the rock:
+From the ``~/flask-hello-world`` directory, initialize the rock:
 
 .. literalinclude:: code/flask/task.yaml
     :language: bash
@@ -158,7 +159,7 @@ Check out the contents of ``rockcraft.yaml``:
 The top of the file should look similar to the following snippet:
 
 .. code-block:: yaml
-    :caption: rockcraft.yaml
+    :caption: ~/flask-hello-world/rockcraft.yaml
 
     name: flask-hello-world
     # see https://documentation.ubuntu.com/rockcraft/en/1.6.0/explanation/bases/
@@ -231,7 +232,7 @@ Copy the rock:
 Create the charm
 ----------------
 
-From the ``/flask-hello-world`` directory, let's create a new directory
+From the ``~/flask-hello-world`` directory, let's create a new directory
 for the charm and change inside it:
 
 .. literalinclude:: code/flask/task.yaml
@@ -378,17 +379,18 @@ Configure the Flask app
 To demonstrate how to provide a configuration to the Flask app,
 we will make the greeting configurable. We will expect this
 configuration option to be available in the Flask app configuration under the
-keyword ``GREETING``. Change back to the ``/flask-hello-world`` directory using
+keyword ``GREETING``. Change back to the ``~/flask-hello-world`` directory using
 ``cd ..`` and copy the following code into ``app.py``:
 
 .. literalinclude:: code/flask/greeting_app.py
+    :caption: ~/flask-hello-world/app.py
     :language: python
 
 Increment the ``version`` in ``rockcraft.yaml`` to ``0.2`` such that the
 top of the ``rockcraft.yaml`` file looks similar to the following:
 
 .. code-block:: yaml
-    :caption: rockcraft.yaml
+    :caption: ~/flask-hello-world/rockcraft.yaml
     :emphasize-lines: 5
 
     name: flask-hello-world
@@ -483,11 +485,12 @@ The charm created by the ``flask-framework`` extension will execute the
 database is initialized and ready to be used by the app. We will
 create a ``migrate.py`` file containing this logic.
 
-Go back out to the ``/flask-hello-world`` directory using ``cd ..``,
+Go back out to the ``~/flask-hello-world`` directory using ``cd ..``,
 create the ``migrate.py`` file, open the file using a text editor
 and paste the following code into it:
 
 .. literalinclude:: code/flask/visitors_migrate.py
+    :caption: ~/flask-hello-world/migrate.py
     :language: python
 
 .. note::
@@ -500,7 +503,7 @@ Increment the ``version`` in ``rockcraft.yaml`` to ``0.3`` such that the
 top of the ``rockcraft.yaml`` file looks similar to the following:
 
 .. code-block:: yaml
-    :caption: rockcraft.yaml
+    :caption: ~/flask-hello-world/rockcraft.yaml
     :emphasize-lines: 5
 
     name: flask-hello-world
@@ -527,7 +530,7 @@ and to include a new endpoint to retrieve the number of visitors to the
 app. Open ``app.py`` in a text editor and replace its contents with the
 following code:
 
-.. collapse:: visitors_app.py
+.. collapse:: app.py
 
   .. literalinclude:: code/flask/visitors_app.py
       :language: python
@@ -599,7 +602,7 @@ development process, including:
 - Integrating the app with a database
 
 If you'd like to reset your working environment, you can run the following
-in the rock directory ``/flask-hello-world`` for the tutorial:
+in the rock directory ``~/flask-hello-world`` for the tutorial:
 
 .. literalinclude:: code/flask/task.yaml
     :language: bash

--- a/docs/tutorial/kubernetes-charm-flask.rst
+++ b/docs/tutorial/kubernetes-charm-flask.rst
@@ -37,12 +37,12 @@ What you'll need
 What you'll do
 --------------
 
-- Create a Flask app.
-- Use that to create a rock with Rockcraft.
-- Use that to create a charm with Charmcraft.
-- Use that to test, deploy, configure, etc., your Flask app on a local
-  Kubernetes cloud with Juju.
-- Repeat the process, mimicking a real development process.
+#. Create a Flask app.
+#. Use that to create a rock with Rockcraft.
+#. Use that to create a charm with Charmcraft.
+#. Use that to test, deploy, configure, etc., your Flask app on a local
+   Kubernetes cloud with Juju.
+#. Repeat the process, mimicking a real development process.
 
 .. important::
 

--- a/docs/tutorial/kubernetes-charm-go.rst
+++ b/docs/tutorial/kubernetes-charm-go.rst
@@ -37,12 +37,12 @@ What you'll need
 What you'll do
 --------------
 
-- Create a Go app.
-- Use that to create a rock with Rockcraft.
-- Use that to create a charm with Charmcraft.
-- Use that to test, deploy, configure, etc., your Go app on a local
-  Kubernetes cloud with Juju.
-- Repeat the process, mimicking a real development process.
+#. Create a Go app.
+#. Use that to create a rock with Rockcraft.
+#. Use that to create a charm with Charmcraft.
+#. Use that to test, deploy, configure, etc., your Go app on a local
+   Kubernetes cloud with Juju.
+#. Repeat the process, mimicking a real development process.
 
 .. important::
 

--- a/docs/tutorial/kubernetes-charm-go.rst
+++ b/docs/tutorial/kubernetes-charm-go.rst
@@ -86,7 +86,7 @@ Then, open the file in a text editor using ``nano main.go``,
 copy the following text into it and then save the file:
 
 .. literalinclude:: code/go/main.go
-    :caption: main.go
+    :caption: ~/go-hello-world/main.go
     :language: go
 
 
@@ -130,7 +130,7 @@ Pack the Go app into a rock
 First, we'll need a ``rockcraft.yaml`` file. Using the
 ``go-framework`` profile, Rockcraft will automate the creation of
 ``rockcraft.yaml`` and tailor the file for a Go app.
-From the ``/go-hello-world`` directory, initialize the rock:
+From the ``~/go-hello-world`` directory, initialize the rock:
 
 .. literalinclude:: code/go/task.yaml
     :language: bash
@@ -150,7 +150,7 @@ Check out the contents of ``rockcraft.yaml``:
 The top of the file should look similar to the following snippet:
 
 .. code-block:: yaml
-    :caption: rockcraft.yaml
+    :caption: ~/go-hello-world/rockcraft.yaml
 
     name: go-hello-world
     # see https://documentation.ubuntu.com/rockcraft/en/latest/explanation/bases/
@@ -229,7 +229,7 @@ Copy the rock:
 Create the charm
 ----------------
 
-From the ``/go-hello-world`` directory, let's create a new directory
+From the ``~/go-hello-world`` directory, let's create a new directory
 for the charm and change inside it:
 
 .. literalinclude:: code/go/task.yaml
@@ -263,7 +263,7 @@ Check out the contents of ``charmcraft.yaml``:
 The top of the file should look similar to the following snippet:
 
 .. code-block:: yaml
-    :caption: charmcraft.yaml
+    :caption: ~/go-hello-world/charm/charmcraft.yaml
 
     # This file configures Charmcraft.
     # See https://juju.is/docs/sdk/charmcraft-config for guidance.
@@ -425,17 +425,18 @@ Configure the Go app
 To demonstrate how to provide a configuration to the Go app,
 we will make the greeting configurable. We will expect this
 configuration option to be available in the Go app configuration under the
-keyword ``GREETING``. Change back to the ``/go-hello-world`` directory using
+keyword ``GREETING``. Change back to the ``~/go-hello-world`` directory using
 ``cd ..`` and replace the code into ``main.go`` with the following:
 
 .. literalinclude:: code/go/greeting_main.txt
+    :caption: ~/go-hello-world/main.go
     :language: go
 
 Increment the ``version`` in ``rockcraft.yaml`` to ``0.2`` such that the
 top of the ``rockcraft.yaml`` file looks similar to the following:
 
 .. code-block:: yaml
-    :caption: rockcraft.yaml
+    :caption: ~/go-hello-world/rockcraft.yaml
     :emphasize-lines: 6
 
     name: go-hello-world
@@ -531,11 +532,12 @@ The charm created by the ``go-framework`` extension will execute the
 database is initialized and ready to be used by the app. We will
 create a ``migrate.sh`` file containing this logic.
 
-Go back out to the ``/go-hello-world`` directory using ``cd ..``.
+Go back out to the ``~/go-hello-world`` directory using ``cd ..``.
 Create the ``migrate.sh`` file using a text editor and paste the
 following code into it:
 
 .. literalinclude:: code/go/visitors_migrate.sh
+    :caption: ~/go-hello-world/migrate.sh
     :language: bash
 
 .. note::
@@ -566,7 +568,7 @@ Increment the ``version`` in ``rockcraft.yaml`` to ``0.3`` such that the
 top of the ``rockcraft.yaml`` file looks similar to the following:
 
 .. code-block:: yaml
-    :caption: rockcraft.yaml
+    :caption: ~/go-hello-world/rockcraft.yaml
     :emphasize-lines: 6
 
     name: go-hello-world
@@ -677,7 +679,7 @@ development process, including:
 - Integrating the app with a database
 
 If you'd like to reset your working environment, you can run the following
-in the rock directory ``/go-hello-world`` for the tutorial:
+in the rock directory ``~/go-hello-world`` for the tutorial:
 
 .. literalinclude:: code/go/task.yaml
     :language: bash


### PR DESCRIPTION
### Overview
Mostly directory-related maintenance work spanning across all four 12-factor tutorials.

### Summary of changes
* The "What you'll do" sections are now numbered lists.
* Any mention of the root directory (e.g., `/django-hello-world`) now contains a tilde in front (e.g., `~/django-hello-world`).
* Captions on full code examples now contain captions with explicit reference to the full path (e.g., `app.py` is now `~/flask-hello-world/app.py`). This change did not affect snippets of YAML files, which contain no caption whatsoever.
* Some mentions of `visitors_app.py` were renamed to `app.py` as the `visitors_app.py` naming was due to the multiple Python files needed for the spread tests.
