### PR TITLE
ci: don't run spread tests when unnecessary

### DIFF
--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -50,6 +50,8 @@ jobs:
     outputs:
       systems: ${{ steps.select.outputs.systems }}
     steps:
+      - name: Checkout charmcraft
+        uses: actions/checkout@v4
       - name: Find spread systems
         id: select
         run: |


### PR DESCRIPTION
This prevents us from running spread tests when there are no changes that could affect the spread tests, also cancelling in-progress snap builds if the build is obsoleted (for example, if a new commit is pushed on a PR).