### PR TITLE
Docs: Update 12-factor tutorials

### DIFF
--- a/docs/tutorial/kubernetes-charm-django.rst
+++ b/docs/tutorial/kubernetes-charm-django.rst
@@ -308,7 +308,8 @@ finish.
 
 Once Rockcraft has finished packing the Django rock, the
 terminal will respond with something similar to
-``Packed django-hello-world_0.1_amd64.rock``.
+``Packed django-hello-world_0.1_amd64.rock``. After the initial
+pack, subsequent rock packings are faster.
 
 .. note::
 
@@ -390,7 +391,8 @@ minutes to finish.
 
 Once Charmcraft has finished packing the charm, the terminal will
 respond with something similar to
-``Packed django-hello-world_ubuntu-22.04-amd64.charm``.
+``Packed django-hello-world_ubuntu-22.04-amd64.charm``. After the initial
+pack, subsequent charm packings are faster.
 
 .. note::
 

--- a/docs/tutorial/kubernetes-charm-django.rst
+++ b/docs/tutorial/kubernetes-charm-django.rst
@@ -366,6 +366,12 @@ of the file:
 .. literalinclude:: code/django/postgres_requires_charmcraft.yaml
     :language: yaml
 
+.. tip::
+
+    Want to learn more about all the configurations in the
+    ``django-framework`` profile? Run ``charmcraft expand-extensions``
+    from the ``~/django-hello-world/charm/`` directory. 
+
 Now let's pack the charm:
 
 .. literalinclude:: code/django/task.yaml

--- a/docs/tutorial/kubernetes-charm-django.rst
+++ b/docs/tutorial/kubernetes-charm-django.rst
@@ -371,7 +371,7 @@ of the file:
 
     Want to learn more about all the configurations in the
     ``django-framework`` profile? Run ``charmcraft expand-extensions``
-    from the ``~/django-hello-world/charm/`` directory. 
+    from the ``~/django-hello-world/charm/`` directory.
 
 Now let's pack the charm:
 
@@ -467,7 +467,7 @@ using :kbd:`Ctrl` + :kbd:`C`.
 .. tip::
 
     To monitor your deployment, keep a ``juju status`` session active in a
-    second terminal. 
+    second terminal.
 
     See more: :external+juju:ref:`Juju | juju status <command-juju-status>`
 

--- a/docs/tutorial/kubernetes-charm-django.rst
+++ b/docs/tutorial/kubernetes-charm-django.rst
@@ -308,7 +308,7 @@ finish.
 
 Once Rockcraft has finished packing the Django rock, the
 terminal will respond with something similar to
-``Packed django-hello-world_0.1_amd64.rock``. After the initial
+``Packed django-hello-world_0.1_<architecture>.rock``. After the initial
 pack, subsequent rock packings are faster.
 
 .. note::

--- a/docs/tutorial/kubernetes-charm-django.rst
+++ b/docs/tutorial/kubernetes-charm-django.rst
@@ -464,9 +464,12 @@ start until the database is ready.
 Once the status of the App has gone to ``active``, you can stop watching
 using :kbd:`Ctrl` + :kbd:`C`.
 
-.. seealso::
+.. tip::
 
-    See more: `Command 'juju status' <https://juju.is/docs/juju/juju-status>`_
+    To monitor your deployment, keep a ``juju status`` session active in a
+    second terminal. 
+
+    See more: :external+juju:ref:`Juju | juju status <command-juju-status>`
 
 The Django app should now be running. We can see the status of
 the deployment using ``juju status`` which should be similar to the

--- a/docs/tutorial/kubernetes-charm-django.rst
+++ b/docs/tutorial/kubernetes-charm-django.rst
@@ -410,10 +410,8 @@ the Django app. Let's create a new model:
     :end-before: [docs:add-juju-model-end]
     :dedent: 2
 
-If you aren't on a host with the AMD64 architecture, you will need
-to include a constraint to the Juju model to specify your architecture.
-
-Set the Juju model constraints with:
+Include a constraint to the Juju model to specify your architecture if you
+aren't on a host with AMD64:
 
 .. literalinclude:: code/django/task.yaml
     :language: bash

--- a/docs/tutorial/kubernetes-charm-fastapi.rst
+++ b/docs/tutorial/kubernetes-charm-fastapi.rst
@@ -344,11 +344,8 @@ the FastAPI app. Let's create a new model:
     :end-before: [docs:add-juju-model-end]
     :dedent: 2
 
