### PR TITLE
docs: list correct grafana charm as consumer of snap lib charm

### DIFF
--- a/docs/reference/files/libname-py-file.rst
+++ b/docs/reference/files/libname-py-file.rst
@@ -330,7 +330,7 @@ containers.
       - - `mongodb <https://charmhub.io/mongodb>`_
         - `mongodb-k8s <https://charmhub.io/mongodb-k8s>`_
         - `postgresql <https://charmhub.io/postgresql>`_
-        - `grafana-agent-k8s <https://charmhub.io/grafana-agent-k8s>`_
+        - `grafana-agent <https://charmhub.io/grafana-agent>`_
         - `kafka <https://charmhub.io/kafka>`_
       - Install and manage packages via ``snapd``.
     * - `sysctl <https://charmhub.io/operator-libs-linux/libraries/sysctl>`_


### PR DESCRIPTION
The machine charm grafana-agent, not the k8s version uses the snap library. Closes #2390 