### PR TITLE
feat(templates): add workload module to Kubernetes and machine profiles

### DIFF
--- a/charmcraft/application/commands/init.py
+++ b/charmcraft/application/commands/init.py
@@ -79,7 +79,9 @@ files and directories:
     ├── README.md                  - Frontpage for your charmhub.io/charm/
     ├── requirements.txt           - PyPI dependencies for your charm, with `ops`
     ├── src
-    │   └── charm.py               - Minimal operator using Python operator framework
+    │   ├── charm.py               - Python code that operates your charm's workload
+    │   └── <workload>.py          - Standalone module for workload-specific logic,
+    │                                created if profile is 'kubernetes' or 'machine'
     ├── tests
     │   ├── integration
     │   │   └── test_charm.py      - Integration tests
@@ -89,9 +91,9 @@ files and directories:
 
 You will need to edit at least charmcraft.yaml and README.md.
 
-Your minimal operator code is in src/charm.py which uses the Python operator
-framework from https://github.com/canonical/operator and there are some
-example unit and integration tests with a harness to run them.
+Your minimal operator code is in src/charm.py, which uses the 'ops' Python framework.
+See https://ops.readthedocs.io/en/latest/. There are also some sample unit and
+integration tests, which you can run using 'tox -e unit' and 'tox -e integration'.
 """
 
 

--- a/charmcraft/application/commands/init.py
+++ b/charmcraft/application/commands/init.py
@@ -110,7 +110,27 @@ README.md
 
 
 def _make_workload_module_name(charm_name: str) -> str:
-    return "workload"
+    module_name = charm_name.replace("-", "_")
+    generic_names = [  # put names with more components at the beginning of the list
+        "k8s_charm",
+        "k8s_operator",
+        "machine_charm",
+        "machine_operator",
+        "vm_charm",
+        "vm_operator",
+        "charm",
+        "operator",
+        "k8s",
+        "machine",
+        "vm",
+    ]
+    if module_name in generic_names:
+        return "workload"
+    for generic_name in generic_names:
+        generic_suffix = f"_{generic_name}"
+        if module_name.endswith(generic_suffix):
+            return module_name[: -len(generic_suffix)]
+    return module_name
 
 
 def _get_users_full_name_gecos() -> str | None:

--- a/charmcraft/templates/init-kubernetes/src/charm.py.j2
+++ b/charmcraft/templates/init-kubernetes/src/charm.py.j2
@@ -5,10 +5,16 @@
 """Charm the application."""
 
 import logging
+import time
 
 import ops
 
+# A standalone module for workload-specific logic (no charming concerns):
+import {{ workload_module }}
+
 logger = logging.getLogger(__name__)
+
+SERVICE_NAME = "some-service"  # Name of Pebble service that runs in the workload container.
 
 
 class {{ class_name }}(ops.CharmBase):
@@ -17,10 +23,59 @@ class {{ class_name }}(ops.CharmBase):
     def __init__(self, framework: ops.Framework):
         super().__init__(framework)
         framework.observe(self.on["some_container"].pebble_ready, self._on_pebble_ready)
+        self.container = self.unit.get_container("some-container")
 
     def _on_pebble_ready(self, event: ops.PebbleReadyEvent):
         """Handle pebble-ready event."""
+        self.unit.status = ops.MaintenanceStatus("starting workload")
+        # To start the workload, we'll add a Pebble layer to the workload container.
+        # The layer specifies which service to run.
+        layer: ops.pebble.LayerDict = {
+            "services": {
+                SERVICE_NAME: {
+                    "override": "replace",
+                    "summary": "A service that runs in the workload container",
+                    "command": "/bin/foo",  # Change this!
+                    "startup": "enabled",
+                }
+            }
+        }
+        self.container.add_layer("base", layer, combine=True)
+        # If the container image is a rock, the container already has a Pebble layer.
+        # In this case, you could remove 'add_layer' or use 'add_layer' to extend the rock's layer.
+        # To learn about rocks, see https://documentation.ubuntu.com/rockcraft/en/stable/
+        self.container.replan()  # Starts the service (because 'startup' is enabled in the layer).
+        self.wait_for_ready()
+        version = {{ workload_module }}.get_version()
+        if version is not None:
+            self.unit.set_workload_version(version)
         self.unit.status = ops.ActiveStatus()
+
+    def is_ready(self) -> bool:
+        """Check whether the workload is ready to use."""
+        # We'll first check whether all Pebble services are running.
+        for name, service_info in self.container.get_services().items():
+            if not service_info.is_running():
+                logger.info("the workload is not ready (service '%s' is not running)", name)
+                return False
+        # The Pebble services are running, but the workload might not be ready to use.
+        # So we'll check whether all Pebble 'ready' checks are passing.
+        checks = self.container.get_checks(level=ops.pebble.CheckLevel.READY)
+        for check_info in checks.values():
+            if check_info.status != ops.pebble.CheckStatus.UP:
+                return False
+        return True
+
+    def wait_for_ready(self) -> None:
+        """Wait for the workload to be ready to use."""
+        for _ in range(3):
+            if self.is_ready():
+                return
+            time.sleep(1)
+        logger.error("the workload was not ready within the expected time")
+        raise RuntimeError("workload is not ready")
+        # The runtime error is for you (the charm author) to see, not for the user of the charm.
+        # Make sure that this function waits long enough for the workload to be ready.
 
 
 if __name__ == "__main__":  # pragma: nocover

--- a/charmcraft/templates/init-kubernetes/src/workload.py.j2
+++ b/charmcraft/templates/init-kubernetes/src/workload.py.j2
@@ -1,0 +1,2 @@
+# Copyright {{ year }} {{ author }}
+# See LICENSE file for licensing details.

--- a/charmcraft/templates/init-kubernetes/src/workload.py.j2
+++ b/charmcraft/templates/init-kubernetes/src/workload.py.j2
@@ -1,2 +1,20 @@
 # Copyright {{ year }} {{ author }}
 # See LICENSE file for licensing details.
+
+"""Functions for interacting with the workload.
+
+The intention is that this module could be used outside the context of a charm.
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+# Functions for interacting with the workload, for example over HTTP:
+
+
+def get_version() -> str | None:
+    """Get the running version of the workload."""
+    # You'll need to implement this function (or remove it if not needed).
+    return None