-If you aren't on a host with the AMD64 architecture, you will
-need to include a constraint to the Juju model to specify your
-architecture.
-
-Set the Juju model constraints with:
+Include a constraint to the Juju model to specify your architecture if you
+aren't on a host with AMD64:
 
 .. literalinclude:: code/fastapi/task.yaml
     :language: bash

--- a/docs/tutorial/kubernetes-charm-fastapi.rst
+++ b/docs/tutorial/kubernetes-charm-fastapi.rst
@@ -379,7 +379,10 @@ It can take a couple of minutes for the app to finish the deployment.
 Once the status of the App has gone to ``active``, you can stop watching
 using :kbd:`Ctrl` + :kbd:`C`.
 
-.. seealso::
+.. tip::
+
+    To monitor your deployment, keep a ``juju status`` session active in a
+    second terminal. 
 
     See more: :external+juju:ref:`Juju | juju status <command-juju-status>`
 

--- a/docs/tutorial/kubernetes-charm-fastapi.rst
+++ b/docs/tutorial/kubernetes-charm-fastapi.rst
@@ -305,7 +305,7 @@ open ``charmcraft.yaml`` in a text editor, comment out ``amd64``, and include
 
     Want to learn more about all the configurations in the
     ``fastapi-framework`` profile? Run ``charmcraft expand-extensions``
-    from the ``~/fastapi-hello-world/charm/`` directory. 
+    from the ``~/fastapi-hello-world/charm/`` directory.
 
 Let's pack the charm:
 
@@ -381,7 +381,7 @@ using :kbd:`Ctrl` + :kbd:`C`.
 .. tip::
 
     To monitor your deployment, keep a ``juju status`` session active in a
-    second terminal. 
+    second terminal.
 
     See more: :external+juju:ref:`Juju | juju status <command-juju-status>`
 

--- a/docs/tutorial/kubernetes-charm-fastapi.rst
+++ b/docs/tutorial/kubernetes-charm-fastapi.rst
@@ -211,7 +211,7 @@ minutes to finish.
 
 Once Rockcraft has finished packing the FastAPI rock,
 the terminal will respond with something similar to
-``Packed fastapi-hello-world_0.1_amd64.rock``. After the initial
+``Packed fastapi-hello-world_0.1_<architecture>.rock``. After the initial
 pack, subsequent rock packings are faster.
 
 .. note::

--- a/docs/tutorial/kubernetes-charm-fastapi.rst
+++ b/docs/tutorial/kubernetes-charm-fastapi.rst
@@ -300,6 +300,12 @@ includes the architecture of your host. If your host uses the ARM architecture,
 open ``charmcraft.yaml`` in a text editor, comment out ``amd64``, and include
 ``arm64`` in ``platforms``.
 
+.. tip::
+
+    Want to learn more about all the configurations in the
+    ``fastapi-framework`` profile? Run ``charmcraft expand-extensions``
+    from the ``~/fastapi-hello-world/charm/`` directory. 
+
 Let's pack the charm:
 
 .. literalinclude:: code/fastapi/task.yaml

--- a/docs/tutorial/kubernetes-charm-fastapi.rst
+++ b/docs/tutorial/kubernetes-charm-fastapi.rst
@@ -211,7 +211,8 @@ minutes to finish.
 
 Once Rockcraft has finished packing the FastAPI rock,
 the terminal will respond with something similar to
-``Packed fastapi-hello-world_0.1_amd64.rock``.
+``Packed fastapi-hello-world_0.1_amd64.rock``. After the initial
+pack, subsequent rock packings are faster.
 
 .. note::
 
@@ -324,7 +325,8 @@ minutes to finish.
 
 Once Charmcraft has finished packing the charm, the terminal will
 respond with something similar to
-``Packed fastapi-hello-world_ubuntu-24.04-amd64.charm``.
+``Packed fastapi-hello-world_ubuntu-24.04-amd64.charm``. After the initial
+pack, subsequent charm packings are faster.
 
 .. note::
 

--- a/docs/tutorial/kubernetes-charm-flask.rst
+++ b/docs/tutorial/kubernetes-charm-flask.rst
@@ -206,7 +206,8 @@ minutes to finish.
 
 Once Rockcraft has finished packing the Flask rock,
 the terminal will respond with something similar to
