### PR TITLE
docs: add 12-factor troubleshooting section

### DIFF
--- a/docs/howto/manage-web-app-charms/use-web-app-charm.rst
+++ b/docs/howto/manage-web-app-charms/use-web-app-charm.rst
@@ -38,11 +38,11 @@ deployment is not successful (for instance, if your app crashes).
 Get the app logs
 ~~~~~~~~~~~~~~~~
 
-The first step of troubleshooting is to review the logs for errors. They are
-your first course of action because they flag simple errors caught in the
-stack, but they are also a constant touchpoint when diagnosing and debugging
-issues. You'll first need to obtain the logs for your particular framework
-using Pebble.
+One important step of troubleshooting is to review the app logs for errors.
+They are a vital course of action because they flag any uncaught exceptions in
+your code, but they are also a constant touchpoint when diagnosing and
+debugging issues. You'll first need to obtain the logs for your particular
+framework using Pebble.
 
 To view the Pebble logs for a deployed web app, run:
 

--- a/docs/howto/manage-web-app-charms/use-web-app-charm.rst
+++ b/docs/howto/manage-web-app-charms/use-web-app-charm.rst
@@ -38,8 +38,11 @@ deployment is not successful (for instance, if your app crashes).
 Get the application logs
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you want to check the logs of your web application, use Pebble to view
-the logs.
+The first step of troubleshooting is to review the logs for errors. They are
+your first course of action because they flag simple errors caught in the
+stack, but they are also a constant touchpoint when diagnosing and debugging
+issues. You'll first need to obtain the logs for your particular framework
+using Pebble.
 
 To view the Pebble logs for a deployed web app, run:
 

--- a/docs/howto/manage-web-app-charms/use-web-app-charm.rst
+++ b/docs/howto/manage-web-app-charms/use-web-app-charm.rst
@@ -29,8 +29,8 @@ can be run multiple times) and that it can be run on multiple units simultaneous
 without issue. Handling multiple migration scripts that run concurrently
 can be achieved by, for example, locking any tables during the migration.
 
-Troubleshoot
-------------
+Troubleshoot the charm
+----------------------
 
 This guide provides helpful commands to run in situations where your web app
 deployment is not successful (for instance, if your app crashes).

--- a/docs/howto/manage-web-app-charms/use-web-app-charm.rst
+++ b/docs/howto/manage-web-app-charms/use-web-app-charm.rst
@@ -35,8 +35,8 @@ Troubleshoot the charm
 This guide provides helpful commands to run in situations where your web app
 deployment is not successful (for instance, if your app crashes).
 
-Get the application logs
-~~~~~~~~~~~~~~~~~~~~~~~~
+Get the app logs
+~~~~~~~~~~~~~~~~
 
 The first step of troubleshooting is to review the logs for errors. They are
 your first course of action because they flag simple errors caught in the
@@ -121,8 +121,8 @@ use).
 SSH into the Juju container
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you want to check the logs and status of your web app, or if you
-want to debug the app directly, you can SSH into the Juju container:
+You can debug the app directly and monitor its status by SSHing into the
+Juju container:
 
 .. tabs::
 

--- a/docs/howto/manage-web-app-charms/use-web-app-charm.rst
+++ b/docs/howto/manage-web-app-charms/use-web-app-charm.rst
@@ -72,10 +72,6 @@ To view the Pebble logs for a deployed web app, run:
 
             juju ssh --container app <go-app-name>/0 pebble logs
 
-If your app is :ref:`integrated with the Canonical Observability
-Stack <integrate_web_app_cos>`, then these logs will be sent to Grafana or Loki
-and can be viewable in the web app dashboard.
-
 .. seealso::
 
    `Pebble CLI commands | logs
@@ -314,3 +310,8 @@ Then, click **Run query**.
 The logs shown in the dashboard depend on the web framework, but they are
 typically access logs, or the history of the requests sent to your web
 app and their status codes.
+
+The Pebble logs are available via Grafana or Loki and can be viewed in
+the **WebApp Operator** dashboard for Flask and Django.
+For other frameworks, you may access the logs by picking ``loki`` in the
+``http://<IP_ADDRESS>/<JUJU_MODEL_NAME>-grafana/explore`` page.

--- a/docs/howto/manage-web-app-charms/use-web-app-charm.rst
+++ b/docs/howto/manage-web-app-charms/use-web-app-charm.rst
@@ -163,7 +163,8 @@ Juju container:
 
 If successful, the command opens a SSH shell into the web app. From there,
 you can debug the app itself, manually run an action, or attempt to
-manually start the web app.
+manually start the web app. The web app can be found in the ``/`` directory
+of the container, for instance, ``/django/app``.
 
 .. seealso::
 

--- a/docs/howto/manage-web-app-charms/use-web-app-charm.rst
+++ b/docs/howto/manage-web-app-charms/use-web-app-charm.rst
@@ -77,6 +77,9 @@ To view the Pebble logs for a deployed web app, run:
    `Pebble CLI commands | logs
    <https://documentation.ubuntu.com/pebble/reference/cli-commands/#logs>`_
 
