### PR TITLE
ci: check charms generated by `charmcraft init`

### DIFF
--- a/tests/spread/smoketests/init-fast-checks/task.yaml
+++ b/tests/spread/smoketests/init-fast-checks/task.yaml
@@ -2,7 +2,6 @@ summary: Check that the templates pass their own linting and unit tests.
 
 # Limited to Ubuntu 22.04 and 24.04 because the templates require Python >= 3.10.
 systems:
-  - ubuntu-22.04-64
   - ubuntu-24.04-64
 
 environment:


### PR DESCRIPTION
This PR adds a spread test that checks the charms produced by `charmcraft init --profile=kubernetes` and `charmcraft init --profile=machine`. We expect both charms to pass linting and unit tests.

This is actually already covered by one of the existing spread tests - [smoketests/full-lifecycle](https://github.com/canonical/charmcraft/blob/main/tests/spread/smoketests/full-lifecycle/task.yaml) - but in discussion with Alex we decided to add a dedicated test.