### PR TITLE
docs: Tutorial updates

### DIFF
--- a/docs/tutorial/kubernetes-charm-django.rst
+++ b/docs/tutorial/kubernetes-charm-django.rst
@@ -219,8 +219,8 @@ the architecture of your system:
 
     dpkg --print-architecture
 
-If your host uses ARM64 architecture, open ``rockcraft.yaml`` in a
-text editor and include ``arm64`` under ``platforms``.
+If your host uses ARM architecture, open ``rockcraft.yaml`` in a
+text editor, comment out ``amd64``, and include ``arm64`` under ``platforms``.
 
 Django apps require a database. Django will use a sqlite
 database by default. This won't work on Kubernetes because the database

--- a/docs/tutorial/kubernetes-charm-django.rst
+++ b/docs/tutorial/kubernetes-charm-django.rst
@@ -765,16 +765,7 @@ development process, including:
 - Exposing the app using an ingress
 - Adding an initial app and configuring the app
 
-If you'd like to reset your working environment, you can run the
-following in the rock directory ``~/django-hello-world`` for the tutorial:
-
-.. literalinclude:: code/django/task.yaml
-    :language: bash
-    :start-after: [docs:clean-environment]
-    :end-before: [docs:clean-environment-end]
-    :dedent: 2
-
-You can also clean up your Multipass instance. Start by exiting it:
+If you'd like to quickly tear things down, start by exiting the Multipass VM:
 
 .. code-block:: bash
 
@@ -787,6 +778,17 @@ And then you can proceed with its deletion:
     multipass delete charm-dev
     multipass purge
 
+If you'd like to manually reset your working environment, you can run the
+following in the rock directory ``~/django-hello-world`` for the tutorial:
+
+.. literalinclude:: code/django/task.yaml
+    :language: bash
+    :start-after: [docs:clean-environment]
+    :end-before: [docs:clean-environment-end]
+    :dedent: 2
+
+You can also clean up your Multipass instance by exiting and deleting it
+using the same commands as above.
 
 Next steps
 ----------

--- a/docs/tutorial/kubernetes-charm-django.rst
+++ b/docs/tutorial/kubernetes-charm-django.rst
@@ -451,7 +451,9 @@ monitor its progress with:
 The ``--relations`` flag will list the currently enabled integrations.
 It can take a couple of minutes for the apps to finish the deployment.
 During this time, the Django app may enter a ``blocked`` state as it
-waits to become integrated with the PostgreSQL database.
+waits to become integrated with the PostgreSQL database. Due to the
+``optional: false`` key in the endpoint definition, the Django app will not
+start until the database is ready.
 
 Once the status of the App has gone to ``active``, you can stop watching
 using :kbd:`Ctrl` + :kbd:`C`.

--- a/docs/tutorial/kubernetes-charm-fastapi.rst
+++ b/docs/tutorial/kubernetes-charm-fastapi.rst
@@ -191,7 +191,7 @@ the architecture of your system:
     dpkg --print-architecture
 
 If your host uses the ARM architecture, open ``rockcraft.yaml`` in a
-text editor and include ``arm64`` in ``platforms``.
+text editor, comment out ``amd64``, and include ``arm64`` in ``platforms``.
 
 Now let's pack the rock:
 
@@ -297,8 +297,8 @@ The top of the file should look similar to the following snippet:
 
 Verify that the ``name`` is ``fastapi-hello-world``. Ensure that ``platforms``
 includes the architecture of your host. If your host uses the ARM architecture,
-open ``charmcraft.yaml`` in a text editor and include ``arm64``
-in ``platforms``.
+open ``charmcraft.yaml`` in a text editor, comment out ``amd64``, and include
+``arm64`` in ``platforms``.
 
 Let's pack the charm:
 

--- a/docs/tutorial/kubernetes-charm-fastapi.rst
+++ b/docs/tutorial/kubernetes-charm-fastapi.rst
@@ -660,8 +660,21 @@ development process, including:
 - Configuring the app
 - Integrating the app with a database
 
