### PR TITLE
docs: Add 12-factor how-to on using observability

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,11 +43,12 @@ ogp_site_name = project
 ogp_image = "https://assets.ubuntu.com/v1/253da317-image-document-ubuntudocs.svg"
 
 html_context = {
-    "product_page": "https://juju.is/",
+    "product_page": "juju.is",
     "product_tag": "_static/juju-logo-no-text.png",
     "github_url": "https://github.com/canonical/charmcraft",
     "github_issues": "https://github.com/canonical/charmcraft/issues",
     "discourse": "https://discourse.charmhub.io",
+    "matrix": "https://matrix.to/#/#charmhub-charmcraft:ubuntu.com",
 }
 
 # Template and asset locations

--- a/docs/howto/manage-web-app-charms/integrate-web-app-charm.rst
+++ b/docs/howto/manage-web-app-charms/integrate-web-app-charm.rst
@@ -87,6 +87,8 @@ provide the integration to your deployed app with:
 You don't need to add an endpoint definition to your charm's
 project file.
 
+.. _integrate_web_app_cos:
+
 Integrate with observability
 ----------------------------
 

--- a/docs/howto/manage-web-app-charms/use-web-app-charm.rst
+++ b/docs/howto/manage-web-app-charms/use-web-app-charm.rst
@@ -61,13 +61,23 @@ To view the specific dashboard for your web app, click :guilabel:`General` and
 then on :guilabel:`WebApp Operator`, where "WebApp" is a stand-in for the
 framework of your web app.
 
-For Flask and Django apps, the dashboard displays default graphs such as status
-codes, requests per second, and request average duration.
+For Flask and Django apps, the dashboard displays default graphs such as:
+
+* Requests: number of requests over time
+* Status code count: the number of requests with the 200 status code 
+* Requests per second: number of requests/second over time 
+* 2XX, 3XX, etc. Rate: ??
+* Request average duration: average duration of the requests over time
+* Request duration percentile: ??
+
 
 View application logs
 ~~~~~~~~~~~~~~~~~~~~~
 
-Go to ``http://<IP_ADDRESS>/<JUJU_MODEL_NAME>-grafana/explore``.
+Go to ``http://<IP_ADDRESS>/<JUJU_MODEL_NAME>-grafana/explore``, where 
+the URL is the one you fetched after running
+``juju show-unit catalogue/0 | grep url``.
+
 At the top of the page, set the label filters to ``juju_application`` and then
 pick ``JUJU_MODEL_NAME`` from the dropdown menu on the right.
 To view the logs, click :guilabel:`Run query`.

--- a/docs/howto/manage-web-app-charms/use-web-app-charm.rst
+++ b/docs/howto/manage-web-app-charms/use-web-app-charm.rst
@@ -73,4 +73,4 @@ pick ``JUJU_MODEL_NAME`` from the dropdown menu on the right.
 To view the logs, click :guilabel:`Run query`.
 
 The logs show the history of the requests sent to your web app and their
-status codes. 
+status codes.

--- a/docs/howto/manage-web-app-charms/use-web-app-charm.rst
+++ b/docs/howto/manage-web-app-charms/use-web-app-charm.rst
@@ -63,13 +63,18 @@ framework of your web app.
 
 For Flask and Django apps, the dashboard displays default graphs such as:
 
-* Requests: number of requests over time
-* Status code count: the number of requests with the 200 status code
-* Requests per second: number of requests/second over time
-* 2XX, 3XX, etc. Rate: ??
-* Request average duration: average duration of the requests over time
-* Request duration percentile: ??
-
+* Requests: Number of requests over time.
+* Status code count: Number of requests broken by responses status code.
+* Requests per second: Number of requests per second over time.
+* 2XX Rate: Portion of responses that were successful (in the 200 range).
+* 3XX Rate: Portion of responses that were redirects (in the 300 range).
+* 4XX Rate: Portion of responses that were client errors (in the 400 range).
+* 5XX Rate: Portion of responses that were server errors (in the 500 range).
+* Request average duration: Average duration of the requests over time.
+* Request duration percentile: The 50th, 90th, and 99th percentile of all the
+  request duration lengths after sorting them from slowest to fastest. For
+  example, the 50th percentile represents the length of time (or less) that
+  50\% of the requests lasted.
 
 View application logs
 ~~~~~~~~~~~~~~~~~~~~~
