### PR TITLE
docs: resolve local build errors

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -116,6 +116,7 @@ exclude_patterns = [
     "common/craft-parts/reference/plugins/cmake_plugin.rst",
     "common/craft-parts/reference/plugins/dotnet_plugin.rst",
     "common/craft-parts/reference/plugins/go_plugin.rst",
+    "common/craft-parts/reference/plugins/jlink_plugin.rst", # not included in ToC
     "common/craft-parts/reference/plugins/make_plugin.rst",
     "common/craft-parts/reference/plugins/maven_plugin.rst",
     "common/craft-parts/reference/plugins/meson_plugin.rst",
@@ -129,6 +130,7 @@ exclude_patterns = [
     "common/craft-parts/reference/plugins/go_use_plugin.rst",
     "common/craft-parts/reference/plugins/uv_plugin.rst",
     # Extra non-craft-parts exclusions can be added after this comment
+    "reuse/reference/extensions/integrations.rst",
     "reuse/tutorial/*"
 ]
 


### PR DESCRIPTION
Local documentation builds currently fail due to the following warnings:

```bash
Warning, treated as error:
/home/ecoldi/Projects/Canonical/charmcraft/docs/reuse/reference/extensions/integrations.rst:125:Undefined substitution referenced: "juju_integrate_postgresql".
make: *** [common.mk:224: docs] Error 2
```

```bash
Warning, treated as error:
/home/ecoldi/Projects/Canonical/charmcraft/docs/common/craft-parts/reference/plugins/jlink_plugin.rst:document isn't included in any toctree
make: *** [common.mk:224: docs] Error 2
```

This absolute behemoth of a PR resolves this issue by adding the guilty files to the `exclude_patterns` list.