+View app details
+~~~~~~~~~~~~~~~~
+
 To view more details about the web app itself, run:
 
 .. tabs::
@@ -158,7 +161,7 @@ Juju container:
     app has not been properly integrated to the PostgreSQL database), then this
     command will fail as the context does not exist.
 
-If successful, the command opens an SSH shell into the web app. From there,
+If successful, the command opens a SSH shell into the web app. From there,
 you can debug the app itself, manually run an action, or attempt to
 manually start the web app.
 
@@ -171,13 +174,14 @@ manually start the web app.
 Check MicroK8s pod services and logs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Check the currently deployed MicroK8s services with the Kubernetes CLI:
+Check the currently deployed Kubernetes resources in the
+``<model-namespace>``, which is the same as the Juju model name:
 
 .. code::
 
    microk8s.kubectl get all -n <model-namespace>
 
-This command outputs a list of all the MicroK8s services in the web app's
+This command outputs a list of all the MicroK8s resources in the web app's
 Juju model.
 
 Check the logs for a specific MicroK8s pod:

--- a/docs/howto/manage-web-app-charms/use-web-app-charm.rst
+++ b/docs/howto/manage-web-app-charms/use-web-app-charm.rst
@@ -72,9 +72,9 @@ To view the Pebble logs for a deployed web app, run:
 
             juju ssh --container app <go-app-name>/0 pebble logs
 
