### PR TITLE
build(docs): add sphinx sitemap

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -221,11 +221,11 @@ test-find-slow:  ##- Identify slow tests. Set cutoff time in seconds with SLOW_C
 
 .PHONY: docs
 docs:  ## Build documentation
-	uv run $(UV_DOCS_GROUPS) sphinx-build -b html -W $(DOCS) $(DOCS)/_build
+	uv run $(UV_DOCS_GROUPS) sphinx-build -b dirhtml -W $(DOCS) $(DOCS)/_build
 
 .PHONY: docs-auto
 docs-auto:  ## Build and host docs with sphinx-autobuild
-	uv run --group docs sphinx-autobuild -b html --open-browser --port=8080 --watch $(PROJECT) -W $(DOCS) $(DOCS)/_build
+	uv run --group docs sphinx-autobuild -b dirhtml --open-browser --port=8080 --watch $(PROJECT) -W $(DOCS) $(DOCS)/_build
 
 .PHONY: pack-pip
 pack-pip:  ##- Build packages for pip (sdist, wheel)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,9 +51,20 @@ html_context = {
     "matrix": "https://matrix.to/#/#charmhub-charmcraft:ubuntu.com",
 }
 
+# Sitemap configuration: https://sphinx-sitemap.readthedocs.io/
+html_baseurl = "https://canonical-charmcraft.readthedocs-hosted.com/"
+
+if "READTHEDOCS_VERSION" in os.environ:
+    version = os.environ["READTHEDOCS_VERSION"]
+    sitemap_url_scheme = "{version}{link}"
+else:
+    sitemap_url_scheme = "latest/{link}"
+
+
 # Template and asset locations
 extensions = [
     "canonical_sphinx",
+    "sphinx_sitemap",
 ]
 
 # Copy extra files to the _static dir during build
@@ -191,7 +202,7 @@ rediraffe_redirects = "redirects.txt"
 
 
 def generate_cli_docs(nil):
-    gen_cli_docs_path = (project_dir / "tools" / "gen_cli_docs.py").resolve()
+    gen_cli_docs_path = (project_dir / "tools/gen_cli_docs.py").resolve()
     subprocess.run([sys.executable, gen_cli_docs_path, project_dir / "docs"], check=True)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ docs = [
     "autodoc-pydantic~=2.0",
     "sphinx-autobuild~=2024.2",
     "sphinx-pydantic~=0.1",
+    "sphinx-sitemap>=2.6.0",
     "sphinx-toolbox~=3.5",
     "sphinx-lint~=1.0",
     "sphinxcontrib-details-directive",

--- a/uv.lock
+++ b/uv.lock
@@ -428,6 +428,7 @@ docs = [
     { name = "sphinx-autobuild" },
     { name = "sphinx-lint" },
     { name = "sphinx-pydantic" },
+    { name = "sphinx-sitemap" },
     { name = "sphinx-toolbox" },
     { name = "sphinxcontrib-details-directive" },
     { name = "sphinxext-rediraffe" },
@@ -517,6 +518,7 @@ docs = [
     { name = "sphinx-autobuild", specifier = "~=2024.2" },
     { name = "sphinx-lint", specifier = "~=1.0" },
     { name = "sphinx-pydantic", specifier = "~=0.1" },
+    { name = "sphinx-sitemap", specifier = ">=2.6.0" },
     { name = "sphinx-toolbox", specifier = "~=3.5" },
     { name = "sphinxcontrib-details-directive" },
     { name = "sphinxext-rediraffe", specifier = "==0.2.7" },
@@ -3600,6 +3602,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/16/6b/bcca2785de4071f604a722444d4d7ba8a9d40de3c14ad52fce93e6d92694/sphinx_reredirects-0.1.6.tar.gz", hash = "sha256:c491cba545f67be9697508727818d8626626366245ae64456fe29f37e9bbea64", size = 7080, upload-time = "2025-03-22T10:52:30.271Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/6f/0b3625be30a1a50f9e4c2cb2ec147b08f15ed0e9f8444efcf274b751300b/sphinx_reredirects-0.1.6-py3-none-any.whl", hash = "sha256:efd50c766fbc5bf40cd5148e10c00f2c00d143027de5c5e48beece93cc40eeea", size = 5675, upload-time = "2025-03-22T10:52:29.113Z" },
+]
+
+[[package]]
+name = "sphinx-sitemap"
+version = "2.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sphinx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/ed/96cc112b671e06df01c8306c25ce3331ccfece0d30235e32eb039afc8094/sphinx_sitemap-2.6.0.tar.gz", hash = "sha256:5e0c66b9f2e371ede80c659866a9eaad337d46ab02802f9c7e5f7bc5893c28d2", size = 6042, upload-time = "2024-04-29T00:18:13.399Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/d4/dffb4da380be24fd390d284634735d6fba560980014050e52569c04d215b/sphinx_sitemap-2.6.0-py3-none-any.whl", hash = "sha256:7478e417d141f99c9af27ccd635f44c03a471a08b20e778a0f9daef7ace1d30b", size = 5632, upload-time = "2024-04-29T00:18:12.147Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
* Adds `sphinx-sitemap` as a docs dependency
* Modifies `conf.py` to generate a sitemap during build
* Switches local builds to the `dirhtml` builder

[sitemap.xml](https://canonical-charmcraft--2323.com.readthedocs.build/2323/sitemap.xml)