### PR TITLE
docs: small tweaks to best practice blocks

### DIFF
--- a/docs/howto/manage-charms.rst
+++ b/docs/howto/manage-charms.rst
@@ -259,16 +259,14 @@ A bigger charm, that needs multi-page documentation, can have either
 a brief description with a link to an external documentation set, or
 a full `Diátaxis <https://diataxis.fr/>`_ navigation tree in the **Description** tab.
 
-.. admonition:: Best practice
-    :class: hint
+.. admonition:: Tip
 
     Smaller charm documentation examples:
 
     * `Azure storage integrator <https://charmhub.io/azure-storage-integrator>`_ charm
     * `Repo policy compliance <https://charmhub.io/repo-policy-compliance>`_ charm
 
-.. admonition:: Best practice
-    :class: hint
+.. admonition:: Tip
 
     Bigger charm documentation examples:
 

--- a/docs/howto/manage-charms.rst
+++ b/docs/howto/manage-charms.rst
@@ -259,16 +259,12 @@ A bigger charm, that needs multi-page documentation, can have either
 a brief description with a link to an external documentation set, or
 a full `Diátaxis <https://diataxis.fr/>`_ navigation tree in the **Description** tab.
 
-.. admonition:: Tip
-
-    Smaller charm documentation examples:
+.. admonition:: Examples of good documentation in small charms
 
     * `Azure storage integrator <https://charmhub.io/azure-storage-integrator>`_ charm
     * `Repo policy compliance <https://charmhub.io/repo-policy-compliance>`_ charm
 
-.. admonition:: Tip
-
-    Bigger charm documentation examples:
+.. admonition:: Examples of good documentation in big charms
 
     * `OpenSearch <https://charmhub.io/opensearch>`_ charm
     * `Wordpress-k8s <https://charmhub.io/wordpress-k8s>`_ charm

--- a/docs/reference/files/charmcraft-yaml-file.rst
+++ b/docs/reference/files/charmcraft-yaml-file.rst
@@ -895,9 +895,9 @@ endpoint.
 .. admonition:: Best practice
     :class: hint
 
-    Include the ``optional`` key in all endpoint definitions, rather than relying on the default
-    value to indicate that the relation is required. Although this field is
-    not enforced by Juju, including it makes it clear to users (and other tools)
+    Include the ``optional`` key in all endpoint definitions, rather than relying on
+    the default value to indicate that the relation is required. Although this field
+    is not enforced by Juju, including it makes it clear to users (and other tools)
     whether the relation is required.
 
 

--- a/docs/reference/files/charmcraft-yaml-file.rst
+++ b/docs/reference/files/charmcraft-yaml-file.rst
@@ -57,8 +57,8 @@ The value of this key is the contents of :ref:`actions-yaml-file`.
 .. admonition:: Best practice
     :class: hint
 
-    Prefer lowercase alphanumeric action names, and use hyphens (-) to separate words. For
-    charms that have already standardised on underscores, it is not necessary to
+    Prefer lowercase alphanumeric action names, and use hyphens (-) to separate words.
+    For charms that have already standardised on underscores, it is not necessary to
     change them, and it is better to be consistent within a charm then to have
     some action names be dashed and some be underscored.
 

--- a/docs/reference/files/charmcraft-yaml-file.rst
+++ b/docs/reference/files/charmcraft-yaml-file.rst
@@ -57,7 +57,7 @@ The value of this key is the contents of :ref:`actions-yaml-file`.
 .. admonition:: Best practice
     :class: hint
 
-    Prefer lowercase alphanumeric names, and use hyphens (-) to separate words. For
+    Prefer lowercase alphanumeric action names, and use hyphens (-) to separate words. For
     charms that have already standardised on underscores, it is not necessary to
     change them, and it is better to be consistent within a charm then to have
     some action names be dashed and some be underscored.
@@ -470,7 +470,7 @@ secret URI.
 .. admonition:: Best practice
     :class: hint
 
-    Prefer lowercase alphanumeric names, separated with dashes if required. For
+    Prefer lowercase alphanumeric option names, separated with dashes if required. For
     charms that have already standardised on underscores, it is not necessary to
     change them, and it is better to be consistent within a charm then to have
     some config names be dashed and some be underscored.
@@ -670,7 +670,7 @@ determines the name administrators will ultimately use to deploy the charm. E.g.
 .. admonition:: Best practice
     :class: hint
 
-    The name should be slug-oriented (ASCII lowercase letters, numbers, and
+    The charm name should be slug-oriented (ASCII lowercase letters, numbers, and
     hyphens) and follow the pattern ``<workload name in full>[<function>][-k8s]``.
     For example, ``argo-server-k8s``.
 
@@ -895,7 +895,7 @@ endpoint.
 .. admonition:: Best practice
     :class: hint
 
-    Always include the ``optional`` key, rather than relying on the default
+    Include the ``optional`` key in all endpoint definitions, rather than relying on the default
     value to indicate that the relation is required. Although this field is
     not enforced by Juju, including it makes it clear to users (and other tools)
     whether the relation is required.


### PR DESCRIPTION
Two small changes to the best practice blocks, to improve how they appear in the consolidated list that will soon be in the Ops docs (https://github.com/canonical/operator/pull/1989), and in the Charmhub public listing review checklist.

* The "manage charms" how-to has two blocks that have examples of good documentation for small/big charms. These aren't really best practices. I've changed them to a tip.
* A few of the best practices in the `charmcraft.yaml` reference don't work very well when removed from the wider context. I've made small adjustments so that they still work in context, but also work if you have the best practice standing on its own.