### PR TITLE
docs: note the additionalProperties default value flip in Juju 4.0

### DIFF
--- a/docs/reference/files/actions-yaml-file.rst
+++ b/docs/reference/files/actions-yaml-file.rst
@@ -224,7 +224,7 @@ Juju will parse additional keywords as a `JSON Schema`_ with some limitations:
   type `object <jsonschema-object>`_ with a map of ``properties`` corresponding to
   each key in ``params``. This instance is what Juju uses to validate user input.
 
-It is highly recommended to explictly include ``additionalProperties`` to have consistent
+Explicitly include ``additionalProperties``, which provides consistent
 behaviour between Juju 3 and Juju 4. Using the Juju 4 default, ``additionalProperties: false``,
 avoids user frustration with accidental typos.
 

--- a/docs/reference/files/actions-yaml-file.rst
+++ b/docs/reference/files/actions-yaml-file.rst
@@ -143,7 +143,9 @@ validation, defined as follows:
     2. It does not currently support the JSON Schema concepts ``$schema`` and ``$ref``.
     3. The ``additionalProperties`` and ``required`` keys from JSON Schema can be used
        at the top-level of an action (adjacent to ``description`` and ``params``), but
-       also used anywhere within a nested schema.
+       also used anywhere within a nested schema. Note that Juju 4 flips the default
+       used in JSON Schema (Juju 3 and JSON Schema use a ``true`` default, Juju 4 uses
+       a default of ``false``).
 
         See more: `JSON schema <https://www.learnjsonschema.com/>`_
 
@@ -222,8 +224,9 @@ Juju will parse additional keywords as a `JSON Schema`_ with some limitations:
   type `object <jsonschema-object>`_ with a map of ``properties`` corresponding to
   each key in ``params``. This instance is what Juju uses to validate user input.
 
-It is highly recommended to provide ``additionalProperties: false`` to avoid user
-frustration with accidental typos.
+It is highly recommended to explictly include ``additionalProperties`` to have consistent
+behaviour in Juju 3 and Juju 4. Using the Juju 4 default, ``additionalProperties: false``,
+avoids user frustration with accidental typos.
 
 .. _JSON-Schema: https://json-schema.org/
 .. _jsonschema-object: https://json-schema.org/understanding-json-schema/reference/object.html

--- a/docs/reference/files/actions-yaml-file.rst
+++ b/docs/reference/files/actions-yaml-file.rst
@@ -225,7 +225,7 @@ Juju will parse additional keywords as a `JSON Schema`_ with some limitations:
   each key in ``params``. This instance is what Juju uses to validate user input.
 
 It is highly recommended to explictly include ``additionalProperties`` to have consistent
-behaviour in Juju 3 and Juju 4. Using the Juju 4 default, ``additionalProperties: false``,
+behaviour between Juju 3 and Juju 4. Using the Juju 4 default, ``additionalProperties: false``,
 avoids user frustration with accidental typos.
 
 .. _JSON-Schema: https://json-schema.org/

--- a/docs/reference/files/charmcraft-yaml-file.rst
+++ b/docs/reference/files/charmcraft-yaml-file.rst
@@ -62,6 +62,13 @@ The value of this key is the contents of :ref:`actions-yaml-file`.
     change them, and it is better to be consistent within a charm then to have
     some action names be dashed and some be underscored.
 
+.. admonition:: Best practice
+    :class: hint
+
+    Always explicitly include the ``additionalProperties`` key. The default value is
+    different in Juju 3 (``true``) and Juju 4 (``false``), so explicitly including it
+    in the actions definition ensures consistent behaviour.
+
 
 .. _charmcraft-yaml-key-analysis:
 

--- a/docs/reference/files/charmcraft-yaml-file.rst
+++ b/docs/reference/files/charmcraft-yaml-file.rst
@@ -67,7 +67,7 @@ The value of this key is the contents of :ref:`actions-yaml-file`.
 
     Always explicitly include the ``additionalProperties`` key. The default value is
     different in Juju 3 (``true``) and Juju 4 (``false``), so explicitly including it
-    in the actions definition ensures consistent behaviour.
+    in the actions definition ensures consistent behaviour between versions.
 
 
 .. _charmcraft-yaml-key-analysis:


### PR DESCRIPTION
In Juju 4 the default value for `additionalProperties` in action config has been flipped from `true` to `false` (https://github.com/juju/juju/issues/21294). Note in this in the actions.yaml and charmcraft.yaml files, recommending explicitly including it rather than relying on the default, to avoid inconsistent behaviour (including potential breakage) across Juju versions.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/charmcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] ~I've successfully run `make lint && make test`.~
- [x] I've added or updated any relevant documentation.
- [ ] ~I've updated the relevant release notes.~
