### PR TITLE
feat: mark the "promote-bundle" command as deprecated

### DIFF
--- a/charmcraft/application/commands/store.py
+++ b/charmcraft/application/commands/store.py
@@ -1037,6 +1037,11 @@ class PromoteBundleCommand(CharmcraftCommand):
 
     def run(self, parsed_args: "Namespace") -> None:
         """Run the command."""
+        emit.progress(
+            "Bundle commands are deprecated and will be removed in Charmcraft 4.",
+            permanent=True,
+        )
+
         if not isinstance(self._services.project, project.Bundle):
             raise CraftError("promote-bundle must be run on a bundle.")
 


### PR DESCRIPTION
This command is deprecated and will be removed in Charmcraft 4.0. Bundle commands will remain available in Charmcraft 3.

CRAFT-4005