### PR TITLE
Docs: Updated 12-factor tutorials

### DIFF
--- a/docs/reuse/tutorial/setup_edge.rst
+++ b/docs/reuse/tutorial/setup_edge.rst
@@ -1,8 +1,3 @@
-.. warning::
-
-    This tutorial requires version ``3.2.0`` or later of Charmcraft.
-    Check the version of Charmcraft using ``charmcraft --version``.
-
 First, install Multipass.
 
 .. seealso::

--- a/docs/reuse/tutorial/setup_edge.rst
+++ b/docs/reuse/tutorial/setup_edge.rst
@@ -28,7 +28,7 @@ classic confinement, which grants it access to the whole file system:
 
 .. code-block:: bash
 
-    sudo snap install rockcraft --classic
+    sudo snap install rockcraft --channel latest/edge --classic
 
 
 LXD will be required for building the rock.

--- a/docs/reuse/tutorial/setup_stable.rst
+++ b/docs/reuse/tutorial/setup_stable.rst
@@ -1,11 +1,3 @@
-.. warning::
-
-    This tutorial requires version ``3.2.0`` or later of Charmcraft. Check the
-    version of Charmcraft using ``charmcraft --version`` If you have an older
-    version of Charmcraft installed, use
-    ``sudo snap refresh charmcraft --channel latest/edge`` to get the latest
-    edge version of Charmcraft.
-
 First, install Multipass.
 
 .. seealso::

--- a/docs/tutorial/kubernetes-charm-django.rst
+++ b/docs/tutorial/kubernetes-charm-django.rst
@@ -83,9 +83,8 @@ Create the Django app
 Let's start by creating the "Hello, world" Django app that
 will be used for this tutorial.
 
-Create and open a new file ``requirements.txt`` in a text editor using
-``nano requirements.txt``, copy the following text into it and then
-save the file:
+Create a new requirements file with ``nano requirements.txt``.
+Then, copy the following text into it, and save:
 
 .. literalinclude:: code/django/requirements.txt
     :caption: ~/django-hello-world/requirements.txt

--- a/docs/tutorial/kubernetes-charm-django.rst
+++ b/docs/tutorial/kubernetes-charm-django.rst
@@ -25,7 +25,7 @@ This tutorial should take 90 minutes for you to complete.
     A rock is a special kind of OCI-compliant container image, while a
     charm is a software operator for cloud operations that use the Juju
     orchestration engine. The result is Django apps that
-    can be easily deployed, configured, scaled, integrated, etc.,
+    can be deployed, configured, scaled, integrated, etc.,
     on any Kubernetes cluster.
 
 
@@ -226,7 +226,7 @@ Django apps require a database. Django will use a sqlite
 database by default. This won't work on Kubernetes because the database
 would disappear every time the pod is restarted -- e.g., to perform an
 upgrade -- and this database wouldn't be shared by all containers as the
-app is scaled. We'll use Juju later to easily deploy a database.
+app is scaled. We'll use Juju later to deploy a database.
 
 We'll need to update the ``settings.py`` file to prepare for integrating
 the app with a database. From the ``~/django-hello-world`` directory, open

--- a/docs/tutorial/kubernetes-charm-django.rst
+++ b/docs/tutorial/kubernetes-charm-django.rst
@@ -298,11 +298,6 @@ Now let's pack the rock:
     :end-before: [docs:pack-end]
     :dedent: 2
 
-.. note::
-
-    In older versions of Rockcraft, you might need to set
-    ``ROCKCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS=true`` before the pack command.
-
 Depending on your system and network, this step can take several minutes to
 finish.
 

--- a/docs/tutorial/kubernetes-charm-django.rst
+++ b/docs/tutorial/kubernetes-charm-django.rst
@@ -25,7 +25,7 @@ This tutorial should take 90 minutes for you to complete.
     A rock is a special kind of OCI-compliant container image, while a
     charm is a software operator for cloud operations that use the Juju
     orchestration engine. The result is Django apps that
-    can be deployed, configured, scaled, integrated, etc.,
+    can be deployed, configured, scaled, integrated, and so on,
     on any Kubernetes cluster.
 
 

