### PR TITLE
test: loosen invalid charm loading test

### DIFF
--- a/tests/integration/invalid-charms/multibase-charm-plugin/errors.json
+++ b/tests/integration/invalid-charms/multibase-charm-plugin/errors.json
@@ -13,7 +13,6 @@
     },
     "ctx": {
       "error": "Cannot use 'charm' or 'reactive' plugins with bases 'ubuntu@25.10' or 'ubuntu@26.04'"
-    },
-    "url": "https://errors.pydantic.dev/2.11/v/value_error"
+    }
   }
 ]

--- a/tests/integration/invalid-charms/multibase-questing-charm-plugin/errors.json
+++ b/tests/integration/invalid-charms/multibase-questing-charm-plugin/errors.json
@@ -13,7 +13,6 @@
     },
     "ctx": {
       "error": "Cannot use 'charm' or 'reactive' plugins with base 'ubuntu@25.10'"
-    },
-    "url": "https://errors.pydantic.dev/2.11/v/value_error"
+    }
   }
 ]

--- a/tests/integration/invalid-charms/multibase-resolute-charm-plugin/errors.json
+++ b/tests/integration/invalid-charms/multibase-resolute-charm-plugin/errors.json
@@ -13,7 +13,6 @@
     },
     "ctx": {
       "error": "Cannot use 'charm' or 'reactive' plugins with base 'ubuntu@26.04'"
-    },
-    "url": "https://errors.pydantic.dev/2.11/v/value_error"
+    }
   }
 ]

--- a/tests/integration/invalid-charms/questing-charm-plugin/errors.json
+++ b/tests/integration/invalid-charms/questing-charm-plugin/errors.json
@@ -13,7 +13,6 @@
     },
     "ctx": {
       "error": "Cannot use 'charm' or 'reactive' plugins with base 'ubuntu@25.10'"
-    },
-    "url": "https://errors.pydantic.dev/2.11/v/value_error"
+    }
   }
 ]

--- a/tests/integration/invalid-charms/questing-reactive-plugin/errors.json
+++ b/tests/integration/invalid-charms/questing-reactive-plugin/errors.json
@@ -13,7 +13,6 @@
     },
     "ctx": {
       "error": "Cannot use 'charm' or 'reactive' plugins with base 'ubuntu@25.10'"
-    },
-    "url": "https://errors.pydantic.dev/2.11/v/value_error"
+    }
   }
 ]

--- a/tests/integration/invalid-charms/resolute-charm-plugin/errors.json
+++ b/tests/integration/invalid-charms/resolute-charm-plugin/errors.json
@@ -13,7 +13,6 @@
     },
     "ctx": {
       "error": "Cannot use 'charm' or 'reactive' plugins with base 'ubuntu@26.04'"
-    },
-    "url": "https://errors.pydantic.dev/2.11/v/value_error"
+    }
   }
 ]

--- a/tests/integration/invalid-charms/resolute-reactive-plugin/errors.json
+++ b/tests/integration/invalid-charms/resolute-reactive-plugin/errors.json
@@ -13,7 +13,6 @@
     },
     "ctx": {
       "error": "Cannot use 'charm' or 'reactive' plugins with base 'ubuntu@26.04'"
-    },
-    "url": "https://errors.pydantic.dev/2.11/v/value_error"
+    }
   }
 ]

--- a/tests/integration/test_application.py
+++ b/tests/integration/test_application.py
@@ -90,9 +90,16 @@ def test_load_invalid_charm(in_project_path: pathlib.Path, charm_dir: pathlib.Pa
     with pytest.raises(pydantic.ValidationError) as exc_info:
         app.services.get("project").get()
 
-    error_dict = json.loads((charm_dir / "errors.json").read_text())
+    expected_exc_list = json.loads((charm_dir / "errors.json").read_text())
 
-    assert json.loads(exc_info.value.json()) == error_dict, "Errors do not match"
+    # The Pydantic errors include a URL that includes the current Pydantic version,
+    # meaning it changes in ways that aren't meaningful to test
+    # Instead, just omit the URL from the test entirely.
+    exc_list = json.loads(exc_info.value.json())
+    for e in exc_list:
+        _ = e.pop("url")
+
+    assert exc_list == expected_exc_list, "Errors do not match"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The current test depends on the exact value of the exception raised, which includes a versioned URL to the Pydantic docs. When Pydantic gets bumped, this URL changes and would require a change to all of the test strings. [Example failure here](https://github.com/canonical/charmcraft/actions/runs/19615212296/job/56166803326?pr=2485)

To avoid having tests that are dependent on minor versions of libraries, this PR just avoids checking the URL in particular.