-If your application is :ref:`integrated with the Canonical Observability
+If your app is :ref:`integrated with the Canonical Observability
 Stack <integrate_web_app_cos>`, then these logs will be sent to Grafana or Loki
-and can be viewable in the web application dashboard.
+and can be viewable in the web app dashboard.
 
 .. seealso::
 
@@ -121,8 +121,8 @@ use).
 SSH into the Juju container
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you want to check the logs and status of your web application, or if you
-want to debug the application directly, you can SSH into the Juju container:
+If you want to check the logs and status of your web app, or if you
+want to debug the app directly, you can SSH into the Juju container:
 
 .. tabs::
 
@@ -301,8 +301,8 @@ framework of your web app.
 
   :ref:`Django framework extension | Grafana dashboard graphs <django-grafana-graphs>`
 
-View application logs
-~~~~~~~~~~~~~~~~~~~~~
+View app logs
+~~~~~~~~~~~~~
 
 Go to ``http://<IP_ADDRESS>/<JUJU_MODEL_NAME>-grafana/explore``, where
 the URL is the one you fetched previously.

--- a/docs/howto/manage-web-app-charms/use-web-app-charm.rst
+++ b/docs/howto/manage-web-app-charms/use-web-app-charm.rst
@@ -29,6 +29,227 @@ can be run multiple times) and that it can be run on multiple units simultaneous
 without issue. Handling multiple migration scripts that run concurrently
 can be achieved by, for example, locking any tables during the migration.
 
+Troubleshoot
+------------
+
+This guide provides helpful commands to run in situations where your web app
+deployment is not successful (for instance, if your app crashes).
+
+Get the application logs
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you want to check the logs of your web application, use Pebble to view
+the logs.
+
+To view the Pebble logs for a deployed web app, run:
+
+.. tabs::
+
+    .. group-tab:: Django
+
+        .. code-block:: bash
+
+            juju ssh --container django-app <django-app-name>/0 pebble logs
+
+    .. group-tab:: FastAPI
+
+        .. code-block:: bash
+
+            juju ssh --container app <fastapi-app-name>/0 pebble logs
+
+    .. group-tab:: Flask
+
+        .. code-block:: bash
+
+            juju ssh --container flask-app <flask-app-name>/0 pebble logs
+
+    .. group-tab:: Go
+
+        .. code-block:: bash
+
+            juju ssh --container app <go-app-name>/0 pebble logs
+
+If your application is :ref:`integrated with the Canonical Observability
+Stack <integrate_web_app_cos>`, then these logs will be sent to Grafana or Loki
+and can be viewable in the web application dashboard.
+
+.. seealso::
+
+   `Pebble CLI commands | logs
+   <https://documentation.ubuntu.com/pebble/reference/cli-commands/#logs>`_
+
+To view more details about the web app itself, run:
+
+.. tabs::
+
+    .. group-tab:: Django
+
+        .. code-block:: bash
+
+            juju ssh --container django-app <django-app-name>/0 pebble plan
+
+    .. group-tab:: FastAPI
+
+        .. code-block:: bash
+
+            juju ssh --container app <fastapi-app-name>/0 pebble plan
+
+    .. group-tab:: Flask
+
+        .. code-block:: bash
+
+            juju ssh --container flask-app <flask-app-name>/0 pebble plan
+
+    .. group-tab:: Go
+
+        .. code-block:: bash
+
+            juju ssh --container app <go-app-name>/0 pebble plan
+
+This command provides information on what services you may start in your app
+and what environment variables exist (i.e., what is available for the app to
+use).
+
+.. seealso::
+
+   `Pebble CLI commands | plan
+   <https://documentation.ubuntu.com/pebble/reference/cli-commands/#plan>`_
+
+SSH into the Juju container
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you want to check the logs and status of your web application, or if you
+want to debug the application directly, you can SSH into the Juju container:
+
+.. tabs::
+
+    .. group-tab:: Django
+
+        .. code-block:: bash
+
+            juju ssh --container django-app <django-app-name>/0 \
+              pebble exec --context=django -- bash
+
+    .. group-tab:: FastAPI
+
+        .. code-block:: bash
+
+            juju ssh --container app <fastapi-app-name>/0 \
+              pebble exec --context=fastapi -- bash
+
+    .. group-tab:: Flask
+
+        .. code-block:: bash
+
+            juju ssh --container flask-app <flask-app-name>/0 \
+              pebble exec --context=flask -- bash
+
+    .. group-tab:: Go
+
+        .. code-block:: bash
+
+            juju ssh --container app <go-app-name>/0 \
+              pebble exec --context=go -- bash
+
+.. important::
+
+    This command is specific to the ``context`` of your web app and will run
+    successfully only if the ``context`` already exists, in other words, if the
+    app has been started. If the app has not been started (for instance, if the
+    app has not been properly integrated to the PostgreSQL database), then this
+    command will fail as the context does not exist.
+
+If successful, the command opens an SSH shell into the web app. From there,
+you can debug the app itself, manually run an action, or attempt to
+manually start the web app.
+
+.. seealso::
+
+   `Juju documentation | ssh
+   <https://documentation.ubuntu.com/juju/latest/user/reference/
+   juju-cli/list-of-juju-cli-commands/ssh/>`_
+
+Check MicroK8s pod services and logs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Check the currently deployed MicroK8s services with the Kubernetes CLI:
+
+.. code::
+
+   microk8s.kubectl get all -n <model-namespace>
+
+This command outputs a list of all the MicroK8s services in the web app's
+Juju model.
+
+Check the logs for a specific MicroK8s pod:
+
+.. code::
+
+   microk8s kubectl logs <pod-name> -n <model-namespace>
+
+This command outputs the logs of the sidecar container pod. To fetch logs
+specific to the workload of the web app, you need to specify the container
+name of the web app with the ``-c`` option.
+
+.. tabs::
+
+    .. group-tab:: Django
+
+        .. code-block:: bash
+
+            microk8s kubectl logs <pod-name> -n <model-namespace> -c django-app
+
+    .. group-tab:: FastAPI
+
+        .. code-block:: bash
+
+            microk8s kubectl logs <pod-name> -n <model-namespace> -c app
+
+    .. group-tab:: Flask
+
+        .. code-block:: bash
+
+            microk8s kubectl logs <pod-name> -n <model-namespace> -c flask-app
+
+    .. group-tab:: Go
+
+        .. code-block:: bash
+
+            microk8s kubectl logs <pod-name> -n <model-namespace> -c app
+
+.. seealso::
+
+   `MicroK8s | Troubleshooting <https://microk8s.io/docs/troubleshooting>`_
+
+Check Juju logs
+~~~~~~~~~~~~~~~
+
+If you want to check the logs and status of your web app charm, Juju contains
+debugging and logging information.
+
+Use ``juju debug-log`` to view a running log for the model on which you
+deployed your web app. The log outputs live messages and errors related to the
+charm that you can follow (tail). To stop following the logs,
+press :kbd:`Ctrl` + :kbd:`C`.
+
+You can also update the model configuration to output more charm debugging
+information using
+``juju model-config "logging-config=<root>=INFO;unit=DEBUG"``.
+
+.. seealso::
+
+   `Juju documentation | How to manage logs
+   <https://documentation.ubuntu.com/juju/latest/user/howto/manage-logs/>`_
+
+
+Report an issue
+~~~~~~~~~~~~~~~
+
+If you cannot solve your issue, please reach out to us on
+`Matrix <https://matrix.to/#/#12-factor-charms:ubuntu.com>`_ for hands-on
+debugging. When describing your issue, please include the output of the
+Juju and Pebble logs.
+
 Use observability
 -----------------
 


### PR DESCRIPTION
Add a troubleshooting section into the "Use a 12-factor app charm" page that covers how a user would access logs (Juju, application, MicroK8s) and how the user can SSH into the Juju container for more in-depth debugging. 

Additional reviewers: @javierdelapuente @jdkandersson 