### PR TITLE
docs: fix broken link to Juju docs in template CONTRIBUTING.md

### DIFF
--- a/charmcraft/templates/init-kubernetes/CONTRIBUTING.md.j2
+++ b/charmcraft/templates/init-kubernetes/CONTRIBUTING.md.j2
@@ -1,6 +1,7 @@
 # Contributing
 
-To make contributions to this charm, you'll need a working [development setup](https://juju.is/docs/sdk/dev-setup).
+To make contributions to this charm, you'll need a working
+[development setup](https://documentation.ubuntu.com/juju/3.6/howto/manage-your-deployment/#set-up-your-deployment-local-testing-and-development).
 
 You can create an environment for development with `tox`:
 

--- a/charmcraft/templates/init-machine/CONTRIBUTING.md.j2
+++ b/charmcraft/templates/init-machine/CONTRIBUTING.md.j2
@@ -1,6 +1,7 @@
 # Contributing
 
-To make contributions to this charm, you'll need a working [development setup](https://juju.is/docs/sdk/dev-setup).
+To make contributions to this charm, you'll need a working
+[development setup](https://documentation.ubuntu.com/juju/3.6/howto/manage-your-deployment/#set-up-your-deployment-local-testing-and-development).
 
 You can create an environment for development with `tox`:
 


### PR DESCRIPTION
juju.is/docs/sdk/dev-setup 404s now. This PR changes the links to that page in the template CONTRIBUTING.md to point to [the current equivalent](https://github.com/tonyandrewmeyer/charmcraft/pull/new/fix-link-in-contributing.md).

(There are many other juju.is links, but fixing these ones in particular seems straightforward, and many of the other redirect).