### PR TITLE
Docs: 12-factor tutorial updates

### DIFF
--- a/docs/tutorial/kubernetes-charm-django.rst
+++ b/docs/tutorial/kubernetes-charm-django.rst
@@ -217,7 +217,7 @@ the architecture of your system:
 
     dpkg --print-architecture
 
-Edit the ``platforms`` entry in ``rockcraft.yaml`` if required.
+Edit the ``platforms`` key in ``rockcraft.yaml`` if required.
 
 Django apps require a database. Django will use a sqlite
 database by default. This won't work on Kubernetes because the database

--- a/docs/tutorial/kubernetes-charm-django.rst
+++ b/docs/tutorial/kubernetes-charm-django.rst
@@ -544,7 +544,7 @@ Add a "Hello, world" app
 
 In this iteration, we'll add a greeting app that returns a ``Hello, world!`` greeting.
 
-The generated Django app doesn't come with an app, which is why
+The generated Django project doesn't come with an app, which is why
 we had to initially enable debug mode for testing.  We will need to go back
 out to the ``~/django-hello-world`` directory where the rock is and enter
 into the ``./django_hello_world`` directory where the Django app

--- a/docs/tutorial/kubernetes-charm-django.rst
+++ b/docs/tutorial/kubernetes-charm-django.rst
@@ -406,8 +406,7 @@ the Django app. Let's create a new model:
     :end-before: [docs:add-juju-model-end]
     :dedent: 2
 
-Include a constraint to the Juju model to specify your architecture if you
-aren't on a host with AMD64:
+Include a constraint to the Juju model to specify your architecture:
 
 .. literalinclude:: code/django/task.yaml
     :language: bash

--- a/docs/tutorial/kubernetes-charm-django.rst
+++ b/docs/tutorial/kubernetes-charm-django.rst
@@ -23,7 +23,7 @@ specifically supported with a template to quickly generate a
 **rock** and a matching template to generate a **charm**.
 A rock is a special kind of OCI-compliant container image, while a
 charm is a software operator for cloud operations that use the Juju
-orchestration engine. The result is Django apps that
+orchestration engine. The combined result is a Django app that
 can be deployed, configured, scaled, integrated, and so on,
 on any Kubernetes cluster.
 

--- a/docs/tutorial/kubernetes-charm-django.rst
+++ b/docs/tutorial/kubernetes-charm-django.rst
@@ -153,8 +153,8 @@ Multipass VM, run:
 
 With the Multipass IP address, we can visit the Django app in a web
 browser. Open a new tab and visit
-``http://<MULTIPASS_PRIVATE_IP>:8000``, replacing
-``<MULTIPASS_PRIVATE_IP>`` with your VM's private IP address.
+``http://<Multipass private IP>:8000``, replacing
+``<Multipass private IP>`` with your VM's private IP address.
 
 The Django app should respond in the browser with
 ``The install worked successfully! Congratulations!``.
@@ -521,9 +521,9 @@ and add a line like the following:
 
 .. code-block:: bash
 
-    <MULTIPASS_PRIVATE_IP> django-hello-world
+    <Multipass private IP> django-hello-world
 
-Here, replace ``<MULTIPASS_PRIVATE_IP>`` with the same Multipass VM
+Here, replace ``<Multipass private IP>`` with the same Multipass VM
 private IP address you previously used.
 
 Now you can open a new tab and visit http://django-hello-world. The

--- a/docs/tutorial/kubernetes-charm-django.rst
+++ b/docs/tutorial/kubernetes-charm-django.rst
@@ -218,8 +218,7 @@ the architecture of your system:
 
     dpkg --print-architecture
 
-If your host uses ARM architecture, open ``rockcraft.yaml`` in a
-text editor, comment out ``amd64``, and include ``arm64`` under ``platforms``.
+Edit the ``platforms`` entry in ``rockcraft.yaml`` if required.
 
 Django apps require a database. Django will use a sqlite
 database by default. This won't work on Kubernetes because the database

--- a/docs/tutorial/kubernetes-charm-django.rst
+++ b/docs/tutorial/kubernetes-charm-django.rst
@@ -18,15 +18,14 @@ running with Juju. Let's get started!
 
 This tutorial should take 90 minutes for you to complete.
 
