### PR TITLE
fix(templates): update out-of-date parts in template README files

### DIFF
--- a/charmcraft/templates/init-kubernetes/README.md.j2
+++ b/charmcraft/templates/init-kubernetes/README.md.j2
@@ -10,7 +10,7 @@ Use links instead.
 
 # {{ name }}
 
-Charmhub package name: operator-template
+Charmhub package name: {{ name }}
 More information: https://charmhub.io/{{ name }}
 
 Describe your charm in one or two sentences.

--- a/charmcraft/templates/init-kubernetes/README.md.j2
+++ b/charmcraft/templates/init-kubernetes/README.md.j2
@@ -23,4 +23,4 @@ Describe your charm in one or two sentences.
 
 - [Contributing](CONTRIBUTING.md) <!-- or link to other contribution documentation -->
 
-- See the [Juju SDK documentation](https://juju.is/docs/sdk) for more information about developing and improving charms.
+- See the [Juju documentation](https://documentation.ubuntu.com/juju/3.6/howto/manage-charms/) for more information about developing and improving charms.

--- a/charmcraft/templates/init-kubernetes/README.md.j2
+++ b/charmcraft/templates/init-kubernetes/README.md.j2
@@ -1,7 +1,7 @@
 <!--
 Avoid using this README file for information that is maintained or published elsewhere, e.g.:
 
-* metadata.yaml > published on Charmhub
+* charmcraft.yaml > published on Charmhub
 * documentation > published on (or linked to from) Charmhub
 * detailed contribution guide > documentation or CONTRIBUTING.md
 

--- a/charmcraft/templates/init-machine/README.md.j2
+++ b/charmcraft/templates/init-machine/README.md.j2
@@ -10,7 +10,7 @@ Use links instead.
 
 # {{ name }}
 
-Charmhub package name: operator-template
+Charmhub package name: {{ name }}
 More information: https://charmhub.io/{{ name }}
 
 Describe your charm in one or two sentences.

--- a/charmcraft/templates/init-machine/README.md.j2
+++ b/charmcraft/templates/init-machine/README.md.j2
@@ -23,4 +23,4 @@ Describe your charm in one or two sentences.
 
 - [Contributing](CONTRIBUTING.md) <!-- or link to other contribution documentation -->
 
-- See the [Juju SDK documentation](https://juju.is/docs/sdk) for more information about developing and improving charms.
+- See the [Juju documentation](https://documentation.ubuntu.com/juju/3.6/howto/manage-charms/) for more information about developing and improving charms.

--- a/charmcraft/templates/init-machine/README.md.j2
+++ b/charmcraft/templates/init-machine/README.md.j2
@@ -1,7 +1,7 @@
 <!--
 Avoid using this README file for information that is maintained or published elsewhere, e.g.:
 
-* metadata.yaml > published on Charmhub
+* charmcraft.yaml > published on Charmhub
 * documentation > published on (or linked to from) Charmhub
 * detailed contribution guide > documentation or CONTRIBUTING.md
 


### PR DESCRIPTION
Inspired by https://github.com/canonical/charmcraft/pull/2350, this PR makes some fixes in the template README files for the `kubernetes` and `machine` profiles.

Fixes:

- Talk about `charmcraft.yaml` instead of `metadata.yaml`
- Use the (dynamic) charm name for the package name instead of `operator-template`
- Replace links to https://juju.is/docs/sdk by https://documentation.ubuntu.com/juju/3.6/howto/manage-charms/