-If you'd like to reset your working environment, you can run the following
-in the rock directory ``~/fastapi-hello-world`` for the tutorial:
+If you'd like to quickly tear things down, start by exiting the Multipass VM:
+
+.. code-block:: bash
+
+    exit
+
+And then you can proceed with its deletion:
+
+.. code-block:: bash
+
+    multipass delete charm-dev
+    multipass purge
+
+If you'd like to manually reset your working environment, you can run the
+following in the rock directory ``~/fastapi-hello-world`` for the tutorial:
 
 .. literalinclude:: code/fastapi/task.yaml
     :language: bash
@@ -669,19 +682,8 @@ in the rock directory ``~/fastapi-hello-world`` for the tutorial:
     :end-before: [docs:clean-environment-end]
     :dedent: 2
 
-You can also clean up your Multipass instance. Start by exiting it:
-
-.. code-block:: bash
-
-    exit
-
-You can then proceed with its deletion:
-
-.. code-block:: bash
-
-    multipass delete charm-dev
-    multipass purge
-
+You can also clean up your Multipass instance by exiting and deleting it
+using the same commands as above.
 
 Next steps
 ----------

--- a/docs/tutorial/kubernetes-charm-fastapi.rst
+++ b/docs/tutorial/kubernetes-charm-fastapi.rst
@@ -620,7 +620,13 @@ Now let's deploy PostgreSQL and integrate it with the FastAPI app:
     :end-before: [docs:deploy-postgres-end]
     :dedent: 2
 
-Wait for ``juju status`` to show that the App is ``active`` again. Running
+Wait for ``juju status`` to show that the App is ``active`` again.
+During this time, the FastAPI app may enter a ``blocked`` state as it
+waits to become integrated with the PostgreSQL database. Due to the
+``optional: false`` key in the endpoint definition, the FastAPI app will not
+start until the database is ready.
+
+Running
 ``curl http://fastapi-hello-world  --resolve fastapi-hello-world:80:127.0.0.1``
 should still return the ``{"message":"Hi!"}`` greeting.
 

--- a/docs/tutorial/kubernetes-charm-flask.rst
+++ b/docs/tutorial/kubernetes-charm-flask.rst
@@ -191,7 +191,7 @@ the architecture of your system:
 
 
 If your host uses the ARM architecture, open ``rockcraft.yaml`` in a
-text editor and include ``arm64`` under ``platforms``.
+text editor, comment out ``amd64``, and include ``arm64`` under ``platforms``.
 
 Now let's pack the rock:
 

--- a/docs/tutorial/kubernetes-charm-flask.rst
+++ b/docs/tutorial/kubernetes-charm-flask.rst
@@ -569,6 +569,11 @@ Now let's deploy PostgreSQL and integrate it with the Flask app:
     :dedent: 2
 
 Wait for ``juju status`` to show that the App is ``active`` again.
+During this time, the Flask app may enter a ``blocked`` state as it
+waits to become integrated with the PostgreSQL database. Due to the
+``optional: false`` key in the endpoint definition, the Flask app will not
+start until the database is ready.
+
 Running ``curl http://flask-hello-world --resolve flask-hello-world:80:127.0.0.1``
 should still return the ``Hi!`` greeting.
 

--- a/docs/tutorial/kubernetes-charm-flask.rst
+++ b/docs/tutorial/kubernetes-charm-flask.rst
@@ -606,16 +606,7 @@ development process, including:
 - Configuring the app
 - Integrating the app with a database
 
-If you'd like to reset your working environment, you can run the following
-in the rock directory ``~/flask-hello-world`` for the tutorial:
-
-.. literalinclude:: code/flask/task.yaml
-    :language: bash
-    :start-after: [docs:clean-environment]
-    :end-before: [docs:clean-environment-end]
-    :dedent: 2
-
-You can also clean up your Multipass instance. Start by exiting it:
+If you'd like to quickly tear things down, start by exiting the Multipass VM:
 
 .. code-block:: bash
 
@@ -628,6 +619,17 @@ And then you can proceed with its deletion:
     multipass delete charm-dev
     multipass purge
 
