### PR TITLE
docs: add venv activation to the contribution instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,7 @@ Make changes as appropriate. Some existing ideas are in the
 To test locally:
 
 ```bash
+source .venv/bin/activate
 CHARMCRAFT_DEVELOPER=1 python -m charmcraft
 ```
 


### PR DESCRIPTION
I was working through the instructions in CONTRIBUTING.md but wasn't able to run `python -m charmcraft`. Then I realised that I needed to first activate the virtual environment created by `make setup`. That's probably obvious to many, but it tripped me up :slightly_smiling_face: 

This PR adds an explicit command for activating the virtual environment.