### PR TITLE
feat: add adoption help at end of init message

### DIFF
--- a/charmcraft/application/commands/init.py
+++ b/charmcraft/application/commands/init.py
@@ -126,7 +126,7 @@ README.md
 
 To manage your charm's dependencies, use uv.
 
-To migrate from the 'charm' plugin, see:
+To migrate from the Charm plugin to the uv plugin, see:
 https://documentation.ubuntu.com/charmcraft/stable/howto/migrate-plugins/charm-to-uv/
 """
 


### PR DESCRIPTION
The machine and Kubernetes profiles in Charmcraft 4 use the uv plugin, which requires a different way of managing dependencies than in earlier versions of Charmcraft. The difference is not apparent when running `charmcraft init`. See https://github.com/canonical/charmcraft/issues/2494 for an example of how this can trip people up.

This PR adds extra lines at the end of the success message from `charmcraft init`:

```
To manage your charm's dependencies, use uv.

To migrate from the 'charm' plugin, see:
https://documentation.ubuntu.com/charmcraft/stable/howto/migrate-plugins/charm-to-uv/
```

My thinking is that the second line (and doc link) could be removed in a future version of Charmcraft.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/charmcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [ ] ~I've added or updated any relevant documentation.~
- [ ] I've updated the relevant release notes.