--- a/charmcraft/templates/init-kubernetes/tests/unit/test_charm.py.j2
+++ b/charmcraft/templates/init-kubernetes/tests/unit/test_charm.py.j2
@@ -1,21 +1,71 @@
 # Copyright {{ year }} {{ author }}
 # See LICENSE file for licensing details.
 #
-# Learn more about testing at: https://juju.is/docs/sdk/testing
+# To learn more about testing, see https://ops.readthedocs.io/en/latest/explanation/testing.html
 
-from ops import testing
+import pytest
+from ops import pebble, testing
 
-from charm import {{ class_name }}
+from charm import SERVICE_NAME, {{ class_name }}
+
+CHECK_NAME = "service-ready"  # Name of Pebble check in the mock workload container.
+
+base_layer: pebble.LayerDict = {"services": {SERVICE_NAME: {}}, "checks": {CHECK_NAME: {}}}
+layers = {"base": pebble.Layer(base_layer)}
 
 
-def test_pebble_ready():
+def mock_get_version():
+    """Get a mock version string without executing the workload code."""
+    return "1.0.0"
+
+
+def test_pebble_ready(monkeypatch: pytest.MonkeyPatch):
+    """Test that the charm has the correct state after handling the pebble-ready event."""
     # Arrange:
     ctx = testing.Context({{ class_name }})
-    container = testing.Container("some-container", can_connect=True)
-    state_in = testing.State(containers={container})
+    check_in = testing.CheckInfo(
+        CHECK_NAME,
+        level=pebble.CheckLevel.READY,
+        status=pebble.CheckStatus.UP,  # Simulate the Pebble check passing.
+    )
+    container_in = testing.Container(
+        "some-container",
+        can_connect=True,
+        layers=layers,
+        service_statuses={SERVICE_NAME: pebble.ServiceStatus.INACTIVE},
+        check_infos={check_in},
+    )
+    state_in = testing.State(containers={container_in})
+    monkeypatch.setattr("charm.{{ workload_module }}.get_version", mock_get_version)
 
     # Act:
-    state_out = ctx.run(ctx.on.pebble_ready(container), state_in)
+    state_out = ctx.run(ctx.on.pebble_ready(container_in), state_in)
 
     # Assert:
