### PR TITLE
chore: add Matrix room to 12-factor YAML templates

### DIFF
--- a/charmcraft/templates/init-django-framework/charmcraft.yaml.j2
+++ b/charmcraft/templates/init-django-framework/charmcraft.yaml.j2
@@ -1,5 +1,6 @@
 # This file configures Charmcraft.
 # See https://juju.is/docs/sdk/charmcraft-config for guidance.
+# For questions or help, visit https://matrix.to/#/#12-factor-charms:ubuntu.com 
 
 name: {{ name }}
 

--- a/charmcraft/templates/init-expressjs-framework/charmcraft.yaml.j2
+++ b/charmcraft/templates/init-expressjs-framework/charmcraft.yaml.j2
@@ -1,5 +1,6 @@
 # This file configures Charmcraft.
 # See https://documentation.ubuntu.com/charmcraft/stable/reference/files/charmcraft-yaml-file/ for guidance.
+# For questions or help, visit https://matrix.to/#/#12-factor-charms:ubuntu.com 
 
 name: {{ name }}
 

--- a/charmcraft/templates/init-fastapi-framework/charmcraft.yaml.j2
+++ b/charmcraft/templates/init-fastapi-framework/charmcraft.yaml.j2
@@ -1,5 +1,6 @@
 # This file configures Charmcraft.
 # See https://juju.is/docs/sdk/charmcraft-config for guidance.
+# For questions or help, visit https://matrix.to/#/#12-factor-charms:ubuntu.com 
 
 name: {{ name }}
 

--- a/charmcraft/templates/init-flask-framework/charmcraft.yaml.j2
+++ b/charmcraft/templates/init-flask-framework/charmcraft.yaml.j2
@@ -1,5 +1,6 @@
 # This file configures Charmcraft.
 # See https://juju.is/docs/sdk/charmcraft-config for guidance.
+# For questions or help, visit https://matrix.to/#/#12-factor-charms:ubuntu.com 
 
 name: {{ name }}
 

--- a/charmcraft/templates/init-go-framework/charmcraft.yaml.j2
+++ b/charmcraft/templates/init-go-framework/charmcraft.yaml.j2
@@ -1,5 +1,6 @@
 # This file configures Charmcraft.
 # See https://juju.is/docs/sdk/charmcraft-config for guidance.
+# For questions or help, visit https://matrix.to/#/#12-factor-charms:ubuntu.com 
 
 name: {{ name }}
 

--- a/charmcraft/templates/init-spring-boot-framework/charmcraft.yaml.j2
+++ b/charmcraft/templates/init-spring-boot-framework/charmcraft.yaml.j2
@@ -1,5 +1,6 @@
 # This file configures Charmcraft.
 # See https://juju.is/docs/sdk/charmcraft-config for guidance.
+# For questions or help, visit https://matrix.to/#/#12-factor-charms:ubuntu.com 
 
 name: {{ name }}
 


### PR DESCRIPTION
Relevant ticket: ISD-3415

### Overview

Add Matrix room to the YAML templates for the 12-factor framework extensions.

### Rationale

As part of the 12-factor documentation roadmap for this cycle, we want to clarify the process for providing feedback and guidance in the user journey. As part of these discussions, one point of improvement was to advertise the 12-factor Matrix room as a way to answer questions and help in the setup and onboarding process. 