--- a/docs/tutorial/kubernetes-charm-django.rst
+++ b/docs/tutorial/kubernetes-charm-django.rst
@@ -83,9 +83,9 @@ Create the Django app
 Let's start by creating the "Hello, world" Django app that
 will be used for this tutorial.
 
-Create a ``requirements.txt`` file using ``touch requirements.txt``.
-Then, open the file in a text editor using ``nano requirements.txt``,
-copy the following text into it and then save the file:
+Create and open a new file ``requirements.txt`` in a text editor using
+``nano requirements.txt``, copy the following text into it and then
+save the file:
 
 .. literalinclude:: code/django/requirements.txt
     :caption: ~/django-hello-world/requirements.txt

--- a/docs/tutorial/kubernetes-charm-fastapi.rst
+++ b/docs/tutorial/kubernetes-charm-fastapi.rst
@@ -80,9 +80,9 @@ Create the FastAPI app
 Start by creating the "Hello, world" FastAPI app that will be used for
 this tutorial.
 
-Create a ``requirements.txt`` file using ``touch requirements.txt``.
-Then, open the file in a text editor using ``nano requirements.txt``,
-copy the following text into it and then save the file:
+Create and open a new file ``requirements.txt`` in a text editor using
+``nano requirements.txt``, copy the following text into it and then
+save the file:
 
 .. literalinclude:: code/fastapi/requirements.txt
     :caption: ~/fastapi-hello-world/requirements.txt

--- a/docs/tutorial/kubernetes-charm-fastapi.rst
+++ b/docs/tutorial/kubernetes-charm-fastapi.rst
@@ -22,7 +22,7 @@ This tutorial should take 90 minutes for you to complete.
     A rock is a special kind of OCI-compliant container image, while a
     charm is a software operator for cloud operations that use the Juju
     orchestration engine. The result is a FastAPI app that
-    can be deployed, configured, scaled, integrated, etc.,
+    can be deployed, configured, scaled, integrated, and so on,
     on any Kubernetes cluster.
 
 

--- a/docs/tutorial/kubernetes-charm-fastapi.rst
+++ b/docs/tutorial/kubernetes-charm-fastapi.rst
@@ -22,7 +22,7 @@ This tutorial should take 90 minutes for you to complete.
     A rock is a special kind of OCI-compliant container image, while a
     charm is a software operator for cloud operations that use the Juju
     orchestration engine. The result is a FastAPI app that
-    can be easily deployed, configured, scaled, integrated, etc.,
+    can be deployed, configured, scaled, integrated, etc.,
     on any Kubernetes cluster.
 
 

--- a/docs/tutorial/kubernetes-charm-fastapi.rst
+++ b/docs/tutorial/kubernetes-charm-fastapi.rst
@@ -80,9 +80,8 @@ Create the FastAPI app
 Start by creating the "Hello, world" FastAPI app that will be used for
 this tutorial.
 
-Create and open a new file ``requirements.txt`` in a text editor using
-``nano requirements.txt``, copy the following text into it and then
-save the file:
+Create a new requirements file with ``nano requirements.txt``.
+Then, copy the following text into it, and save:
 
 .. literalinclude:: code/fastapi/requirements.txt
     :caption: ~/fastapi-hello-world/requirements.txt

--- a/docs/tutorial/kubernetes-charm-flask.rst
+++ b/docs/tutorial/kubernetes-charm-flask.rst
@@ -21,7 +21,7 @@ This tutorial should take 90 minutes for you to complete.
     A rock is a special kind of OCI-compliant container image, while a
     charm is a software operator for cloud operations that use the Juju
     orchestration engine. The result is a Flask app that
-    can be deployed, configured, scaled, integrated, etc.,
+    can be deployed, configured, scaled, integrated, and so on,
     on any Kubernetes cluster.
 
 

--- a/docs/tutorial/kubernetes-charm-flask.rst
+++ b/docs/tutorial/kubernetes-charm-flask.rst
@@ -79,9 +79,8 @@ Create the Flask app
 Let's start by creating the "Hello, world" Flask app that
 will be used for this tutorial.
 
-Create and open a new file ``requirements.txt`` in a text editor using
-``nano requirements.txt``, copy the following text into it and then
-save the file:
+Create a new requirements file with ``nano requirements.txt``.
+Then, copy the following text into it, and save:
 
 .. literalinclude:: code/flask/requirements.txt
     :caption: ~/flask-hello-world/requirements.txt