+    container_out = state_out.get_container(container_in.name)
+    assert container_out.service_statuses[SERVICE_NAME] == pebble.ServiceStatus.ACTIVE
+    assert state_out.workload_version is not None
     assert state_out.unit_status == testing.ActiveStatus()
+
+
+def test_pebble_ready_service_not_ready():
+    """Test that the charm raises an error if the workload isn't ready after Pebble starts it."""
+    # Arrange:
+    ctx = testing.Context({{ class_name }})
+    check_in = testing.CheckInfo(
+        CHECK_NAME,
+        level=pebble.CheckLevel.READY,
+        status=pebble.CheckStatus.DOWN,  # Simulate the Pebble check failing.
+    )
+    container_in = testing.Container(
+        "some-container",
+        can_connect=True,
+        layers=layers,
+        service_statuses={SERVICE_NAME: pebble.ServiceStatus.INACTIVE},
+        check_infos={check_in},
+    )
+    state_in = testing.State(containers={container_in})
+
+    # Act & assert:
+    with pytest.raises(testing.errors.UncaughtCharmError):
+        ctx.run(ctx.on.pebble_ready(container_in), state_in)

--- a/charmcraft/templates/init-machine/src/charm.py.j2
+++ b/charmcraft/templates/init-machine/src/charm.py.j2
@@ -8,6 +8,9 @@ import logging
 
 import ops
 
+# A standalone module for workload-specific logic (no charming concerns):
+import {{ workload_module }}
+
 logger = logging.getLogger(__name__)
 
 
@@ -16,10 +19,20 @@ class {{ class_name }}(ops.CharmBase):
 
     def __init__(self, framework: ops.Framework):
         super().__init__(framework)
+        framework.observe(self.on.install, self._on_install)
         framework.observe(self.on.start, self._on_start)
+
+    def _on_install(self, event: ops.InstallEvent):
+        """Install the workload on the machine."""
+        {{ workload_module }}.install()
 
     def _on_start(self, event: ops.StartEvent):
         """Handle start event."""
+        self.unit.status = ops.MaintenanceStatus("starting workload")
+        {{ workload_module }}.start()
+        version = {{ workload_module }}.get_version()
+        if version is not None:
+            self.unit.set_workload_version(version)
         self.unit.status = ops.ActiveStatus()
 
 

--- a/charmcraft/templates/init-machine/src/workload.py.j2
+++ b/charmcraft/templates/init-machine/src/workload.py.j2
@@ -1,0 +1,2 @@
+# Copyright {{ year }} {{ author }}
+# See LICENSE file for licensing details.

--- a/charmcraft/templates/init-machine/src/workload.py.j2
+++ b/charmcraft/templates/init-machine/src/workload.py.j2
@@ -1,2 +1,34 @@
 # Copyright {{ year }} {{ author }}
 # See LICENSE file for licensing details.
