### PR TITLE
ci: split spread tests by system

### DIFF
--- a/.github/workflows/spread-docs.yaml
+++ b/.github/workflows/spread-docs.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Find spread systems
         id: select
         run: |
-          echo systems=$(spread -list google: | cut -d: -f2 | sort | uniq | jq --raw-input . | jq --slurp --compact-output) | tee -a "${GITHUB_OUTPUT}"
+          echo systems=$(spread -list google:docs/ | cut -d: -f2 | sort | uniq | jq --raw-input . | jq --slurp --compact-output) | tee -a "${GITHUB_OUTPUT}"
 
   docs-tests:
     runs-on: spread-installed
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        spread: ${{ fromJSON(needs.spread-select.outputs.systems) }}
+        system: ${{ fromJSON(needs.spread-select.outputs.systems) }}
 
     steps:
       - name: Cleanup job workspace
@@ -50,7 +50,7 @@ jobs:
 
       - name: Run spread
         run: |
-          spread google:docs/howto/code/ google:docs/tutorial/code/
+          spread google:${{ matrix.system }}:docs/
 
       - name: Discard spread workers
         if: always()

--- a/.github/workflows/spread-docs.yaml
+++ b/.github/workflows/spread-docs.yaml
@@ -14,8 +14,24 @@ on:
     - cron: "0 0 * * 0" # Midnight UTC on Sundays
 
 jobs:
+  spread-select:
+    runs-on: spread-installed
+    outputs:
+      systems: ${{ steps.select.outputs.systems }}
+    steps:
+      - name: Find spread systems
+        id: select
+        run: |
+          echo systems=\'$(spread -list google: | cut -d: -f2 | sort | uniq | jq --raw-input . | jq --slurp --compact-output)\' | tee -a "${GITHUB_OUTPUT}"
+
   docs-tests:
     runs-on: spread-installed
+    needs: [spread-select]
+    strategy:
+      fail-fast: false
+      matrix:
+        spread: ${{ fromJSON(needs.spread-select.outputs.systems) }}
+
     steps:
       - name: Cleanup job workspace
         run: |

--- a/.github/workflows/spread-docs.yaml
+++ b/.github/workflows/spread-docs.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Find spread systems
         id: select
         run: |
-          echo systems=\'$(spread -list google: | cut -d: -f2 | sort | uniq | jq --raw-input . | jq --slurp --compact-output)\' | tee -a "${GITHUB_OUTPUT}"
+          echo systems=$(spread -list google: | cut -d: -f2 | sort | uniq | jq --raw-input . | jq --slurp --compact-output) | tee -a "${GITHUB_OUTPUT}"
 
   docs-tests:
     runs-on: spread-installed

--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -25,17 +25,23 @@ jobs:
           name: snap
           path: ${{ steps.charmcraft.outputs.snap }}
 
+  spread-select:
+    runs-on: spread-installed
+    outputs:
+      systems: ${{ steps.select.outputs.systems }}
+    steps:
+      - name: Find spread systems
+        id: select
+        run: |
+          echo systems=\'$(spread -list google: | cut -d: -f2 | sort | uniq | jq --raw-input . | jq --slurp --compact-output)\' | tee -a "${GITHUB_OUTPUT}"
+
   snap-tests:
     runs-on: spread-installed
-    needs: [snap-build]
+    needs: [snap-build, spread-select]
     strategy:
       fail-fast: false
       matrix:
-        spread:
-          - "google:ubuntu-18.04-64"
-          - "google:ubuntu-20.04-64"
-          - "google:ubuntu-22.04-64"
-          - "google:ubuntu-24.04-64"
+        spread: ${{ fromJSON(needs.spread-select.outputs.systems) }}
 
     steps:
       - name: Cleanup job workspace

--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -32,7 +32,10 @@ jobs:
       fail-fast: false
       matrix:
         spread:
-          - "google:"
+          - "google:ubuntu-18.04-64"
+          - "google:ubuntu-20.04-64"
+          - "google:ubuntu-22.04-64"
+          - "google:ubuntu-24.04-64"
 
     steps:
       - name: Cleanup job workspace

--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Find spread systems
         id: select
         run: |
-          echo systems=\'$(spread -list google: | cut -d: -f2 | sort | uniq | jq --raw-input . | jq --slurp --compact-output)\' | tee -a "${GITHUB_OUTPUT}"
+          echo systems=$(spread -list google: | cut -d: -f2 | sort | uniq | jq --raw-input . | jq --slurp --compact-output) | tee -a "${GITHUB_OUTPUT}"
 
   snap-tests:
     runs-on: spread-installed

--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        spread: ${{ fromJSON(needs.spread-select.outputs.systems) }}
+        system: ${{ fromJSON(needs.spread-select.outputs.systems) }}
 
     steps:
       - name: Cleanup job workspace
@@ -62,7 +62,7 @@ jobs:
 
       - name: Run spread
         run: |
-          spread ${{ matrix.spread }}
+          spread google:${{ matrix.system }}
 
       - name: Discard spread workers
         if: always()

--- a/spread.yaml
+++ b/spread.yaml
@@ -35,6 +35,10 @@ backends:
           workers: 6
           memory: 8G
           storage: 40G
+      - ubuntu-24.04-64:
+          workers: 6
+          memory: 8G
+          storage: 40G
 
   multipass:
     type: adhoc


### PR DESCRIPTION
This sets up the spread test jobs to split the tests by system. It automatically generates the list of systems based on the spread file in order to reduce re-runs for flaky tests.