### PR TITLE
docs: Updates to the 12-factor tutorials

### DIFF
--- a/docs/tutorial/kubernetes-charm-django.rst
+++ b/docs/tutorial/kubernetes-charm-django.rst
@@ -337,8 +337,8 @@ Similar to the rock, we'll take advantage of a pre-defined extension in
 Charmcraft with the ``--profile`` flag that caters initial charm files for
 specific web app frameworks. Using the ``django-framework`` profile, Charmcraft
 automates the creation of the files needed for our charm, including a
-``charmcraft.yaml``, ``requirements.txt`` and source code for the charm.
-The source code contains the logic required to operate the Django app.
+``charmcraft.yaml`` project file, ``requirements.txt`` and source code for the
+charm. The source code contains the logic required to operate the Django app.
 
 Initialize a charm named ``django-hello-world``:
 
@@ -352,10 +352,10 @@ The files will automatically be created in your working directory.
 
 We will need to integrate our Django app to the PostgreSQL database,
 which means we must declare a requirement in the charm project file.
-Open the ``charmcraft.yaml`` file and add the following section to the end
-of the file:
+Edit the project file by adding the following section to the end:
 
 .. literalinclude:: code/django/postgres_requires_charmcraft.yaml
+    :caption: ~/django-hello-world/charm/charmcraft.yaml
     :language: yaml
 
 .. tip::

--- a/docs/tutorial/kubernetes-charm-django.rst
+++ b/docs/tutorial/kubernetes-charm-django.rst
@@ -291,7 +291,7 @@ We will also use PostgreSQL as the database for our Django app. In
 
 Save and close the ``settings.py`` file. The app will no longer run locally
 due to these changes, and we can't test the app until we've deployed
-the app and connected it to the PostgreSQL database.
+it and connected it to the PostgreSQL database.
 
 Now let's pack the rock:
 
@@ -493,8 +493,8 @@ Set the configuration:
 
 .. note::
 
-    The ``django-debug`` configuration sets the Django environment variable
-    ``DJANGO_DEBUG`` that we previously updated in ``settings.py``.
+    The ``django-debug`` configuration sets the ``DJANGO_DEBUG`` environment
+    variable that we previously updated in ``settings.py``.
 
     Turning on debug mode shouldn't be done in production. We will do this in
     the tutorial for now and later disable debug mode.

--- a/docs/tutorial/kubernetes-charm-django.rst
+++ b/docs/tutorial/kubernetes-charm-django.rst
@@ -388,7 +388,7 @@ pack, subsequent charm packings are faster.
 
 .. admonition:: For more options when packing charms
 
-    See the :literalref:`ref_commands_pack` command reference.
+    See the :literalref:`pack<ref_commands_pack>` command reference.
 
 Deploy the Django app
 ---------------------

--- a/docs/tutorial/kubernetes-charm-django.rst
+++ b/docs/tutorial/kubernetes-charm-django.rst
@@ -286,7 +286,9 @@ We will also use PostgreSQL as the database for our Django app. In
         }
     }
 
-Save and close the ``settings.py`` file.
+Save and close the ``settings.py`` file. The app will no longer run locally
+due to these changes, and we can't test the app until we've deployed
+the app and connected it to the PostgreSQL database.
 
 Now let's pack the rock:
 

--- a/docs/tutorial/kubernetes-charm-django.rst
+++ b/docs/tutorial/kubernetes-charm-django.rst
@@ -394,7 +394,11 @@ Deploy the Django app
 ---------------------
 
 A Juju model is needed to handle Kubernetes resources while deploying
-the Django app. Let's create a new model:
+the Django app. The Juju model holds the application along any supporting
+components. In this tutorial, our model will hold the Django app, the
+PostgreSQL database, and ingress.
+
+Let's create a new model:
 
 .. literalinclude:: code/django/task.yaml
     :language: bash

--- a/docs/tutorial/kubernetes-charm-django.rst
+++ b/docs/tutorial/kubernetes-charm-django.rst
@@ -394,7 +394,7 @@ Deploy the Django app
 ---------------------
 
 A Juju model is needed to handle Kubernetes resources while deploying
