### PR TITLE
test(spread): enable Ubuntu 25.10 and 26.04 spread runners

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -43,11 +43,11 @@ backends:
           workers: 6
           memory: 8G
           storage: 40G
-      # https://github.com/canonical/charmcraft/issues/2480
-      # - ubuntu-25.10-64:
-      #     workers: 6
-      #     memory: 8G
-      #     storage: 40G
+      - ubuntu-25.10-64:
+          image: ubuntu-os-cloud/ubuntu-2510-amd64
+          workers: 6
+          memory: 8G
+          storage: 40G
       - ubuntu-26.04-64:
           image: ubuntu-os-cloud-devel/ubuntu-2604-lts-amd64
           workers: 6


### PR DESCRIPTION
Fixes: 2480

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/charmcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
- [ ] I've updated the relevant release notes.
