### PR TITLE
docs: align FastAPI tutorial structure with Django tutorial

### DIFF
--- a/docs/tutorial/kubernetes-charm-fastapi.rst
+++ b/docs/tutorial/kubernetes-charm-fastapi.rst
@@ -9,6 +9,10 @@ such as PostgreSQL and need to deploy it. In a traditional setup,
 this can be quite a challenge, but with Charmcraft you'll find
 yourself packaging and deploying your FastAPI app in no time.
 
+
+Introduction
+------------
+
 In this tutorial we will build a Kubernetes charm for a FastAPI
 app using Charmcraft, so we can have a FastAPI app
 up and running with Juju. Let's get started!
@@ -26,7 +30,7 @@ on any Kubernetes cluster.
 
 
 What you'll need
-----------------
+~~~~~~~~~~~~~~~~
 
 - A local system, e.g., a laptop, with AMD64 or ARM64 architecture which
   has sufficient resources to launch a virtual machine with 4 CPUs,
@@ -35,7 +39,7 @@ What you'll need
 
 
 What you'll do
---------------
+~~~~~~~~~~~~~~
 
 #. Create a FastAPI app.
 #. Use that to create a rock with Rockcraft.
@@ -126,7 +130,7 @@ endpoint. You will need a new terminal for this; use
     :end-before: [docs:curl-fastapi-end]
     :dedent: 2
 
-The FastAPI app should respond with ``{"message":"Hello World"}``.
+The FastAPI app should respond with ``{"message":"Hello, world!"}``.
 
 The FastAPI app looks good, so we can stop for now from the
 original terminal using :kbd:`Ctrl` + :kbd:`C`.
@@ -439,7 +443,7 @@ Monitor ``juju status`` until everything has a status of ``active``.
 Test the deployment using
 ``curl http://fastapi-hello-world --resolve fastapi-hello-world:80:127.0.0.1``
 to send a request via the ingress. It should return the
-``{"message":"Hello World"}`` greeting.
+``{"message":"Hello, world!"}`` greeting.
 
 .. note::
 
@@ -448,8 +452,16 @@ to send a request via the ingress. It should return the
     setting a DNS record.
 
 
-Configure the FastAPI app
--------------------------
+The development cycle
+---------------------
+
+So far, we have worked through the entire cycle, from creating an app to deploying it.
+But now – as in every real-world case – we will go through the experience
+of iterating to develop the app, and deploy each iteration.
+
+
+Provide a configuration
+~~~~~~~~~~~~~~~~~~~~~~~
 
 To demonstrate how to provide a configuration to the FastAPI app,
 we will make the greeting configurable. We will expect this
@@ -460,6 +472,10 @@ using ``cd ..`` and copy the following code into ``app.py``:
 .. literalinclude:: code/fastapi/greeting_app.py
     :caption: ~/fastapi-hello-world/app.py
     :language: python
+
+
+Update the rock
+~~~~~~~~~~~~~~~
 
 Increment the ``version`` in ``rockcraft.yaml`` to ``0.2`` such that the
 top of the ``rockcraft.yaml`` file looks similar to the following:
@@ -494,6 +510,10 @@ Let's pack and upload the rock:
     :start-after: [docs:docker-update]
     :end-before: [docs:docker-update-end]
     :dedent: 2
+
+
+Update the charm
+~~~~~~~~~~~~~~~~
 
 Change back into the charm directory using ``cd charm``.
 
@@ -574,6 +594,10 @@ and paste the following code into it:
     ``POSTGRESQL_DB_CONNECT_STRING`` environment variable once postgres has
     been integrated with the charm.
 
+
+Update the rock again
+~~~~~~~~~~~~~~~~~~~~~
+
 Increment the ``version`` in ``rockcraft.yaml`` to ``0.3`` such that the
 top of the ``rockcraft.yaml`` file looks similar to the following:
 
@@ -617,6 +641,10 @@ Let's pack and upload the rock:
     :start-after: [docs:docker-2nd-update]
     :end-before: [docs:docker-2nd-update-end]
     :dedent: 2
+
+
+Update the charm again
+~~~~~~~~~~~~~~~~~~~~~~
 
 Change back into the charm directory using ``cd charm``.
 
@@ -678,7 +706,7 @@ development process, including:
 - Deploying the app locally
 - Packaging the app using Rockcraft
 - Building the app with Ops code using Charmcraft
-- Deplyoing the app using Juju
+- Deploying the app using Juju
 - Exposing the app using an ingress
 - Configuring the app
 - Integrating the app with a database


### PR DESCRIPTION
Closes [Charmcraft FastAPI tutorial: Add structure to sections #208](https://github.com/canonical/open-documentation-academy/issues/208)

- Inserted "The development cycle" section after "Deploy the FastAPI app", and split the existing content under new subheadings.
- Added an "Introduction" heading below the main title, and changed the subsequent two headings into subheadings to match Django's tutorial structure
- Fixed typo: "Deplyoing" -> "Deploying". 
- Changed "Hello World" to "Hello, world!" for consistency inside the FastAPI tutorial, and alignment with the Django tutorial. 
