### PR TITLE
ci: run tests on GH-hosted runners

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -16,12 +16,14 @@ jobs:
   test:
     uses: canonical/starflow/.github/workflows/test-python.yaml@main
     with:
-      # Self-hosted Jammy and Noble runners, GH-hosted macos and Windows runners.
       # Limiting to amd64 is a workaround for https://github.com/canonical/charmcraft/issues/2018
-      fast-test-platforms: '[["jammy", "amd64"], ["noble", "amd64"], "macos-13", "macos-14-large", "windows-2019", "windows-2022"]'
+      # Once that's resolved we should run fast and slow tests on ARM64 Ubuntu too.
+      fast-test-platforms: '["ubuntu-22.04", "ubuntu-24.04", "macos-13", "macos-14-large", "windows-2019", "windows-2022"]'
       fast-test-python-versions: '["3.10", "3.12"]'
       # Slow tests run on noble to avoid an issue with old skopeo versions.
-      slow-test-platforms: '["noble", "macos-14-large"]'
+      slow-test-platforms: '["ubuntu-24.04", "macos-14-large"]'
       slow-test-python-versions: '["3.10", "3.12"]'
-      # Switch to just noble when we fix #2018
-      lowest-python-platform: self-hosted-linux-amd64-noble-large
+      # Lowest tests run on noble to avoid an issue with old skopeo versions.
+      lowest-python-platform: ubuntu-24.04
+      lowest-python-version: "3.10"
+      use-lxd: true

--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,7 @@ else ifneq ($(shell which snap),)
 	sudo snap install lxd
 	sudo lxd init --auto
 else
+	$(warning lxd not installed and snap is not available. Please install snap and lxd)
 endif
 
 .PHONY: install-macos-build-deps

--- a/Makefile
+++ b/Makefile
@@ -112,9 +112,11 @@ endif
 
 .PHONY: install-linux-build-deps
 install-linux-build-deps:
-ifneq ($(shell which snap),)
+ifneq ($(wildcard /snap/bin/lxd),)
+else ifneq ($(shell which snap),)
 	sudo snap install lxd
 	sudo lxd init --auto
+else
 endif
 
 .PHONY: install-macos-build-deps


### PR DESCRIPTION
I got a query from @cbartz about why we're using hosted runners for Charmcraft QA rather than GH-hosted runners, as Platform Engineering would prefer we use GH-hosted runners when possible for public repos. This makes this change.

Note that this only affects linux runners on the QA workflow.