### PR TITLE
docs: use lists for all links in landing pages

### DIFF
--- a/docs/explanation/index.rst
+++ b/docs/explanation/index.rst
@@ -13,7 +13,7 @@ Cryptography
 Charmcraft and its external libraries use cryptographic tools for fetching files,
 communicating with local processes, and storing user credentials.
 
-- :ref:`explanation-cryptographic-technology`.
+- :ref:`Cryptographic technology <explanation-cryptographic-technology>`
 
 
 .. toctree::

--- a/docs/explanation/index.rst
+++ b/docs/explanation/index.rst
@@ -13,7 +13,7 @@ Cryptography
 Charmcraft and its external libraries use cryptographic tools for fetching files,
 communicating with local processes, and storing user credentials.
 
-:ref:`explanation-cryptographic-technology`.
+- :ref:`explanation-cryptographic-technology`.
 
 
 .. toctree::

--- a/docs/howto/index.rst
+++ b/docs/howto/index.rst
@@ -11,9 +11,9 @@ Install Charmcraft
 ------------------
 
 Charmcraft can be installed in just a few short steps, regardless of if you are
-installing on Linux, macOS, or an isolated environment. Specific instructions for
-installing Charmcraft and setting up your build container can be found in
-:ref:`manage-charmcraft`.
+installing on Linux, macOS, or an isolated environment.
+
+- :ref:`manage-charmcraft`.
 
 
 Craft charms

--- a/docs/howto/index.rst
+++ b/docs/howto/index.rst
@@ -24,13 +24,13 @@ you are charming. Once you initialize the project with either the default profil
 of Charmcraft's web app extensions, you can modify a charm's YAML and Ops-powered Python
 to include any necessary libraries, parts, or other assets your application may require.
 
-* :ref:`manage-charms`
-* :ref:`Manage builds <howto-build-guides>`
-* :ref:`Manage 12-factor app charms <manage-12-factor-app-charms>`
-* :ref:`manage-parts`
-* :ref:`manage-resources`
-* :ref:`manage-libraries`
-* :ref:`manage-extensions`
+- :ref:`manage-charms`
+- :ref:`Manage builds <howto-build-guides>`
+- :ref:`Manage 12-factor app charms <manage-12-factor-app-charms>`
+- :ref:`manage-parts`
+- :ref:`manage-resources`
+- :ref:`manage-libraries`
+- :ref:`manage-extensions`
 
 
 Publish charms and manage releases
@@ -39,12 +39,12 @@ Publish charms and manage releases
 When you're ready to distribute your charm, Charmcraft provides commands to register it,
 publish it to Charmhub, and manage its releases.
 
-* :ref:`manage-the-current-charmhub-user`
-* :ref:`manage-names`
-* :ref:`manage-icons`
-* :ref:`manage-charm-revisions`
-* :ref:`manage-tracks`
-* :ref:`manage-channels`
+- :ref:`manage-the-current-charmhub-user`
+- :ref:`manage-names`
+- :ref:`manage-icons`
+- :ref:`manage-charm-revisions`
+- :ref:`manage-tracks`
+- :ref:`manage-channels`
 
 
 Migrate between plugins
@@ -54,9 +54,9 @@ Certain charms may benefit from using a plugin other than the default Charm plug
 instructions on migrating away from the default Charm plugin, refer to the appropriate
 migration guide for your charm:
 
-* :ref:`howto-migrate-to-poetry`
-* :ref:`howto-migrate-to-python`
-* :ref:`howto-migrate-to-uv`
+- :ref:`howto-migrate-to-poetry`
+- :ref:`howto-migrate-to-python`
+- :ref:`howto-migrate-to-uv`
 
 
 .. toctree::

--- a/docs/howto/index.rst
+++ b/docs/howto/index.rst
@@ -13,7 +13,7 @@ Install Charmcraft
 Charmcraft can be installed in just a few short steps, regardless of if you are
 installing on Linux, macOS, or an isolated environment.
 
-- :ref:`manage-charmcraft`.
+- :ref:`manage-charmcraft`
 
 
 Craft charms

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -13,13 +13,13 @@ Command-line reference
 The following pages document all of Charmcraft's commands, including their usage,
 options, and arguments:
 