-.. note::
-    If you're new to the charming world, Django apps are
-    specifically supported with a template to quickly generate a
-    **rock** and a matching template to generate a **charm**.
-    A rock is a special kind of OCI-compliant container image, while a
-    charm is a software operator for cloud operations that use the Juju
-    orchestration engine. The result is Django apps that
-    can be deployed, configured, scaled, integrated, and so on,
-    on any Kubernetes cluster.
+If you're new to the charming world, Django apps are
+specifically supported with a template to quickly generate a
+**rock** and a matching template to generate a **charm**.
+A rock is a special kind of OCI-compliant container image, while a
+charm is a software operator for cloud operations that use the Juju
+orchestration engine. The result is Django apps that
+can be deployed, configured, scaled, integrated, and so on,
+on any Kubernetes cluster.
 
 
 What you'll need

--- a/docs/tutorial/kubernetes-charm-django.rst
+++ b/docs/tutorial/kubernetes-charm-django.rst
@@ -211,7 +211,7 @@ The top of the file should look similar to the following snippet:
 
 Verify that the ``name`` is ``django-hello-world``.
 
-Ensure that ``platforms`` includes the architecture of your host. Check
+The ``platforms`` must match the architecture of your host. Check
 the architecture of your system:
 
 .. code-block:: bash

--- a/docs/tutorial/kubernetes-charm-django.rst
+++ b/docs/tutorial/kubernetes-charm-django.rst
@@ -210,7 +210,7 @@ The top of the file should look similar to the following snippet:
 
 Verify that the ``name`` is ``django-hello-world``.
 
-The ``platforms`` must match the architecture of your host. Check
+The ``platforms`` key must match the architecture of your host. Check
 the architecture of your system:
 
 .. code-block:: bash

--- a/docs/tutorial/kubernetes-charm-django.rst
+++ b/docs/tutorial/kubernetes-charm-django.rst
@@ -404,7 +404,7 @@ the Django app. Let's create a new model:
     :end-before: [docs:add-juju-model-end]
     :dedent: 2
 
-Include a constraint to the Juju model to specify your architecture:
+Constrain the Juju model to your architecture:
 
 .. literalinclude:: code/django/task.yaml
     :language: bash

--- a/docs/tutorial/kubernetes-charm-fastapi.rst
+++ b/docs/tutorial/kubernetes-charm-fastapi.rst
@@ -15,15 +15,14 @@ up and running with Juju. Let's get started!
 
 This tutorial should take 90 minutes for you to complete.
 
-.. note::
-    If you're new to the charming world, FastAPI apps are
-    specifically supported with a template to quickly generate a
-    **rock** and a matching template to generate a **charm**.
-    A rock is a special kind of OCI-compliant container image, while a
-    charm is a software operator for cloud operations that use the Juju
-    orchestration engine. The result is a FastAPI app that
-    can be deployed, configured, scaled, integrated, and so on,
-    on any Kubernetes cluster.
+If you're new to the charming world, FastAPI apps are
+specifically supported with a template to quickly generate a
+**rock** and a matching template to generate a **charm**.
+A rock is a special kind of OCI-compliant container image, while a
+charm is a software operator for cloud operations that use the Juju
+orchestration engine. The result is a FastAPI app that
+can be deployed, configured, scaled, integrated, and so on,
+on any Kubernetes cluster.
 
 
 What you'll need

--- a/docs/tutorial/kubernetes-charm-fastapi.rst
+++ b/docs/tutorial/kubernetes-charm-fastapi.rst
@@ -188,7 +188,7 @@ the architecture of your system:
 
     dpkg --print-architecture
 
-Edit the ``platforms`` entry in ``rockcraft.yaml`` if required.
+Edit the ``platforms`` key in ``rockcraft.yaml`` if required.
 
 Now let's pack the rock:
 

--- a/docs/tutorial/kubernetes-charm-fastapi.rst
+++ b/docs/tutorial/kubernetes-charm-fastapi.rst
@@ -345,8 +345,7 @@ the FastAPI app. Let's create a new model:
     :end-before: [docs:add-juju-model-end]
     :dedent: 2
 