--- a/docs/tutorial/kubernetes-charm-flask.rst
+++ b/docs/tutorial/kubernetes-charm-flask.rst
@@ -21,7 +21,7 @@ This tutorial should take 90 minutes for you to complete.
     A rock is a special kind of OCI-compliant container image, while a
     charm is a software operator for cloud operations that use the Juju
     orchestration engine. The result is a Flask app that
-    can be easily deployed, configured, scaled, integrated, etc.,
+    can be deployed, configured, scaled, integrated, etc.,
     on any Kubernetes cluster.
 
 

--- a/docs/tutorial/kubernetes-charm-flask.rst
+++ b/docs/tutorial/kubernetes-charm-flask.rst
@@ -79,9 +79,9 @@ Create the Flask app
 Let's start by creating the "Hello, world" Flask app that
 will be used for this tutorial.
 
-Create a ``requirements.txt`` file using ``touch requirements.txt``.
-Then, open the file in a text editor using ``nano requirements.txt``,
-copy the following text into it and then save the file:
+Create and open a new file ``requirements.txt`` in a text editor using
+``nano requirements.txt``, copy the following text into it and then
+save the file:
 
 .. literalinclude:: code/flask/requirements.txt
     :caption: ~/flask-hello-world/requirements.txt

--- a/docs/tutorial/kubernetes-charm-go.rst
+++ b/docs/tutorial/kubernetes-charm-go.rst
@@ -21,7 +21,7 @@ This tutorial should take 90 minutes for you to complete.
     A rock is a special kind of OCI-compliant container image, while a
     charm is a software operator for cloud operations that use the Juju
     orchestration engine. The result is a Go app that
-    can be deployed, configured, scaled, integrated, etc.,
+    can be deployed, configured, scaled, integrated, and so on,
     on any Kubernetes cluster.
 
 

--- a/docs/tutorial/kubernetes-charm-go.rst
+++ b/docs/tutorial/kubernetes-charm-go.rst
@@ -81,8 +81,8 @@ Install ``go`` and initialize the Go module:
     :end-before: [docs:install-init-go-end]
     :dedent: 2
 
-Create and open a ``main.go`` file in a text editor using ``nano main.go``,
-copy the following text into it and then save the file:
+Create a new Go program file with ``nano main.go``.
+Then, copy the following text into it, and save:
 
 .. literalinclude:: code/go/main.go
     :caption: ~/go-hello-world/main.go

--- a/docs/tutorial/kubernetes-charm-go.rst
+++ b/docs/tutorial/kubernetes-charm-go.rst
@@ -21,7 +21,7 @@ This tutorial should take 90 minutes for you to complete.
     A rock is a special kind of OCI-compliant container image, while a
     charm is a software operator for cloud operations that use the Juju
     orchestration engine. The result is a Go app that
-    can be easily deployed, configured, scaled, integrated, etc.,
+    can be deployed, configured, scaled, integrated, etc.,
     on any Kubernetes cluster.
 
 

--- a/docs/tutorial/kubernetes-charm-go.rst
+++ b/docs/tutorial/kubernetes-charm-go.rst
@@ -81,8 +81,7 @@ Install ``go`` and initialize the Go module:
     :end-before: [docs:install-init-go-end]
     :dedent: 2
 
-Create a ``main.go`` file using ``touch main.go``.
-Then, open the file in a text editor using ``nano main.go``,
+Create and open a ``main.go`` file in a text editor using ``nano main.go``,
 copy the following text into it and then save the file:
 
 .. literalinclude:: code/go/main.go


### PR DESCRIPTION
Updates to the 12-factor tutorials that affect the reusable setup files and all four tutorials. Some of these changes were suggested by @evildmp in https://github.com/canonical/charmcraft/issues/2235

### Summary of changes
* Updated the `setup_edge.rst` file to install the `latest/edge` channel of Rockcraft.
* Removed an admonition block in the Django tutorial that warned users about using an older version of Rockcraft. 
* Removed any mentions of "easily" in the tutorials.
* Removed `touch` from the instructions and ask users to instead open the new file directly with `nano`.
* Removed the admonition block warning users about the Charmcraft version.