### PR TITLE
feat(upload): warn when uploading a charm if it has newer local libs

### DIFF
--- a/charmcraft/application/commands/store.py
+++ b/charmcraft/application/commands/store.py
@@ -58,6 +58,8 @@ from charmcraft.utils import cli
 if TYPE_CHECKING:
     from argparse import ArgumentParser, Namespace
 
+    from charmcraft.services.charmlibs import CharmLibsService
+
 
 # some types
 class _EntityType(typing.NamedTuple):
@@ -586,6 +588,15 @@ class UploadCommand(CharmcraftCommand):
     common = True
     format_option = True
 
+    @override
+    def needs_project(self, parsed_args: argparse.Namespace) -> bool:
+        """Determine whether this command needs a project.
+
+        The implementation here is that we need a project if we're in a project
+        directory, allowing us to examine unpublished libraries.
+        """
+        return pathlib.Path("charmcraft.yaml").exists()
+
     def fill_parser(self, parser):
         """Add own parameters to the general parser."""
         super().fill_parser(parser)
@@ -614,7 +625,7 @@ class UploadCommand(CharmcraftCommand):
             ),
         )
 
-    def run(self, parsed_args):
+    def run(self, parsed_args: argparse.Namespace) -> int:
         """Run the command."""
         if parsed_args.name:
             name = parsed_args.name
@@ -635,6 +646,42 @@ class UploadCommand(CharmcraftCommand):
                 for error in result.errors:
                     emit.message(f"- {error.code}: {error.message}")
             return 1
+
+        if self._services.project:
+            libs_service = cast("CharmLibsService", self._services.get("charm_libs"))
+            unpublished_libs = libs_service.get_unpublished_libs()
+            if unpublished_libs:
+                emit.progress(
+                    "WARNING: some local charmlibs owned by this charm are not published on the store",
+                    permanent=True,
+                )
+                display_libs = [
+                    {
+                        "name": f"{self._services.project.name}.{lib.lib_name}",
+                        "local": "N/A"
+                        if not lib.local_version
+                        else ".".join(str(i) for i in lib.local_version),
+                        "store": "N/A"
+                        if not lib.store_version
+                        else ".".join(str(i) for i in lib.store_version),
+                    }
+                    for lib in unpublished_libs
+                ]
+                emit.progress(
+                    tabulate(
+                        display_libs,
+                        headers={
+                            "name": "Name",
+                            "local": "Local version",
+                            "store": "Store version",
+                        },
+                        tablefmt="plain",
+                        disable_numparse=True,
+                    ),
+                    permanent=True,
+                )
+        else:
+            emit.verbose("Not examining on-disk project.")
 
         if parsed_args.release:
             # also release!

--- a/charmcraft/services/store.py
+++ b/charmcraft/services/store.py
@@ -32,7 +32,12 @@ from overrides import override
 from charmcraft import const, env, errors, store
 from charmcraft.models import CharmLib
 from charmcraft.store import AUTH_DEFAULT_PERMISSIONS, AUTH_DEFAULT_TTL
-from charmcraft.store.models import ChannelData, Library, LibraryMetadataRequest
+from charmcraft.store.models import (
+    ChannelData,
+    Library,
+    LibraryMetadataIdRequest,
+    LibraryMetadataRequest,
+)
 
 
 class BaseStoreService(craft_application.AppService):
@@ -399,3 +404,13 @@ class StoreService(BaseStoreService):
         return self.anonymous_client.get_library(
             charm_name=charm_name, library_id=library_id, api=api, patch=patch
         )
+
+    def get_libraries_metadata_by_id(self, *lib_id: str) -> Mapping[str, Library]:
+        """Get the metadata for a set of libraries by their IDs."""
+        store_requests = [
+            LibraryMetadataIdRequest({"library-id": lib}) for lib in lib_id
+        ]
+        return {
+            lib.lib_id: lib
+            for lib in self.anonymous_client.fetch_libraries_metadata(store_requests)
+        }

--- a/charmcraft/store/client.py
+++ b/charmcraft/store/client.py
@@ -32,7 +32,11 @@ from requests_toolbelt import (  # type: ignore[import]
 )
 
 from charmcraft import __version__, const, utils
-from charmcraft.store.models import Library, LibraryMetadataRequest
+from charmcraft.store.models import (
+    Library,
+    LibraryMetadataIdRequest,
+    LibraryMetadataRequest,
+)
 
 TESTING_ENV_PREFIXES = ["TRAVIS", "AUTOPKGTEST_TMP"]
 
@@ -106,7 +110,7 @@ class AnonymousClient:
         )
 
     def fetch_libraries_metadata(
-        self, libs: Sequence[LibraryMetadataRequest]
+        self, libs: Sequence[LibraryMetadataRequest | LibraryMetadataIdRequest]
     ) -> Sequence[Library]:
         """Fetch the metadata for one or more charm libraries.
 

--- a/charmcraft/store/models.py
+++ b/charmcraft/store/models.py
@@ -307,3 +307,4 @@ LibraryMetadataRequest = TypedDict(
         "patch": NotRequired[int],
     },
 )
+LibraryMetadataIdRequest = TypedDict("LibraryMetadataIdRequest", {"library-id": str})

--- a/tests/integration/services/test_charmlibs.py
+++ b/tests/integration/services/test_charmlibs.py
@@ -1,0 +1,73 @@
+# Copyright 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For further info, check https://github.com/canonical/charmcraft
+"""Integration tests for charmlibs service."""
+
+import pytest
+
+from charmcraft import services
+from charmcraft.services.charmlibs import CharmLibDelta
+from charmcraft.store.models import Library
+
+
+@pytest.fixture
+def service(service_factory):
+    return service_factory.get("charm_libs")
+
+
+# This test is marked as slow because it hits the real charmhub.
+@pytest.mark.slow
+@pytest.mark.parametrize(
+    ("local_libs", "expected"),
+    [
+        pytest.param({}, [], id="no-libs"),
+        pytest.param(
+            {
+                "lib/charms/charmcraft_test_charm/v0/test_lib.py": 'LIBID = "e000776021fd4b73ade744727654ac72"\nLIBAPI = 0\nLIBPATCH = 1'
+            },
+            [],
+            id="up-to-date-lib",
+        ),
+        pytest.param(
+            {
+                "lib/charms/charmcraft_test_charm/v0/unpublished_lib.py": 'LIBID = "unpublished"\nLIBAPI = 0\nLIBPATCH = 1'
+            },
+            [CharmLibDelta("unpublished_lib", (0, 1), None)],
+            id="unpublished-lib",
+        ),
+        pytest.param(
+            {
+                "lib/charms/charmcraft_test_charm/v0/test_lib.py": 'LIBID = "e000776021fd4b73ade744727654ac72"\nLIBAPI = 0\nLIBPATCH = 2'
+            },
+            [CharmLibDelta("test_lib", (0, 2), (0, 1))],
+            id="out-of-date-lib",
+        ),
+    ],
+)
+def test_get_unpublished_libs(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+    service: services.CharmLibsService,
+    local_libs: dict[str, Library],
+    expected: list[CharmLibDelta],
+):
+    service._project_dir = tmp_path
+    service._project.name = "charmcraft-test-charm"
+    for lib_path_str, lib_contents in local_libs.items():
+        lib_path = tmp_path / lib_path_str
+        lib_path.parent.mkdir(parents=True)
+        lib_path.write_text(lib_contents)
+
+    assert service.get_unpublished_libs() == expected


### PR DESCRIPTION
This warns the user when uploading a charm if said charm has local charmlibs that are newer than what's available on the store.

CRAFT-890
Fixes #213