-Include a constraint to the Juju model to specify your architecture if you
-aren't on a host with AMD64:
+Include a constraint to the Juju model to specify your architecture:
 
 .. literalinclude:: code/fastapi/task.yaml
     :language: bash

--- a/docs/tutorial/kubernetes-charm-fastapi.rst
+++ b/docs/tutorial/kubernetes-charm-fastapi.rst
@@ -189,8 +189,7 @@ the architecture of your system:
 
     dpkg --print-architecture
 
-If your host uses the ARM architecture, open ``rockcraft.yaml`` in a
-text editor, comment out ``amd64``, and include ``arm64`` in ``platforms``.
+Edit the ``platforms`` entry in ``rockcraft.yaml`` if required.
 
 Now let's pack the rock:
 

--- a/docs/tutorial/kubernetes-charm-fastapi.rst
+++ b/docs/tutorial/kubernetes-charm-fastapi.rst
@@ -343,7 +343,7 @@ the FastAPI app. Let's create a new model:
     :end-before: [docs:add-juju-model-end]
     :dedent: 2
 
-Include a constraint to the Juju model to specify your architecture:
+Constrain the Juju model to your architecture:
 
 .. literalinclude:: code/fastapi/task.yaml
     :language: bash

--- a/docs/tutorial/kubernetes-charm-fastapi.rst
+++ b/docs/tutorial/kubernetes-charm-fastapi.rst
@@ -182,7 +182,7 @@ The top of the file should look similar to the following snippet:
 
 Verify that the ``name`` is ``fastapi-hello-world``.
 
-Ensure that ``platforms`` includes the architecture of your host. Check
+The ``platforms`` must match the architecture of your host. Check
 the architecture of your system:
 
 .. code-block:: bash

--- a/docs/tutorial/kubernetes-charm-fastapi.rst
+++ b/docs/tutorial/kubernetes-charm-fastapi.rst
@@ -20,7 +20,7 @@ specifically supported with a template to quickly generate a
 **rock** and a matching template to generate a **charm**.
 A rock is a special kind of OCI-compliant container image, while a
 charm is a software operator for cloud operations that use the Juju
-orchestration engine. The result is a FastAPI app that
+orchestration engine. The combined result is a FastAPI app that
 can be deployed, configured, scaled, integrated, and so on,
 on any Kubernetes cluster.
 

--- a/docs/tutorial/kubernetes-charm-fastapi.rst
+++ b/docs/tutorial/kubernetes-charm-fastapi.rst
@@ -181,7 +181,7 @@ The top of the file should look similar to the following snippet:
 
 Verify that the ``name`` is ``fastapi-hello-world``.
 
-The ``platforms`` must match the architecture of your host. Check
+The ``platforms`` key must match the architecture of your host. Check
 the architecture of your system:
 
 .. code-block:: bash

--- a/docs/tutorial/kubernetes-charm-flask.rst
+++ b/docs/tutorial/kubernetes-charm-flask.rst
@@ -14,15 +14,14 @@ up and running with Juju. Let's get started!
 
 This tutorial should take 90 minutes for you to complete.
 
-.. note::
-    If you're new to the charming world, Flask apps are
-    specifically supported with a template to quickly generate a
-    **rock** and a matching template to generate a **charm**.
-    A rock is a special kind of OCI-compliant container image, while a
-    charm is a software operator for cloud operations that use the Juju
-    orchestration engine. The result is a Flask app that
-    can be deployed, configured, scaled, integrated, and so on,
-    on any Kubernetes cluster.
+If you're new to the charming world, Flask apps are
+specifically supported with a template to quickly generate a
+**rock** and a matching template to generate a **charm**.
+A rock is a special kind of OCI-compliant container image, while a
+charm is a software operator for cloud operations that use the Juju
+orchestration engine. The result is a Flask app that
+can be deployed, configured, scaled, integrated, and so on,
+on any Kubernetes cluster.
 
 
 What you'll need

--- a/docs/tutorial/kubernetes-charm-flask.rst
+++ b/docs/tutorial/kubernetes-charm-flask.rst
@@ -297,8 +297,7 @@ the Flask app. Let's create a new model:
     :end-before: [docs:add-juju-model-end]
     :dedent: 2
 