-the Django app. The Juju model holds the application along any supporting
+the Django app. The Juju model holds the app along with any supporting
 components. In this tutorial, our model will hold the Django app, the
 PostgreSQL database, and ingress.
 

--- a/docs/tutorial/kubernetes-charm-django.rst
+++ b/docs/tutorial/kubernetes-charm-django.rst
@@ -489,6 +489,9 @@ Set the configuration:
 
 .. note::
 
+    The ``django-debug`` configuration sets the Django environment variable
+    ``DJANGO_DEBUG`` that we previously updated in ``settings.py``.
+
     Turning on debug mode shouldn't be done in production. We will do this in
     the tutorial for now and later disable debug mode.
 

--- a/docs/tutorial/kubernetes-charm-django.rst
+++ b/docs/tutorial/kubernetes-charm-django.rst
@@ -386,9 +386,9 @@ respond with something similar to
 reflects your system's architecture. After the initial
 pack, subsequent charm packings are faster.
 
-.. seealso::
+.. admonition:: For more options when packing charms
 
-    :ref:`ref_commands_pack`
+    See the :literalref:`ref_commands_pack` command reference.
 
 Deploy the Django app
 ---------------------

--- a/docs/tutorial/kubernetes-charm-django.rst
+++ b/docs/tutorial/kubernetes-charm-django.rst
@@ -493,8 +493,8 @@ Set the configuration:
 
 .. note::
 
-    The ``django-debug`` configuration sets the ``DJANGO_DEBUG`` environment
-    variable that we previously updated in ``settings.py``.
+    The ``django-debug`` configuration key sets the ``DJANGO_DEBUG``
+    environment variable that we previously updated in ``settings.py``.
 
     Turning on debug mode shouldn't be done in production. We will do this in
     the tutorial for now and later disable debug mode.

--- a/docs/tutorial/kubernetes-charm-django.rst
+++ b/docs/tutorial/kubernetes-charm-django.rst
@@ -165,6 +165,9 @@ original terminal of the Multipass VM using :kbd:`Ctrl` + :kbd:`C`.
 Pack the Django app into a rock
 -------------------------------
 
+Now let's create a container image for our Django app. We'll use a rock,
+which is an OCI-compliant container image based on Ubuntu.
+
 First, we'll need a ``rockcraft.yaml`` project file. We'll take advantage of a
 pre-defined extension in Rockcraft with the ``--profile`` flag that caters
 initial rock files for specific web app frameworks. Using the

--- a/docs/tutorial/kubernetes-charm-django.rst
+++ b/docs/tutorial/kubernetes-charm-django.rst
@@ -381,6 +381,10 @@ respond with something similar to
 reflects your system's architecture. After the initial
 pack, subsequent charm packings are faster.
 
+.. seealso::
+
+    :ref:`ref_commands_pack`
+
 Deploy the Django app
 ---------------------
 

--- a/docs/tutorial/kubernetes-charm-fastapi.rst
+++ b/docs/tutorial/kubernetes-charm-fastapi.rst
@@ -328,9 +328,9 @@ respond with something similar to
 reflects your system's architecture. After the initial
 pack, subsequent charm packings are faster.
 
-.. seealso::
+.. admonition:: For more options when packing charms
 
-    :ref:`ref_commands_pack`
+    See the :literalref:`ref_commands_pack` command reference.
 
 
 Deploy the FastAPI app

--- a/docs/tutorial/kubernetes-charm-fastapi.rst
+++ b/docs/tutorial/kubernetes-charm-fastapi.rst
@@ -135,6 +135,9 @@ original terminal using :kbd:`Ctrl` + :kbd:`C`.
 Pack the FastAPI app into a rock
 --------------------------------
 
+Now let's create a container image for our FastAPI app. We'll use a rock,
+which is an OCI-compliant container image based on Ubuntu.
+
 First, we'll need a ``rockcraft.yaml`` project file. We'll take advantage of a
 pre-defined extension in Rockcraft with the ``--profile`` flag that caters
 initial rock files for specific web app frameworks. Using the