@@ -82,5 +87,6 @@ At the top of the page, set the label filters to ``juju_application`` and then
 pick ``JUJU_MODEL_NAME`` from the dropdown menu on the right.
 To view the logs, click :guilabel:`Run query`.
 
-The logs show the history of the requests sent to your web app and their
-status codes.
+The logs shown in the dashboard depend on the web framework, but they are
+typically access logs, or the history of the requests sent to your web
+app and their status codes.

--- a/docs/howto/manage-web-app-charms/use-web-app-charm.rst
+++ b/docs/howto/manage-web-app-charms/use-web-app-charm.rst
@@ -64,8 +64,8 @@ framework of your web app.
 For Flask and Django apps, the dashboard displays default graphs such as:
 
 * Requests: number of requests over time
-* Status code count: the number of requests with the 200 status code 
-* Requests per second: number of requests/second over time 
+* Status code count: the number of requests with the 200 status code
+* Requests per second: number of requests/second over time
 * 2XX, 3XX, etc. Rate: ??
 * Request average duration: average duration of the requests over time
 * Request duration percentile: ??
@@ -74,7 +74,7 @@ For Flask and Django apps, the dashboard displays default graphs such as:
 View application logs
 ~~~~~~~~~~~~~~~~~~~~~
 
-Go to ``http://<IP_ADDRESS>/<JUJU_MODEL_NAME>-grafana/explore``, where 
+Go to ``http://<IP_ADDRESS>/<JUJU_MODEL_NAME>-grafana/explore``, where
 the URL is the one you fetched after running
 ``juju show-unit catalogue/0 | grep url``.
 

--- a/docs/howto/manage-web-app-charms/use-web-app-charm.rst
+++ b/docs/howto/manage-web-app-charms/use-web-app-charm.rst
@@ -28,3 +28,40 @@ script will run on every unit. The script is assumed to be idempotent (in other 
 can be run multiple times) and that it can be run on multiple units simultaneously
 without issue. Handling multiple migration scripts that run concurrently
 can be achieved by, for example, locking any tables during the migration.
+
+Use observability
+-----------------
+
+First, :ref:`integrate your web app with the Canonical Observability
+Stack <integrate_web_app_cos>`.
+
+View Grafana dashboard
+~~~~~~~~~~~~~~~~~~~~~~
+
+To view the dashboard, get the endpoints:
+
+.. code-block::
+
+    juju show-unit catalogue/0 | grep url
+    juju run grafana/leader get-admin-password
+
+These commands output URLs and the default admin password. Look for the URL
+with the Grafana postfix with the syntax
+``http://<IP_ADDRESS>/<JUJU_MODEL_NAME>-grafana``. Here, ``JUJU_MODEL_NAME``
+is the name of the Juju model on which you deployed your web app.
+
+Append the ``/dashboards``
+postfix to the URL and log in using the admin password to view the dashboards
+overview page.
+
+To view the specific dashboard for your web app, click :guilabel:`General` and
+then on :guilabel:`WebApp Operator`, where "WebApp" is a stand-in for the
+framework of your web app.
+
+View application logs
+~~~~~~~~~~~~~~~~~~~~~
+
+Go to ``http://<IP_ADDRESS>/<JUJU_MODEL_NAME>-grafana/explore``. 
+At the top of the page, set the label filters to ``juju_application`` and then
+pick ``JUJU_MODEL_NAME`` from the dropdown menu on the right.
+To view the logs, click :guilabel:`Run query`.

