### PR TITLE
fix: dockerhub registry for urls with port

### DIFF
--- a/.github/workflows/spread-docs.yaml
+++ b/.github/workflows/spread-docs.yaml
@@ -57,11 +57,8 @@ jobs:
     steps:
       - name: Fix network issues related to docker and lxd
         run: |
-          sudo ip a
           sudo iptables -P FORWARD ACCEPT
           sudo ip6tables -P FORWARD ACCEPT
-          sudo nft list ruleset
-          curl -v -k --connect-timeout 10 https://github-runner-dockerhub-cache.canonical.com
 
       - name: Checkout charmcraft
         uses: actions/checkout@v4
@@ -97,16 +94,6 @@ jobs:
       - name: Run spread
         run: |
           $(go env GOPATH)/bin/spread "${{ matrix.system }}"
-
-      - name: Aproxy logs
-        if: ${{ failure() }}
-        run: |
-          sudo nft list ruleset
-          sudo snap logs aproxy -n=all
-
-      # - name: Setup tmate session
-      #   if: ${{ failure() }}
-      #   uses: canonical/action-tmate@main
 
       - name: Discard spread workers
         if: always()

--- a/spread.yaml
+++ b/spread.yaml
@@ -156,7 +156,7 @@ suites:
     manual: true
     prepare: |
       juju_channel=3.6/stable
-      microk8s_channel=1.31-strict/stable
+      microk8s_channel=1.32/stable
 
       lxc network set lxdbr0 ipv6.address none
       mkdir -p ~/.local/share  # Workaround for Juju not being able to create the directory
@@ -165,7 +165,7 @@ suites:
       . "/charmcraft/tests/spread/tools/prepare.sh"
 
       refresh_or_install_snap juju "$juju_channel"
-      refresh_or_install_snap microk8s "$microk8s_channel"
+      refresh_or_install_snap microk8s "$microk8s_channel" --classic
       refresh_or_install_snap rockcraft latest/edge --classic
 
       if [[ -v CONTAINER_REGISTRY_URL ]]; then
@@ -186,17 +186,14 @@ suites:
       microk8s enable ingress
       microk8s kubectl rollout status deployments/hostpath-provisioner -n kube-system -w --timeout=600s
 
-      # TODO DEBUG
-      microk8s kubectl get all -A
       # Bootstrap controller
-      juju bootstrap microk8s dev-controller --config bootstrap-timeout=1200
+      microk8s config | juju add-k8s my-k8s --client
+      juju bootstrap my-k8s dev-controller --config bootstrap-timeout=500
 
       echo 'connect-timeout = 10' >> ~/.curlrc
       echo 'max-time = 20' >> ~/.curlrc
     debug: |
-      nft list ruleset
       cat /var/snap/microk8s/current/args/certs.d/docker.io/hosts.toml
-      cat /var/snap/microk8s/current/args/certs.d/docker.io/*
       curl -v -k --connect-timeout 10 https://github-runner-dockerhub-cache.canonical.com
       microk8s kubectl get all -A
       microk8s kubectl describe pods -A


### PR DESCRIPTION
When the env var CONTAINER_REGISTRY_URL contains a port, the host entry in 
`/var/snap/microk8s/current/args/certs.d/docker.io/hosts.toml`, the host name should not be the full url, and should not include the protocol (it does not work).

For a CONTAINER_REGISTRY_URL="https://docker.hub.example:5050", the correct content of the file `/var/snap/microk8s/current/args/certs.d/docker.io/hosts.toml` should be:
```
server = "https://docker.hub.example:5050"
[host."docker.hub.example:5050"]
capabilities = ["pull", "resolve"]
```

There were tests failing in some self hosted runners (ps5), as the env var CONTAINER_REGISTRY_URL contains the port number. See this [run](https://github.com/canonical/charmcraft/actions/runs/16243588260/job/45863449276) as an example.

See [actions-operator](https://github.com/charmed-kubernetes/actions-operator/blob/ea90ed489690bf3b1c1fcca6ac5f9edab70aecb0/src/bootstrap/index.ts#L143) for a similar example using typescript.

Also add the wait-for before integration postgresql-k8s in expressjs as it is failing (fix already in place for other frameworks).