--- a/docs/tutorial/kubernetes-charm-fastapi.rst
+++ b/docs/tutorial/kubernetes-charm-fastapi.rst
@@ -337,7 +337,11 @@ Deploy the FastAPI app
 ----------------------
 
 A Juju model is needed to handle Kubernetes resources while deploying
-the FastAPI app. Let's create a new model:
+the FastAPI app. The Juju model holds the application along any supporting
+components. In this tutorial, our model will hold the FastAPI app, ingress,
+and a PostgreSQL database.
+
+Let's create a new model:
 
 .. literalinclude:: code/fastapi/task.yaml
     :language: bash

--- a/docs/tutorial/kubernetes-charm-fastapi.rst
+++ b/docs/tutorial/kubernetes-charm-fastapi.rst
@@ -325,6 +325,11 @@ respond with something similar to
 reflects your system's architecture. After the initial
 pack, subsequent charm packings are faster.
 
+.. seealso::
+
+    :ref:`ref_commands_pack`
+
+
 Deploy the FastAPI app
 ----------------------
 

--- a/docs/tutorial/kubernetes-charm-fastapi.rst
+++ b/docs/tutorial/kubernetes-charm-fastapi.rst
@@ -249,8 +249,9 @@ Similar to the rock, we'll take advantage of a pre-defined extension in
 Charmcraft with the ``--profile`` flag that caters initial charm files for
 specific web app frameworks. Using the ``fastapi-framework`` profile,
 Charmcraft automates the creation of the files needed for our charm,
-including a ``charmcraft.yaml``, ``requirements.txt`` and source code for the
-charm. The source code contains the logic required to operate the FastAPI app.
+including a ``charmcraft.yaml`` project file, ``requirements.txt`` and source
+code for the charm. The source code contains the logic required to operate the
+FastAPI app.
 
 Initialize a charm named ``fastapi-hello-world``:
 
@@ -296,9 +297,8 @@ The top of the file should look similar to the following snippet:
     ...
 
 Verify that the ``name`` is ``fastapi-hello-world``. Ensure that ``platforms``
-includes the architecture of your host. If your host uses the ARM architecture,
-open ``charmcraft.yaml`` in a text editor, comment out ``amd64``, and include
-``arm64`` in ``platforms``.
+includes the architecture of your host. Edit the ``platforms`` key in the
+project file if required.
 
 .. tip::
 

--- a/docs/tutorial/kubernetes-charm-fastapi.rst
+++ b/docs/tutorial/kubernetes-charm-fastapi.rst
@@ -337,7 +337,7 @@ Deploy the FastAPI app
 ----------------------
 
 A Juju model is needed to handle Kubernetes resources while deploying
-the FastAPI app. The Juju model holds the application along any supporting
+the FastAPI app. The Juju model holds the app along with any supporting
 components. In this tutorial, our model will hold the FastAPI app, ingress,
 and a PostgreSQL database.
 

--- a/docs/tutorial/kubernetes-charm-fastapi.rst
+++ b/docs/tutorial/kubernetes-charm-fastapi.rst
@@ -330,7 +330,7 @@ pack, subsequent charm packings are faster.
 
 .. admonition:: For more options when packing charms
 
-    See the :literalref:`ref_commands_pack` command reference.
+    See the :literalref:`pack<ref_commands_pack>` command reference.
 
 
 Deploy the FastAPI app

--- a/docs/tutorial/kubernetes-charm-flask.rst
+++ b/docs/tutorial/kubernetes-charm-flask.rst
@@ -283,7 +283,7 @@ pack, subsequent charm packings are faster.
 
 .. admonition:: For more options when packing charms
 
-    See the :literalref:`ref_commands_pack` command reference.
+    See the :literalref:`pack<ref_commands_pack>` command reference.
 
 
 Deploy the Flask app

--- a/docs/tutorial/kubernetes-charm-flask.rst
+++ b/docs/tutorial/kubernetes-charm-flask.rst
@@ -281,9 +281,9 @@ respond with something similar to
 reflects your system's architecture. After the initial
 pack, subsequent charm packings are faster.
 
-.. seealso::
+.. admonition:: For more options when packing charms
 