-Include a constraint to the Juju model to specify your architecture if you
-aren't on a host with AMD64:
+Include a constraint to the Juju model to specify your architecture:
 
 .. literalinclude:: code/flask/task.yaml
     :language: bash

--- a/docs/tutorial/kubernetes-charm-flask.rst
+++ b/docs/tutorial/kubernetes-charm-flask.rst
@@ -181,7 +181,7 @@ The top of the file should look similar to the following snippet:
 
 Verify that the ``name`` is ``flask-hello-world``.
 
-Ensure that ``platforms`` includes the architecture of your host. Check
+The ``platforms`` must match the architecture of your host. Check
 the architecture of your system:
 
 .. code-block:: bash

--- a/docs/tutorial/kubernetes-charm-flask.rst
+++ b/docs/tutorial/kubernetes-charm-flask.rst
@@ -188,7 +188,7 @@ the architecture of your system:
     dpkg --print-architecture
 
 
-Edit the ``platforms`` entry in ``rockcraft.yaml`` if required.
+Edit the ``platforms`` key in ``rockcraft.yaml`` if required.
 
 Now let's pack the rock:
 

--- a/docs/tutorial/kubernetes-charm-flask.rst
+++ b/docs/tutorial/kubernetes-charm-flask.rst
@@ -180,7 +180,7 @@ The top of the file should look similar to the following snippet:
 
 Verify that the ``name`` is ``flask-hello-world``.
 
-The ``platforms`` must match the architecture of your host. Check
+The ``platforms`` key must match the architecture of your host. Check
 the architecture of your system:
 
 .. code-block:: bash

--- a/docs/tutorial/kubernetes-charm-flask.rst
+++ b/docs/tutorial/kubernetes-charm-flask.rst
@@ -19,7 +19,7 @@ specifically supported with a template to quickly generate a
 **rock** and a matching template to generate a **charm**.
 A rock is a special kind of OCI-compliant container image, while a
 charm is a software operator for cloud operations that use the Juju
-orchestration engine. The result is a Flask app that
+orchestration engine. The combined result is a Flask app that
 can be deployed, configured, scaled, integrated, and so on,
 on any Kubernetes cluster.
 

--- a/docs/tutorial/kubernetes-charm-flask.rst
+++ b/docs/tutorial/kubernetes-charm-flask.rst
@@ -189,8 +189,7 @@ the architecture of your system:
     dpkg --print-architecture
 
 
-If your host uses the ARM architecture, open ``rockcraft.yaml`` in a
-text editor, comment out ``amd64``, and include ``arm64`` under ``platforms``.
+Edit the ``platforms`` entry in ``rockcraft.yaml`` if required.
 
 Now let's pack the rock:
 

--- a/docs/tutorial/kubernetes-charm-flask.rst
+++ b/docs/tutorial/kubernetes-charm-flask.rst
@@ -295,7 +295,7 @@ the Flask app. Let's create a new model:
     :end-before: [docs:add-juju-model-end]
     :dedent: 2
 
-Include a constraint to the Juju model to specify your architecture:
+Constrain the Juju model to your architecture:
 
 .. literalinclude:: code/flask/task.yaml
     :language: bash

--- a/docs/tutorial/kubernetes-charm-go.rst
+++ b/docs/tutorial/kubernetes-charm-go.rst
@@ -14,15 +14,14 @@ up and running with Juju. Let's get started!
 
 This tutorial should take 90 minutes for you to complete.
 
-.. note::
-    If you're new to the charming world, Go apps are
-    specifically supported with a template to quickly generate a
-    **rock** and a matching template to generate a **charm**.
-    A rock is a special kind of OCI-compliant container image, while a
-    charm is a software operator for cloud operations that use the Juju
-    orchestration engine. The result is a Go app that
-    can be deployed, configured, scaled, integrated, and so on,
-    on any Kubernetes cluster.
+If you're new to the charming world, Go apps are
+specifically supported with a template to quickly generate a
+**rock** and a matching template to generate a **charm**.
+A rock is a special kind of OCI-compliant container image, while a
+charm is a software operator for cloud operations that use the Juju
+orchestration engine. The result is a Go app that
+can be deployed, configured, scaled, integrated, and so on,
+on any Kubernetes cluster.
 
 
 What you'll need