+If you'd like to manually reset your working environment, you can run the
+following in the rock directory ``~/flask-hello-world`` for the tutorial:
+
+.. literalinclude:: code/flask/task.yaml
+    :language: bash
+    :start-after: [docs:clean-environment]
+    :end-before: [docs:clean-environment-end]
+    :dedent: 2
+
+You can also clean up your Multipass instance by exiting and deleting it
+using the same commands as above.
 
 Next steps
 ----------

--- a/docs/tutorial/kubernetes-charm-go.rst
+++ b/docs/tutorial/kubernetes-charm-go.rst
@@ -683,16 +683,7 @@ development process, including:
 - Configuring the app
 - Integrating the app with a database
 
-If you'd like to reset your working environment, you can run the following
-in the rock directory ``~/go-hello-world`` for the tutorial:
-
-.. literalinclude:: code/go/task.yaml
-    :language: bash
-    :start-after: [docs:clean-environment]
-    :end-before: [docs:clean-environment-end]
-    :dedent: 2
-
-You can also clean up your Multipass instance. Start by exiting it:
+If you'd like to quickly tear things down, start by exiting the Multipass VM:
 
 .. code-block:: bash
 
@@ -705,6 +696,17 @@ And then you can proceed with its deletion:
     multipass delete charm-dev
     multipass purge
 
+If you'd like to manually reset your working environment, you can run the
+following in the rock directory ``~/go-hello-world`` for the tutorial:
+
+.. literalinclude:: code/go/task.yaml
+    :language: bash
+    :start-after: [docs:clean-environment]
+    :end-before: [docs:clean-environment-end]
+    :dedent: 2
+
+You can also clean up your Multipass instance by exiting and deleting it
+using the same commands as above.
 
 Next steps
 ----------

--- a/docs/tutorial/kubernetes-charm-go.rst
+++ b/docs/tutorial/kubernetes-charm-go.rst
@@ -183,7 +183,7 @@ the architecture of your system:
 
 
 If your host uses the ARM architecture, open ``rockcraft.yaml`` in a
-text editor and include ``arm64`` in ``platforms``.
+text editor, comment out ``amd64``, and include ``arm64`` in ``platforms``.
 
 Now let's pack the rock:
 
@@ -289,8 +289,8 @@ The top of the file should look similar to the following snippet:
 
 Verify that the ``name`` is ``go-hello-world``. Ensure that ``platforms``
 includes the architecture of your host. If your host uses the ARM architecture,
-open ``charmcraft.yaml`` in a text editor and include ``arm64``
-in ``platforms``.
+open ``charmcraft.yaml`` in a text editor, comment out ``amd64``, and include
+``arm64`` in ``platforms``.
 
 Let's pack the charm:
 

--- a/docs/tutorial/kubernetes-charm-go.rst
+++ b/docs/tutorial/kubernetes-charm-go.rst
@@ -645,6 +645,11 @@ Now let's deploy PostgreSQL and integrate it with the Go app:
     :dedent: 2
 
 Wait for ``juju status`` to show that the App is ``active`` again.
+During this time, the Go app may enter a ``blocked`` state as it
+waits to become integrated with the PostgreSQL database. Due to the
+``optional: false`` key in the endpoint definition, the Go app will not
+start until the database is ready.
+
 Running ``curl http://go-hello-world  --resolve go-hello-world:80:127.0.0.1``
 should still return the ``Hi!`` greeting.
 


### PR DESCRIPTION
Three updates that expand over all four tutorials. These changes were suggested from one or more UX sessions. 

Summary of changes:
1. If the user needs to open rockcraft.yaml or charmcraft.yaml to update the architecture to `arm64`, have them also comment out `amd64`. While there's no harm or issue with having both architectures available, for novice users, this change will eliminate any possible concern or worry over including both architectures in the YAML file(s).
2. Provide more explanation and reassurance about the web app entering a blocked state when adding the PostgreSQL database.
3. Rephrase the "tear things down" section to tell the users that they can just delete the whole instance if they're not going to keep the VM. 

Additional reviewer: @jdkandersson 