-    :ref:`ref_commands_pack`
+    See the :literalref:`ref_commands_pack` command reference.
 
 
 Deploy the Flask app

--- a/docs/tutorial/kubernetes-charm-flask.rst
+++ b/docs/tutorial/kubernetes-charm-flask.rst
@@ -290,7 +290,7 @@ Deploy the Flask app
 --------------------
 
 A Juju model is needed to handle Kubernetes resources while deploying
-the Flask app. The Juju model holds the application along any supporting
+the Flask app. The Juju model holds the app along with any supporting
 components. In this tutorial, our model will hold the Flask app, ingress,
 and a PostgreSQL database.
 

--- a/docs/tutorial/kubernetes-charm-flask.rst
+++ b/docs/tutorial/kubernetes-charm-flask.rst
@@ -134,6 +134,9 @@ original terminal using :kbd:`Ctrl` + :kbd:`C`.
 Pack the Flask app into a rock
 ------------------------------
 
+Now let's create a container image for our Flask app. We'll use a rock,
+which is an OCI-compliant container image based on Ubuntu.
+
 First, we'll need a ``rockcraft.yaml`` project file. We'll take advantage of a
 pre-defined extension in Rockcraft with the ``--profile`` flag that caters
 initial rock files for specific web app frameworks. Using the

--- a/docs/tutorial/kubernetes-charm-flask.rst
+++ b/docs/tutorial/kubernetes-charm-flask.rst
@@ -244,8 +244,9 @@ Similar to the rock, we'll take advantage of a pre-defined extension in
 Charmcraft with the ``--profile`` flag that caters initial charm files for
 specific web app frameworks. Using the ``flask-framework`` profile,
 Charmcraft automates the creation of the files needed for our charm,
-including a ``charmcraft.yaml``, ``requirements.txt`` and source code for the
-charm. The source code contains the logic required to operate the Flask app.
+including a ``charmcraft.yaml`` project file, ``requirements.txt`` and source
+code for the charm. The source code contains the logic required to operate the
+Flask app.
 
 Initialize a charm named ``flask-hello-world``:
 

--- a/docs/tutorial/kubernetes-charm-flask.rst
+++ b/docs/tutorial/kubernetes-charm-flask.rst
@@ -277,6 +277,11 @@ respond with something similar to
 reflects your system's architecture. After the initial
 pack, subsequent charm packings are faster.
 
+.. seealso::
+
+    :ref:`ref_commands_pack`
+
+
 Deploy the Flask app
 --------------------
 

--- a/docs/tutorial/kubernetes-charm-flask.rst
+++ b/docs/tutorial/kubernetes-charm-flask.rst
@@ -289,7 +289,11 @@ Deploy the Flask app
 --------------------
 
 A Juju model is needed to handle Kubernetes resources while deploying
-the Flask app. Let's create a new model:
+the Flask app. The Juju model holds the application along any supporting
+components. In this tutorial, our model will hold the Flask app, ingress,
+and a PostgreSQL database.
+
+Let's create a new model:
 
 .. literalinclude:: code/flask/task.yaml
     :language: bash

--- a/docs/tutorial/kubernetes-charm-go.rst
+++ b/docs/tutorial/kubernetes-charm-go.rst
@@ -317,6 +317,11 @@ respond with something similar to
 reflects your system's architecture. After the initial
 pack, subsequent charm packings are faster.
 
+.. seealso::
+
+    :ref:`ref_commands_pack`
+
+
 Deploy the Go app
 -----------------
 

--- a/docs/tutorial/kubernetes-charm-go.rst
+++ b/docs/tutorial/kubernetes-charm-go.rst
@@ -320,9 +320,9 @@ respond with something similar to
 reflects your system's architecture. After the initial
 pack, subsequent charm packings are faster.
 
-.. seealso::
+.. admonition:: For more options when packing charms
 
-    :ref:`ref_commands_pack`
+    See the :literalref:`ref_commands_pack` command reference.
 
 
 Deploy the Go app

--- a/docs/tutorial/kubernetes-charm-go.rst
+++ b/docs/tutorial/kubernetes-charm-go.rst
@@ -329,7 +329,7 @@ Deploy the Go app
 -----------------
 
 A Juju model is needed to handle Kubernetes resources while deploying