--- a/docs/howto/manage-web-app-charms/use-web-app-charm.rst
+++ b/docs/howto/manage-web-app-charms/use-web-app-charm.rst
@@ -35,10 +35,10 @@ Use observability
 First, :ref:`integrate your web app with the Canonical Observability
 Stack <integrate_web_app_cos>`.
 
-View Grafana dashboard
-~~~~~~~~~~~~~~~~~~~~~~
+Get Grafana login details
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To view the dashboard, get the endpoints:
+View the endpoints by running:
 
 .. code-block::
 
@@ -50,7 +50,10 @@ with the Grafana postfix with the syntax
 ``http://<IP_ADDRESS>/<JUJU_MODEL_NAME>-grafana``. Here, ``JUJU_MODEL_NAME``
 is the name of the Juju model on which you deployed your web app.
 
-Append the ``/dashboards``
+View Grafana dashboard
+~~~~~~~~~~~~~~~~~~~~~~
+
+To view the dashboard, append the ``/dashboards``
 postfix to the URL and log in using the admin password to view the dashboards
 overview page.
 

--- a/docs/howto/manage-web-app-charms/use-web-app-charm.rst
+++ b/docs/howto/manage-web-app-charms/use-web-app-charm.rst
@@ -71,6 +71,12 @@ To view the specific dashboard for your web app, click **General** and
 then on **WebApp Operator**, where "WebApp" is a stand-in for the
 framework of your web app.
 
+.. seealso::
+
+  :ref:`Flask framework extension | Grafana dashboard graphs <flask-grafana-graphs>`
+
+  :ref:`Django framework extension | Grafana dashboard graphs <django-grafana-graphs>`
+
 View application logs
 ~~~~~~~~~~~~~~~~~~~~~
 
@@ -79,7 +85,7 @@ the URL is the one you fetched previously.
 
 Filter for the label ``juju_application`` and then
 select your Juju model name from the dropdown.
-Then, click :guilabel:`Run query`.
+Then, click **Run query**.
 
 The logs shown in the dashboard depend on the web framework, but they are
 typically access logs, or the history of the requests sent to your web

--- a/docs/howto/manage-web-app-charms/use-web-app-charm.rst
+++ b/docs/howto/manage-web-app-charms/use-web-app-charm.rst
@@ -4,8 +4,8 @@ Use a 12-factor app charm
 =========================
 
 
-(If your charm is a Django charm) Create an admin user
-------------------------------------------------------
+Create an admin user for a Django app charm
+-------------------------------------------
 
 Use the ``create-superuser`` action to create a new Django admin account:
 
@@ -14,8 +14,8 @@ Use the ``create-superuser`` action to create a new Django admin account:
     juju run <app name> create-superuser username=<username> email=<email>
 
 
-(If your workload depends on a database) Migrate the database
--------------------------------------------------------------
+Migrate the workload database
+-----------------------------
 
 If your app depends on a database, it is common to run a database migration
 script before app startup which, for example, creates or modifies tables. This

--- a/docs/howto/manage-web-app-charms/use-web-app-charm.rst
+++ b/docs/howto/manage-web-app-charms/use-web-app-charm.rst
@@ -61,7 +61,7 @@ framework of your web app.
 View application logs
 ~~~~~~~~~~~~~~~~~~~~~
 
-Go to ``http://<IP_ADDRESS>/<JUJU_MODEL_NAME>-grafana/explore``. 
+Go to ``http://<IP_ADDRESS>/<JUJU_MODEL_NAME>-grafana/explore``.
 At the top of the page, set the label filters to ``juju_application`` and then
 pick ``JUJU_MODEL_NAME`` from the dropdown menu on the right.
 To view the logs, click :guilabel:`Run query`.

--- a/docs/howto/manage-web-app-charms/use-web-app-charm.rst
+++ b/docs/howto/manage-web-app-charms/use-web-app-charm.rst
@@ -35,57 +35,51 @@ Use observability
 First, :ref:`integrate your web app with the Canonical Observability
 Stack <integrate_web_app_cos>`.
 