-``Packed flask-hello-world_0.1_amd64.rock``.
+``Packed flask-hello-world_0.1_amd64.rock``. After the initial
+pack, subsequent rock packings are faster.
 
 .. note::
 
@@ -276,7 +277,8 @@ minutes to finish.
 
 Once Charmcraft has finished packing the charm, the terminal will
 respond with something similar to
-``Packed flask-hello-world_ubuntu-24.04-amd64.charm``.
+``Packed flask-hello-world_ubuntu-24.04-amd64.charm``. After the initial
+pack, subsequent charm packings are faster.
 
 .. note::
 

--- a/docs/tutorial/kubernetes-charm-flask.rst
+++ b/docs/tutorial/kubernetes-charm-flask.rst
@@ -296,10 +296,8 @@ the Flask app. Let's create a new model:
     :end-before: [docs:add-juju-model-end]
     :dedent: 2
 
-If you aren't on a host with the AMD64 architecture, you will need to include
-to include a constraint to the Juju model to specify your architecture.
-
-Set the Juju model constraints with:
+Include a constraint to the Juju model to specify your architecture if you
+aren't on a host with AMD64:
 
 .. literalinclude:: code/flask/task.yaml
     :language: bash

--- a/docs/tutorial/kubernetes-charm-flask.rst
+++ b/docs/tutorial/kubernetes-charm-flask.rst
@@ -262,7 +262,7 @@ The files will automatically be created in your working directory.
 
     Want to learn more about all the configurations in the
     ``flask-framework`` profile? Run ``charmcraft expand-extensions``
-    from the ``~/flask-hello-world/charm/`` directory. 
+    from the ``~/flask-hello-world/charm/`` directory.
 
 Let's pack the charm:
 
@@ -331,7 +331,7 @@ using :kbd:`Ctrl` + :kbd:`C`.
 .. tip::
 
     To monitor your deployment, keep a ``juju status`` session active in a
-    second terminal. 
+    second terminal.
 
     See more: :external+juju:ref:`Juju | juju status <command-juju-status>`
 

--- a/docs/tutorial/kubernetes-charm-flask.rst
+++ b/docs/tutorial/kubernetes-charm-flask.rst
@@ -256,6 +256,13 @@ Initialize a charm named ``flask-hello-world``:
     :dedent: 2
 
 The files will automatically be created in your working directory.
+
+.. tip::
+
+    Want to learn more about all the configurations in the
+    ``flask-framework`` profile? Run ``charmcraft expand-extensions``
+    from the ``~/flask-hello-world/charm/`` directory. 
+
 Let's pack the charm:
 
 .. literalinclude:: code/flask/task.yaml

--- a/docs/tutorial/kubernetes-charm-flask.rst
+++ b/docs/tutorial/kubernetes-charm-flask.rst
@@ -206,7 +206,7 @@ minutes to finish.
 
 Once Rockcraft has finished packing the Flask rock,
 the terminal will respond with something similar to
-``Packed flask-hello-world_0.1_amd64.rock``. After the initial
+``Packed flask-hello-world_0.1_<architecture>.rock``. After the initial
 pack, subsequent rock packings are faster.
 
 .. note::

--- a/docs/tutorial/kubernetes-charm-flask.rst
+++ b/docs/tutorial/kubernetes-charm-flask.rst
@@ -328,7 +328,10 @@ It can take a couple of minutes for the app to finish the deployment.
 Once the status of the App has gone to ``active``, you can stop watching
 using :kbd:`Ctrl` + :kbd:`C`.
 
-.. seealso::
+.. tip::
+
+    To monitor your deployment, keep a ``juju status`` session active in a
+    second terminal. 
 
     See more: :external+juju:ref:`Juju | juju status <command-juju-status>`
 

--- a/docs/tutorial/kubernetes-charm-go.rst
+++ b/docs/tutorial/kubernetes-charm-go.rst
@@ -203,7 +203,8 @@ minutes to finish.
 
 Once Rockcraft has finished packing the Go rock,
 the terminal will respond with something similar to
-``Packed go-hello-world_0.1_amd64.rock``.
+``Packed go-hello-world_0.1_amd64.rock``. After the initial
+pack, subsequent rock packings are faster.
 
 .. note::
 