-the Go app. The Juju model holds the application along any supporting
+the Go app. The Juju model holds the app along with any supporting
 components. In this tutorial, our model will hold the Go app, ingress,
 and a PostgreSQL database.
 

--- a/docs/tutorial/kubernetes-charm-go.rst
+++ b/docs/tutorial/kubernetes-charm-go.rst
@@ -329,7 +329,11 @@ Deploy the Go app
 -----------------
 
 A Juju model is needed to handle Kubernetes resources while deploying
-the Go app. Let's create a new model:
+the Go app. The Juju model holds the application along any supporting
+components. In this tutorial, our model will hold the Go app, ingress,
+and a PostgreSQL database.
+
+Let's create a new model:
 
 .. literalinclude:: code/go/task.yaml
     :language: bash

--- a/docs/tutorial/kubernetes-charm-go.rst
+++ b/docs/tutorial/kubernetes-charm-go.rst
@@ -322,7 +322,7 @@ pack, subsequent charm packings are faster.
 
 .. admonition:: For more options when packing charms
 
-    See the :literalref:`ref_commands_pack` command reference.
+    See the :literalref:`pack<ref_commands_pack>` command reference.
 
 
 Deploy the Go app

--- a/docs/tutorial/kubernetes-charm-go.rst
+++ b/docs/tutorial/kubernetes-charm-go.rst
@@ -125,6 +125,9 @@ original terminal using :kbd:`Ctrl` + :kbd:`C`.
 Pack the Go app into a rock
 ---------------------------
 
+Now let's create a container image for our Go app. We'll use a rock,
+which is an OCI-compliant container image based on Ubuntu.
+
 First, we'll need a ``rockcraft.yaml`` project file. We'll take advantage of a
 pre-defined extension in Rockcraft with the ``--profile`` flag that caters
 initial rock files for specific web app frameworks. Using the

--- a/docs/tutorial/kubernetes-charm-go.rst
+++ b/docs/tutorial/kubernetes-charm-go.rst
@@ -241,8 +241,9 @@ Similar to the rock, we'll take advantage of a pre-defined extension in
 Charmcraft with the ``--profile`` flag that caters initial charm files for
 specific web app frameworks. Using the ``go-framework`` profile,
 Charmcraft automates the creation of the files needed for our charm,
-including a ``charmcraft.yaml``, ``requirements.txt`` and source code for the
-charm. The source code contains the logic required to operate the Go app.
+including a ``charmcraft.yaml`` project file, ``requirements.txt`` and source
+code for the charm. The source code contains the logic required to operate the
+Go app.
 
 Initialize a charm named ``go-hello-world``:
 
@@ -288,9 +289,8 @@ The top of the file should look similar to the following snippet:
     ...
 
 Verify that the ``name`` is ``go-hello-world``. Ensure that ``platforms``
-includes the architecture of your host. If your host uses the ARM architecture,
-open ``charmcraft.yaml`` in a text editor, comment out ``amd64``, and include
-``arm64`` in ``platforms``.
+includes the architecture of your host. Edit the ``platforms`` key in the
+project file if required.
 
 .. tip::
 


### PR DESCRIPTION
Six updates proposed by @evildmp in https://github.com/canonical/charmcraft/issues/2235 that affect all four of the 12-factor tutorials.

### Summary of changes
* Added a brief explanation of a rock at the beginning of the rock sections.
* (Django tutorial) Before packing the rock, added a note that explains that the user can no longer run or test the app locally due to the changes we made in preparing the app for a PostgreSQL database.
* (FastAPI and Go tutorials) Changed some instances of the mechanical instruction "open" to a functional action "edit" for updating the `charmcraft.yaml` file. This also establishes consistency with the corresponding rock sections.
* Added a `seealso` box to `charmcraft pack` to provide more context to the user.
* Added a brief explanation of a Juju model at the beginning of the deploy section.
* (Django tutorial) When setting the `django-debug` configuration, added more information in the note admonition that this configuration sets an environment variable in the Django app. This gives the user a way to connect the Juju-specific command with a familiar concept.