### PR TITLE
ci: be more selective about when we run expensive tests

### DIFF
--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -1,10 +1,43 @@
 name: Spread
 on:
   pull_request:
+    paths-ignore:
+      - .github/**
+      - "!.github/workflows/spread.yaml" # Run on this file getting changed
+      - docs/**
+      - schema/**
+      - tests/** # Don't run if only tests changed, unless a spread test changed.
+      - "!tests/spread/**"
+      - .editorconfig
+      - .pre-commit-config.yaml
+      - .readthedocs.yaml
+      - "*.md" # Only top-level Markdown files
   merge_group:
+    paths-ignore:
+      - .github/**
+      - "!.github/workflows/spread.yaml" # Run on this file getting changed
+      - docs/**
+      - schema/**
+      - tests/** # Don't run if only tests changed, unless a spread test changed.
+      - "!tests/spread/**"
+      - .editorconfig
+      - .pre-commit-config.yaml
+      - .readthedocs.yaml
+      - "*.md" # Only top-level Markdown files
   push:
     branches:
       - main
+    paths-ignore:
+      - .github/**
+      - "!.github/workflows/spread.yaml" # Run on this file getting changed
+      - docs/**
+      - schema/**
+      - tests/** # Don't run if only tests changed, unless a spread test changed.
+      - "!tests/spread/**"
+      - .editorconfig
+      - .pre-commit-config.yaml
+      - .readthedocs.yaml
+      - "*.md" # Only top-level Markdown files
   schedule:
     - cron: "0 0 */2 * *"
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,9 +5,43 @@ on:
     branches:
       - main
       - "feature/**"
+      - "hotfix/**"
+    paths-ignore:
+      - .github/**
+      - "!.github/workflows/tests.yaml" # Run on this file getting changed
+      - docs/**
+      - schema/**
+      - tests/spread/**
+      - .editorconfig
+      - .pre-commit-config.yaml
+      - .readthedocs.yaml
+      - "*.md" # Only top-level Markdown files
+      - spread.yaml
 
   pull_request:
+    paths-ignore:
+      - .github/**
+      - "!.github/workflows/tests.yaml" # Run on this file getting changed
+      - docs/**
+      - schema/**
+      - tests/spread/**
+      - .editorconfig
+      - .pre-commit-config.yaml
+      - .readthedocs.yaml
+      - "*.md" # Only top-level Markdown files
+      - spread.yaml
   merge_group:
+    paths-ignore:
+      - .github/**
+      - "!.github/workflows/tests.yaml" # Run on this file getting changed
+      - docs/**
+      - schema/**
+      - tests/spread/**
+      - .editorconfig
+      - .pre-commit-config.yaml
+      - .readthedocs.yaml
+      - "*.md" # Only top-level Markdown files
+      - spread.yaml
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/tics.yaml
+++ b/.github/workflows/tics.yaml
@@ -4,6 +4,17 @@ on:
     branches:
       - "main"
       - "tiobe"
+    paths-ignore:
+      - .github/**
+      - "!.github/workflows/tics.yaml" # Run on this file getting changed
+      - docs/**
+      - schema/**
+      - tests/spread/**
+      - .editorconfig
+      - .pre-commit-config.yaml
+      - .readthedocs.yaml
+      - "*.md" # Only top-level Markdown files
+      - spread.yaml
 
 jobs:
   TICS:


### PR DESCRIPTION
We have a number of tests that take a long time (and a lot of energy) to run, and we don't need to run those on every single PR. This sets them not to run when the *only* changes are on certain paths that cannot affect them.