### PR TITLE
docs: remove command output example

### DIFF
--- a/charmcraft/application/commands/store.py
+++ b/charmcraft/application/commands/store.py
@@ -653,12 +653,6 @@ class ListRevisionsCommand(CharmcraftCommand):
         """
         Show version, date and status for each revision in Charmhub.
 
-        For example:
-
-           $ charmcraft revisions mycharm
-           Revision    Version    Created at              Status
-           1           1          2020-11-15T11:13:15Z    released
-
         Listing revisions will take you through login if needed.
     """
     )


### PR DESCRIPTION
Closes #2375. This PR just removes the example given, as similar tabulated commands do not have output examples (see [snapcraft status](https://documentation.ubuntu.com/snapcraft/stable/reference/commands/status/)) and anything beyond simple text is pretty unstable to use in our help messages.