### PR TITLE
ci: use Ubuntu latest for schema diff

### DIFF
--- a/.github/workflows/schema.yaml
+++ b/.github/workflows/schema.yaml
@@ -6,7 +6,7 @@ env:
 
 jobs:
   diff-schema:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout


### PR DESCRIPTION
This was breaking on Jammy due to apt issues, but there's no reason not to just roll to the latest LTS.