--- a/docs/tutorial/kubernetes-charm-go.rst
+++ b/docs/tutorial/kubernetes-charm-go.rst
@@ -335,7 +335,7 @@ the Go app. Let's create a new model:
     :end-before: [docs:add-juju-model-end]
     :dedent: 2
 
-Include a constraint to the Juju model to specify your architecture:
+Constrain the Juju model to your architecture:
 
 .. literalinclude:: code/go/task.yaml
     :language: bash

--- a/docs/tutorial/kubernetes-charm-go.rst
+++ b/docs/tutorial/kubernetes-charm-go.rst
@@ -181,8 +181,7 @@ the architecture of your system:
     dpkg --print-architecture
 
 
-If your host uses the ARM architecture, open ``rockcraft.yaml`` in a
-text editor, comment out ``amd64``, and include ``arm64`` in ``platforms``.
+Edit the ``platforms`` entry in ``rockcraft.yaml`` if required.
 
 Now let's pack the rock:
 

--- a/docs/tutorial/kubernetes-charm-go.rst
+++ b/docs/tutorial/kubernetes-charm-go.rst
@@ -173,7 +173,7 @@ The top of the file should look similar to the following snippet:
 
 Verfiy that the ``name`` is ``go-hello-world``.
 
-Ensure that ``platforms`` includes the architecture of your host. Check
+The ``platforms`` must match the architecture of your host. Check
 the architecture of your system:
 
 .. code-block:: bash

--- a/docs/tutorial/kubernetes-charm-go.rst
+++ b/docs/tutorial/kubernetes-charm-go.rst
@@ -172,7 +172,7 @@ The top of the file should look similar to the following snippet:
 
 Verfiy that the ``name`` is ``go-hello-world``.
 
-The ``platforms`` must match the architecture of your host. Check
+The ``platforms`` key must match the architecture of your host. Check
 the architecture of your system:
 
 .. code-block:: bash

--- a/docs/tutorial/kubernetes-charm-go.rst
+++ b/docs/tutorial/kubernetes-charm-go.rst
@@ -337,8 +337,7 @@ the Go app. Let's create a new model:
     :end-before: [docs:add-juju-model-end]
     :dedent: 2
 
-Include a constraint to the Juju model to specify your architecture if you
-aren't on a host with AMD64:
+Include a constraint to the Juju model to specify your architecture:
 
 .. literalinclude:: code/go/task.yaml
     :language: bash

--- a/docs/tutorial/kubernetes-charm-go.rst
+++ b/docs/tutorial/kubernetes-charm-go.rst
@@ -180,7 +180,7 @@ the architecture of your system:
     dpkg --print-architecture
 
 
-Edit the ``platforms`` entry in ``rockcraft.yaml`` if required.
+Edit the ``platforms`` key in ``rockcraft.yaml`` if required.
 
 Now let's pack the rock:
 

--- a/docs/tutorial/kubernetes-charm-go.rst
+++ b/docs/tutorial/kubernetes-charm-go.rst
@@ -19,7 +19,7 @@ specifically supported with a template to quickly generate a
 **rock** and a matching template to generate a **charm**.
 A rock is a special kind of OCI-compliant container image, while a
 charm is a software operator for cloud operations that use the Juju
-orchestration engine. The result is a Go app that
+orchestration engine. The combined result is a Go app that
 can be deployed, configured, scaled, integrated, and so on,
 on any Kubernetes cluster.
 


### PR DESCRIPTION
Six updates proposed by @evildmp in https://github.com/canonical/charmcraft/issues/2235 that affect all four of the 12-factor tutorials.

### Summary of changes
* Converted first note admonition into a normal paragraph.
* Updated the ambiguity of "Ensure that platforms includes the architecture of your host." by using the suggestion "Platforms must match the architecture of your host."
* Updated the instruction to edit `rockcraft.yaml` using the suggestion. 
* Removed an explicit reference to AMD64 architecture at the Juju model constraint step to let the user build up muscle memory. Architecture is still mentioned because that's what the command is explicitly doing.
* (Django tutorial only) Updated "The generated Django app doesn’t come with an app" to reference the Django *project* instead.
* (Django tutorial only) Updated `MULTIPASS_PRIVATE_IP` to use regular text formatting, as the original spelling implied a variable.