### PR TITLE
fix(snap): workaround for snapcraft/craft-application bug

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -137,6 +137,9 @@ parts:
     build-attributes:
       - enable-patchelf
     override-build: |
+      # Workaround for https://github.com/canonical/snapcraft/issues/5831
+      git checkout spread.yaml spread/.extension
+
       /snap/snapcraft/current/libexec/snapcraft/craftctl default
 
       # Install python3-apt


### PR DESCRIPTION
See: https://github.com/canonical/snapcraft/issues/5831

Since this is the only change for 4.0.1 I'm not adding it to the changelog.