### PR TITLE
docs: fix tree in init command docstring

### DIFF
--- a/charmcraft/application/commands/init.py
+++ b/charmcraft/application/commands/init.py
@@ -76,7 +76,7 @@ Available profiles are:
         A basic Kubernetes charm for a 12-factor Go app.
 
 Depending on the profile choice, Charmcraft will setup the following tree of
-files and directories:
+files and directories::
 
     .
     ├── charmcraft.yaml            - Charm build configuration

--- a/docs/reference/files/bundle-yaml-file.rst
+++ b/docs/reference/files/bundle-yaml-file.rst
@@ -748,9 +748,6 @@ The default base for deploying charms that can be deployed on multiple bases.
 
 **Purpose:** A link to a documentation cover page.
 
-    See more: :external+juju:ref:`Juju | Documentation conventions
-    <charm-best-practices-documentation>`
-
 
 ``issues``
 ----------


### PR DESCRIPTION
For CHARMCRAFT-629:

- Fix an issue where Sphinx treated the code block of the file tree as a block quote.
- This doesn't fix an underlying issue where the lines are too long on 80-char terminals.

Other:

- Remove a link to a Juju page that no longer exists.