### PR TITLE
fix: align oidc redirect-uri to Spring Boot defaults

### DIFF
--- a/tests/extensions/test_app.py
+++ b/tests/extensions/test_app.py
@@ -672,7 +672,7 @@ def test_handle_charm_part_adds_part(flask_input_yaml, tmp_path):
                 "oidc-foobar-redirect-path": {
                     "type": "string",
                     "description": "The path that the user will be redirected upon completing login.",
-                    "default": "/callback",
+                    "default": "/login/oauth2/code/oidc-foobar",
                 },
                 "oidc-foobar-scopes": {
                     "type": "string",


### PR DESCRIPTION
Currently the default callback (redirect-uri) for oidc is `/callback` for all frameworks. 

This is not very Spring Boot specific, and requires code changes in the applications, see:
https://docs.spring.io/spring-security/reference/servlet/oauth2/login/advanced.html#oauth2login-advanced-redirection-endpoint 

Set the default value of redirect-uri to the Spring Boot default as `/login/oauth2/code/{endpoint_name}`. This will make working with Spring Boot seamlessly, and the user still can change it using the config option.

As the Spring Boot extension is still experimental, this is a not breaking change.