-* :ref:`reference-lifecycle-commands`
-* :ref:`reference-store-commands`
-* :ref:`reference-account-commands`
-* :ref:`reference-charm-commands`
-* :ref:`reference-library-commands`
-* :ref:`reference-extension-commands`
-* :ref:`reference-other-commands`
+- :ref:`reference-lifecycle-commands`
+- :ref:`reference-store-commands`
+- :ref:`reference-account-commands`
+- :ref:`reference-charm-commands`
+- :ref:`reference-library-commands`
+- :ref:`reference-extension-commands`
+- :ref:`reference-other-commands`
 
 
 Files
@@ -28,26 +28,26 @@ Files
 In the context of Charmcraft, a *file* refers to any file in a project that can be
 initialized or packed. The files are documented in the following pages:
 
-* :ref:`actions-yaml-file`
-* :ref:`charmcraft-yaml-file`
-* :ref:`config-yaml-file`
-* :ref:`contributing-md-file`
-* :ref:`dispatch-file`
-* :ref:`icon-svg-file`
-* :ref:`libname-py-file`
-* :ref:`license-file`
-* :ref:`lxd-profile-yaml-file`
-* :ref:`manifest-yaml-file`
-* :ref:`metadata-yaml-file`
-* :ref:`pyproject-toml-file`
-* :ref:`readme-md-file`
-* :ref:`requirements-txt-file`
-* :ref:`src-charm-py-file`
-* :ref:`src-workload-py-file`
-* :ref:`tests-integration-test-charm-py-file`
-* :ref:`tests-unit-test-charm-py-file`
-* :ref:`tox-ini-file`
-* :ref:`uv-lock-file`
+- :ref:`actions-yaml-file`
+- :ref:`charmcraft-yaml-file`
+- :ref:`config-yaml-file`
+- :ref:`contributing-md-file`
+- :ref:`dispatch-file`
+- :ref:`icon-svg-file`
+- :ref:`libname-py-file`
+- :ref:`license-file`
+- :ref:`lxd-profile-yaml-file`
+- :ref:`manifest-yaml-file`
+- :ref:`metadata-yaml-file`
+- :ref:`pyproject-toml-file`
+- :ref:`readme-md-file`
+- :ref:`requirements-txt-file`
+- :ref:`src-charm-py-file`
+- :ref:`src-workload-py-file`
+- :ref:`tests-integration-test-charm-py-file`
+- :ref:`tests-unit-test-charm-py-file`
+- :ref:`tox-ini-file`
+- :ref:`uv-lock-file`
 
 
 Plugins and extensions
@@ -57,9 +57,9 @@ Extensions help initialize your project with template YAML and Ops-powered Pytho
 remove the boilerplate steps of crafting charms for Django, FastAPI, Flask, and Go
 applications.
 
-* :ref:`profile`
-* :ref:`extensions`
-* :ref:`plugins`
+- :ref:`profile`
+- :ref:`extensions`
+- :ref:`plugins`
 
 
 .. toctree::

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -16,12 +16,12 @@ Charmcraft's extensions enable you to build Django, FastAPI, Flask, and Go appli
 with just a few modifications to the YAML template content. To familiarize yourself
 with one of these workflows, start with its tutorial:
 
-* :ref:`write-your-first-kubernetes-charm-for-a-django-app`
-* :ref:`write-your-first-kubernetes-charm-for-a-expressjs-app`
-* :ref:`write-your-first-kubernetes-charm-for-a-fastapi-app`
-* :ref:`write-your-first-kubernetes-charm-for-a-flask-app`
-* :ref:`write-your-first-kubernetes-charm-for-a-go-app`
-* :ref:`write-your-first-kubernetes-charm-for-a-spring-boot-app`
+- :ref:`write-your-first-kubernetes-charm-for-a-django-app`
+- :ref:`write-your-first-kubernetes-charm-for-a-expressjs-app`
+- :ref:`write-your-first-kubernetes-charm-for-a-fastapi-app`
+- :ref:`write-your-first-kubernetes-charm-for-a-flask-app`
+- :ref:`write-your-first-kubernetes-charm-for-a-go-app`
+- :ref:`write-your-first-kubernetes-charm-for-a-spring-boot-app`
 
 
 .. toctree::


### PR DESCRIPTION
Only the change to the explanation index was needed, but I changed the list type while I was at it.