### PR TITLE
fix: correct the container name in the 'simple' profile

### DIFF
--- a/charmcraft/templates/init-simple/charmcraft.yaml.j2
+++ b/charmcraft/templates/init-simple/charmcraft.yaml.j2
@@ -48,7 +48,7 @@ config:
 # Your workload’s containers.
 # https://canonical-charmcraft.readthedocs-hosted.com/en/stable/reference/files/charmcraft-yaml-file/#containers
 containers:
-  some-container:
+  httpbin:
     resource: some-container-image
 
 


### PR DESCRIPTION
The 'simple' project was updated to use a different container name in the charm code and tests but the charmcraft.yaml name was not updated.

When run in 3.5 a freshly init'd "simple" will fail tests, with this fix they pass.

The "simple" profile has been removed in main, but it'd be nice to have it work correctly in 3.5.