### PR TITLE
build(build-deps): install cargo if not installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,9 @@ endif
 ifeq ($(shell which skopeo),)
 APT_PACKAGES += skopeo
 endif
+ifeq ($(shell which cargo),)
+APT_PACKAGES += cargo
+endif
 
 # Used for installing build dependencies in CI.
 .PHONY: install-build-deps


### PR DESCRIPTION
This installs cargo if it's not installed already. This is needed for CI runners that aren't AMD64 or ARM64 for cryptography.