### PR TITLE
docs: copy note from Juju docs, tidy up container structure doc

### DIFF
--- a/docs/reference/files/charmcraft-yaml-file.rst
+++ b/docs/reference/files/charmcraft-yaml-file.rst
@@ -508,33 +508,42 @@ created adjacent to the charm (as a sidecar, in the same pod).
 **Structure:** This key consists of a list of containers along with their
 specification. Each container can be specified in terms of ``resource``, ``bases``,
 ``uid``, ``gid`` and ``mounts``, where one of either the ``resource`` or the
-``bases`` subkeys must be defined, and ``mounts`` is optional. ``resource`` stands
-for the OCI image resource used to create the container; to use it, specify  an OCI
-image resource name (that you will then define further in the `resources`_ block).
-``bases`` is a list of bases to be used for resolving a container image, in descending
-order of preference; to use it, specify a base name (for example, ``ubuntu``,
-``centos``, ``windows``, ``osx``, ``opensuse``), a
-`channel <https://snapcraft.io/docs/channels>`_, and an architecture. ``mounts`` is a
-list of mounted storages for this container; to use it, specify the name of the
-storage to mount from the charm storage and, optionally, the location where to mount
-the storage. Starting with Juju 3.5.0, ``uid`` and ``gid`` are the UID and,
-respectively, GID to run the Pebble entry process for this container as; they can
-be any value from 0-999 or any value from 10,000 (values from 1000-9999 are reserved
-for users) and the default is 0 (root).
+``bases`` subkeys must be defined, and ``mounts`` is optional.
+
+The location attribute must be specified when mounting a storage into a workload
+container. It dictates the mount point for the specific container.
+
+Optionally, you can specify the location attribute on the `storage`_ itself,
+which also sets the mount point in the charm container.
 
 .. code-block:: yaml
 
     containers:
       <container name>:
+        # The OCI image resource used to create the container.
+        # Specify an OCI image resource name (that you will then define further
+        # in the `resources` block.
         resource: <resource name>
+        # A list of bases to be used for resolving a container image, in
+        # descending order of preference. Specify a base name (for example,
+        # `ubuntu`, `centos`, `osx`, `opensuse`), a channel
+        # (https://snapcraft.io/docs/channels), and an architecture.
         bases:
           - name: <base name>
             channel: <track[/risk][/branch]>
             architectures:
               - <architecture>
+        # (Optional) A list of mounted storages for this container. Specify the
+        # name of the storage to mount from the charm storage, and, optionally,
+        # the location where to mount the storage.
         mounts:
           - storage: <storage name>
             location: <path>
+        # (Optional) The UID and GID to run the Pebble entry process for this
+        # container as. These can be any value from 0-999 or any value above
+        # 10,000 (values 1000-9999 are reserved for users). The default is 0
+        # (root).
+        # Available in Juju 3.5.0 and above.
         uid: <unix UID>
         gid: <unix GID>
 


### PR DESCRIPTION
The ["Defining storage"](https://documentation.ubuntu.com/juju/3.6/reference/storage/#defining-storage) Juju doc is being removed. Most of this information is already in the `charmcraft.yaml` reference doc, but there is a note about the ability to specify the location of the mounted storage for K8s charms in either `storage` or `containers` that isn't there, so this copies that across.

While doing this, I've also updated the `containers` section of the doc to be less of a wall of text and more similar to the other sections of the doc, like `config`, where there's a shorter "Structure" section and then comments in example YAML that detail each of the fields.

This PR replaces #2380, targeting hotfix/3.5 rather than main as suggested there. The only difference between main and 3.5 in the existing text is dropping "windows" as an example base. I've dropped it here, since it's only in a list of examples not a list of all possible values, I assume we're not wanting to encourage its use, and it means that this will cleanly merge against main.