-Get Grafana login details
-~~~~~~~~~~~~~~~~~~~~~~~~~
+Connect to the Grafana service
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-View the endpoints by running:
+Retrieve the observability endpoints:
 
-.. code-block::
+.. code-block:: bash
 
     juju show-unit catalogue/0 | grep url
+
+Retrieve the password of the default Grafana admin account:
+
+.. code-block:: bash
+
     juju run grafana/leader get-admin-password
 
-These commands output URLs and the default admin password. Look for the URL
-with the Grafana postfix with the syntax
-``http://<IP_ADDRESS>/<JUJU_MODEL_NAME>-grafana``. Here, ``JUJU_MODEL_NAME``
-is the name of the Juju model on which you deployed your web app.
+From the list of URLs, look for the endpoint that contains a ``grafana``
+suffix. This URL has the format:
 
-View Grafana dashboard
-~~~~~~~~~~~~~~~~~~~~~~
+.. terminal::
 
-To view the dashboard, append the ``/dashboards``
-postfix to the URL and log in using the admin password to view the dashboards
-overview page.
+    http://<IP_ADDRESS>/<JUJU_MODEL_NAME>-grafana
 
-To view the specific dashboard for your web app, click :guilabel:`General` and
-then on :guilabel:`WebApp Operator`, where "WebApp" is a stand-in for the
+Here, ``JUJU_MODEL_NAME`` is the name of the Juju model on which you deployed
+your web app.
+
+
+Access the Grafana web app
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To view the dashboards overview page, append the ``/dashboards``
+suffix to the URL and log in using the admin password.
+
+To view the specific dashboard for your web app, click **General** and
+then on **WebApp Operator**, where "WebApp" is a stand-in for the
 framework of your web app.
-
-For Flask and Django apps, the dashboard displays default graphs such as:
-
-* Requests: Number of requests over time.
-* Status code count: Number of requests broken by responses status code.
-* Requests per second: Number of requests per second over time.
-* 2XX Rate: Portion of responses that were successful (in the 200 range).
-* 3XX Rate: Portion of responses that were redirects (in the 300 range).
-* 4XX Rate: Portion of responses that were client errors (in the 400 range).
-* 5XX Rate: Portion of responses that were server errors (in the 500 range).
-* Request average duration: Average duration of the requests over time.
-* Request duration percentile: The 50th, 90th, and 99th percentile of all the
-  request duration lengths after sorting them from slowest to fastest. For
-  example, the 50th percentile represents the length of time (or less) that
-  50\% of the requests lasted.
 
 View application logs
 ~~~~~~~~~~~~~~~~~~~~~
 
 Go to ``http://<IP_ADDRESS>/<JUJU_MODEL_NAME>-grafana/explore``, where
-the URL is the one you fetched after running
-``juju show-unit catalogue/0 | grep url``.
+the URL is the one you fetched previously.
 
-At the top of the page, set the label filters to ``juju_application`` and then
-pick ``JUJU_MODEL_NAME`` from the dropdown menu on the right.
-To view the logs, click :guilabel:`Run query`.
+Filter for the label ``juju_application`` and then
+select your Juju model name from the dropdown.
+Then, click :guilabel:`Run query`.
 
 The logs shown in the dashboard depend on the web framework, but they are
 typically access logs, or the history of the requests sent to your web

--- a/docs/howto/manage-web-app-charms/use-web-app-charm.rst
+++ b/docs/howto/manage-web-app-charms/use-web-app-charm.rst
@@ -61,6 +61,9 @@ To view the specific dashboard for your web app, click :guilabel:`General` and
 then on :guilabel:`WebApp Operator`, where "WebApp" is a stand-in for the
 framework of your web app.
 
+For Flask and Django apps, the dashboard displays default graphs such as status
+codes, requests per second, and request average duration.
+
 View application logs
 ~~~~~~~~~~~~~~~~~~~~~
 