@@ -316,7 +317,8 @@ minutes to finish.
 
 Once Charmcraft has finished packing the charm, the terminal will
 respond with something similar to
-``Packed go-hello-world_ubuntu-24.04-amd64.charm``.
+``Packed go-hello-world_ubuntu-24.04-amd64.charm``. After the initial
+pack, subsequent charm packings are faster.
 
 .. note::
 

--- a/docs/tutorial/kubernetes-charm-go.rst
+++ b/docs/tutorial/kubernetes-charm-go.rst
@@ -203,7 +203,7 @@ minutes to finish.
 
 Once Rockcraft has finished packing the Go rock,
 the terminal will respond with something similar to
-``Packed go-hello-world_0.1_amd64.rock``. After the initial
+``Packed go-hello-world_0.1_<architecture>.rock``. After the initial
 pack, subsequent rock packings are faster.
 
 .. note::

--- a/docs/tutorial/kubernetes-charm-go.rst
+++ b/docs/tutorial/kubernetes-charm-go.rst
@@ -297,7 +297,7 @@ open ``charmcraft.yaml`` in a text editor, comment out ``amd64``, and include
 
     Want to learn more about all the configurations in the
     ``go-framework`` profile? Run ``charmcraft expand-extensions``
-    from the ``~/go-hello-world/charm/`` directory. 
+    from the ``~/go-hello-world/charm/`` directory.
 
 Let's pack the charm:
 
@@ -371,7 +371,7 @@ using :kbd:`Ctrl` + :kbd:`C`.
 .. tip::
 
     To monitor your deployment, keep a ``juju status`` session active in a
-    second terminal. 
+    second terminal.
 
     See more: :external+juju:ref:`Juju | juju status <command-juju-status>`
 

--- a/docs/tutorial/kubernetes-charm-go.rst
+++ b/docs/tutorial/kubernetes-charm-go.rst
@@ -368,7 +368,10 @@ It can take a couple of minutes for the app to finish the deployment.
 Once the status of the App has gone to ``active``, you can stop watching
 using :kbd:`Ctrl` + :kbd:`C`.
 
-.. seealso::
+.. tip::
+
+    To monitor your deployment, keep a ``juju status`` session active in a
+    second terminal. 
 
     See more: :external+juju:ref:`Juju | juju status <command-juju-status>`
 

--- a/docs/tutorial/kubernetes-charm-go.rst
+++ b/docs/tutorial/kubernetes-charm-go.rst
@@ -336,10 +336,8 @@ the Go app. Let's create a new model:
     :end-before: [docs:add-juju-model-end]
     :dedent: 2
 
-If you aren't on a host with the AMD64 architecture, you will need to include
-to include a constraint to the Juju model to specify your architecture.
-
-Set the Juju model constraints with:
+Include a constraint to the Juju model to specify your architecture if you
+aren't on a host with AMD64:
 
 .. literalinclude:: code/go/task.yaml
     :language: bash

--- a/docs/tutorial/kubernetes-charm-go.rst
+++ b/docs/tutorial/kubernetes-charm-go.rst
@@ -292,6 +292,12 @@ includes the architecture of your host. If your host uses the ARM architecture,
 open ``charmcraft.yaml`` in a text editor, comment out ``amd64``, and include
 ``arm64`` in ``platforms``.
 
+.. tip::
+
+    Want to learn more about all the configurations in the
+    ``go-framework`` profile? Run ``charmcraft expand-extensions``
+    from the ``~/go-hello-world/charm/`` directory. 
+
 Let's pack the charm:
 
 .. literalinclude:: code/go/task.yaml


### PR DESCRIPTION
Updates to the 12-factor tutorials that affect all four tutorials.

### Summary of changes
* Add a tip admonition to let the user know about `charmcraft expand-extensions`. This has been a repeated ask from UX research participants.
* Convert the `juju status` admonition to a tip to recommend that users start a `juju status` session in a new tab to monitor their deployment. This prepares the user for a successful deployment setup. 
* Update the terminal output for `rockcraft pack` to use a generic architecture stand-in. This indicates that the architecture plays an active role in defining the rock. 
* Mention that subsequent `charmcraft pack` and `rockcraft pack` commands are faster after the initial packing. This has been a repeated ask from UX research participants. 
* Condense text about adding an architecture constraint to the Juju model, for conciseness.  