### PR TITLE
fix(templates): fix layer in K8s template unit test

### DIFF
--- a/charmcraft/templates/init-kubernetes/tests/unit/test_charm.py.j2
+++ b/charmcraft/templates/init-kubernetes/tests/unit/test_charm.py.j2
@@ -10,7 +10,15 @@ from charm import SERVICE_NAME, {{ class_name }}
 
 CHECK_NAME = "service-ready"  # Name of Pebble check in the mock workload container.
 
-base_layer: pebble.LayerDict = {"services": {SERVICE_NAME: {}}, "checks": {CHECK_NAME: {}}}
+base_layer: pebble.LayerDict = {
+    "services": {SERVICE_NAME: {}},
+    "checks": {
+        CHECK_NAME: {
+            "startup": "enabled",
+            "level": "ready",
+        }
+    },
+}
 layers = {"base": pebble.Layer(base_layer)}
 
 


### PR DESCRIPTION
This PR fixes an issues with the unit tests of the `kubernetes` profile charm. The Pebble layer didn't explicitly specify some properties, which caused inconsistency errors from `ops.testing`.