@@ -68,3 +71,6 @@ Go to ``http://<IP_ADDRESS>/<JUJU_MODEL_NAME>-grafana/explore``.
 At the top of the page, set the label filters to ``juju_application`` and then
 pick ``JUJU_MODEL_NAME`` from the dropdown menu on the right.
 To view the logs, click :guilabel:`Run query`.
+
+The logs show the history of the requests sent to your web app and their
+status codes. 

--- a/docs/reference/extensions/django-framework-extension.rst
+++ b/docs/reference/extensions/django-framework-extension.rst
@@ -150,6 +150,8 @@ underscores and all the letters capitalised.
 
    See more: :external+juju:ref:`Juju | Secret <secret>`
 
+.. _django-grafana-graphs:
+
 Grafana dashboard graphs
 ------------------------
 

--- a/docs/reference/extensions/django-framework-extension.rst
+++ b/docs/reference/extensions/django-framework-extension.rst
@@ -149,3 +149,24 @@ the environment variable name will have the hyphens replaced by
 underscores and all the letters capitalised.
 
    See more: :external+juju:ref:`Juju | Secret <secret>`
+
+Grafana dashboard graphs
+------------------------
+
+If the Django app is connected to the `Canonical Observability Stack
+(COS) <https://charmhub.io/topics/canonical-observability-stack>`_,
+the Grafana dashboard **Django Operator** displays the following
+default graphs:
+
+* Requests: Number of requests over time.
+* Status code count: Number of requests broken by responses status code.
+* Requests per second: Number of requests per second over time.
+* 2XX Rate: Portion of responses that were successful (in the 200 range).
+* 3XX Rate: Portion of responses that were redirects (in the 300 range).
+* 4XX Rate: Portion of responses that were client errors (in the 400 range).
+* 5XX Rate: Portion of responses that were server errors (in the 500 range).
+* Request average duration: Average duration of the requests over time.
+* Request duration percentile: The 50th, 90th, and 99th percentile of all the
+  request duration lengths after sorting them from slowest to fastest. For
+  example, the 50th percentile represents the length of time (or less) that
+  50\% of the requests lasted.

--- a/docs/reference/extensions/flask-framework-extension.rst
+++ b/docs/reference/extensions/flask-framework-extension.rst
@@ -138,3 +138,24 @@ variable name will have the hyphens replaced by underscores and all the letters
 capitalised.
 
    See more: :external+juju:ref:`Juju | Secret <secret>`
+
+Grafana dashboard graphs
+------------------------
+
+If the Flask app is connected to the `Canonical Observability Stack
+(COS) <https://charmhub.io/topics/canonical-observability-stack>`_,
+the Grafana dashboard **Flask Operator** displays the following
+default graphs:
+
+* Requests: Number of requests over time.
+* Status code count: Number of requests broken by responses status code.
+* Requests per second: Number of requests per second over time.
+* 2XX Rate: Portion of responses that were successful (in the 200 range).
+* 3XX Rate: Portion of responses that were redirects (in the 300 range).
+* 4XX Rate: Portion of responses that were client errors (in the 400 range).
+* 5XX Rate: Portion of responses that were server errors (in the 500 range).
+* Request average duration: Average duration of the requests over time.
+* Request duration percentile: The 50th, 90th, and 99th percentile of all the
+  request duration lengths after sorting them from slowest to fastest. For
+  example, the 50th percentile represents the length of time (or less) that
+  50\% of the requests lasted.

--- a/docs/reference/extensions/flask-framework-extension.rst
+++ b/docs/reference/extensions/flask-framework-extension.rst
@@ -139,6 +139,8 @@ capitalised.
 
    See more: :external+juju:ref:`Juju | Secret <secret>`
 
+.. _flask-grafana-graphs:
+
 Grafana dashboard graphs
 ------------------------
 


### PR DESCRIPTION
### Summary of changes
* Add a new section, "Use observability" on how to access the dashboards and view application logs.
* Tweak titles of other usage-related how-to's in the same file.
* Add a section target on "Integrate with observability".
* Based on the PR review, updated the Flask and Django reference pages.

Additional reviewer: @jdkandersson 