+
+"""Functions for managing and interacting with the workload.
+
+The intention is that this module could be used outside the context of a charm.
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+# Functions for managing the workload process on the local machine:
+
+
+def install() -> None:
+    """Install the workload (by installing a snap, for example)."""
+    # You'll need to implement this function.
+
+
+def start() -> None:
+    """Start the workload (by running a commamd, for example)."""
+    # You'll need to implement this function.
+    # Ideally, this function should only return once the workload is ready to use.
+
+
+# Functions for interacting with the workload, for example over HTTP:
+
+
+def get_version() -> str | None:
+    """Get the running version of the workload."""
+    # You'll need to implement this function (or remove it if not needed).
+    return None

--- a/charmcraft/templates/init-machine/tests/unit/test_charm.py.j2
+++ b/charmcraft/templates/init-machine/tests/unit/test_charm.py.j2
@@ -1,19 +1,26 @@
 # Copyright {{ year }} {{ author }}
 # See LICENSE file for licensing details.
 #
-# Learn more about testing at: https://juju.is/docs/sdk/testing
+# To learn more about testing, see https://ops.readthedocs.io/en/latest/explanation/testing.html
 
-import unittest
-
+import pytest
 from ops import testing
 
 from charm import {{ class_name }}
 
 
-def test_start():
+def mock_get_version():
+    """Get a mock version string without executing the workload code."""
+    return "1.0.0"
+
+
+def test_start(monkeypatch: pytest.MonkeyPatch):
+    """Test that the charm has the correct state after handling the start event."""
     # Arrange:
     ctx = testing.Context({{ class_name }})
+    monkeypatch.setattr("charm.{{ workload_module }}.get_version", mock_get_version)
     # Act:
     state_out = ctx.run(ctx.on.start(), testing.State())
     # Assert:
+    assert state_out.workload_version is not None
     assert state_out.unit_status == testing.ActiveStatus()

--- a/tests/integration/commands/test_init.py
+++ b/tests/integration/commands/test_init.py
@@ -103,7 +103,14 @@ def create_namespace(
         pytest.param("kubernetes", BASIC_INIT_FILES, True, id="kubernetes"),
     ],
 )
-@pytest.mark.parametrize("charm_name", ["my-charm", "charm123"])
+@pytest.mark.parametrize(
+    ("charm_name", "workload_module_filename"),
+    [
+        pytest.param("machine", "workload.py", id="generic_name"),
+        pytest.param("foo-bar-k8s-operator", "foo_bar.py", id="generic_suffix"),
+        pytest.param("charm123", "charm123.py", id="name_with_numbers"),
+    ],
+)
 @pytest.mark.parametrize("author", VALID_AUTHORS)
 def test_files_created_correct(
     new_path,
@@ -112,13 +119,15 @@ def test_files_created_correct(
     base_expected_files: set[pathlib.Path],
     has_workload_module: bool,
     charm_name,
+    workload_module_filename: str,
     author,
 ):
     params = create_namespace(name=charm_name, author=author, profile=profile)
     init_command.run(params)
 
     if has_workload_module:
-        expected_files = base_expected_files.union({pathlib.Path("src/workload.py")})
+        workload_module_path = pathlib.Path(f"src/{workload_module_filename}")
+        expected_files = base_expected_files.union({workload_module_path})
     else:
         expected_files = base_expected_files
 

--- a/tests/integration/commands/test_init.py
+++ b/tests/integration/commands/test_init.py
@@ -96,11 +96,11 @@ def create_namespace(
 
 
 @pytest.mark.parametrize(
-    ("profile", "expected_files"),
+    ("profile", "base_expected_files", "has_workload_module"),
     [
-        pytest.param("simple", BASIC_INIT_FILES, id="simple"),
-        pytest.param("machine", BASIC_INIT_FILES, id="machine"),
-        pytest.param("kubernetes", BASIC_INIT_FILES, id="kubernetes"),
+        pytest.param("simple", BASIC_INIT_FILES, False, id="simple"),
+        pytest.param("machine", BASIC_INIT_FILES, True, id="machine"),
+        pytest.param("kubernetes", BASIC_INIT_FILES, True, id="kubernetes"),
     ],
 )
 @pytest.mark.parametrize("charm_name", ["my-charm", "charm123"])
@@ -109,12 +109,18 @@ def test_files_created_correct(
     new_path,
     init_command,
     profile: str,
-    expected_files: set[pathlib.Path],
+    base_expected_files: set[pathlib.Path],
+    has_workload_module: bool,
     charm_name,
     author,
 ):
     params = create_namespace(name=charm_name, author=author, profile=profile)
     init_command.run(params)
+
+    if has_workload_module:
+        expected_files = base_expected_files.union({pathlib.Path("src/workload.py")})
+    else:
+        expected_files = base_expected_files
 
     actual_files = {p.relative_to(new_path) for p in new_path.rglob("*")}
 


### PR DESCRIPTION
This PR update the `kubernetes` and `machine` profiles to include a standalone module for workload-specific logic. Other profiles are not changed in any way.

In addition to the new workload module, the updated profiles have a bit more structure in `charm.py` to illustrate the basic flow of logic through the charm & workload module, and improved unit tests in `test_charm.py`.

**This PR includes**
- New/updated template files for the `kubernetes` and `machine` profiles.
- Changes to `charmcraft/application/commands/init.py`, to determine the name of the workload module from the charm name (using `workload.py` if the charm has a generic name such as `charm` or `k8s-operator`).
- Changes to `tests/integration/commands/test_init.py`, to test the updated functionality (with tests passing).
- Updated help and output of `charmcraft init`, to make users aware of the workload module.

Hopefully it will be easy to follow my commits in sequence. I tried to make the changes in a logical step-by-step order.

**TODO**
- Check whether any documentation needs updating, and include relevant changes in this PR.
