### PR TITLE
feat!(create-track): make name and track named-args

### DIFF
--- a/charmcraft/application/commands/store.py
+++ b/charmcraft/application/commands/store.py
@@ -2307,11 +2307,13 @@ class CreateTrack(CharmcraftCommand):
         """Add own parameters to the general parser."""
         super().fill_parser(parser=parser)
         parser.add_argument(
-            "name",
+            "--name",
+            required=True,
             help="The store name onto which to create the track",
         )
         parser.add_argument(
-            "track",
+            "--track",
+            required=True,
             nargs="+",
             help="The track name to create",
         )

--- a/tests/spread/store/charm-upload-and-release/task.yaml
+++ b/tests/spread/store/charm-upload-and-release/task.yaml
@@ -44,7 +44,7 @@ execute: |
 
   # Create a track and release it to that, too.
   track_name=$(date +%s)
-  charmcraft create-track $CHARM_DEFAULT_NAME $track_name
+  charmcraft create-track --name=$CHARM_DEFAULT_NAME --track=$track_name
   charmcraft release $CHARM_DEFAULT_NAME -r $uploaded_revno -c ${track_name}/edge/testing
 
   # Releases may have some delay in the craft store, so sleep for a bit before trying and try up to 10 times.


### PR DESCRIPTION
This is a breaking change in Charmcraft 4.0 for the create-track command.

CRAFT-3837