### PR TITLE
feat: mark bundles as deprecated

### DIFF
--- a/charmcraft/models/project.py
+++ b/charmcraft/models/project.py
@@ -1132,6 +1132,10 @@ class Bundle(CharmcraftProject):
     @classmethod
     def preprocess_bundle(cls, values: dict[str, Any]) -> dict[str, Any]:
         """Preprocess any values that charmcraft infers, before attribute validation."""
+        emit.progress(
+            "Packing bundles is deprecated and will be removed in Charmcraft 4.",
+            permanent=True,
+        )
         if "name" not in values:
             values["name"] = values.get("bundle", {}).get("name")
 


### PR DESCRIPTION
Bundles are deprecated and will be removed in Charmcraft 4. Charmcraft 3 will remain available for packing bundles.

CRAFT-4006

Lint issues are fixed in https://github.com/canonical/charmcraft/pull/2229