### PR TITLE
feat(templates): add 'assumes' for machine and kubernetes profiles

### DIFF
--- a/charmcraft/templates/init-kubernetes/charmcraft.yaml.j2
+++ b/charmcraft/templates/init-kubernetes/charmcraft.yaml.j2
@@ -20,6 +20,10 @@ platforms:
   amd64:
   arm64:
 
+assumes:
+  - juju >= 3.6
+  - k8s-api
+
 parts:
   charm:
     plugin: uv

--- a/charmcraft/templates/init-machine/charmcraft.yaml.j2
+++ b/charmcraft/templates/init-machine/charmcraft.yaml.j2
@@ -20,6 +20,9 @@ platforms:
   amd64:
   arm64:
 
+assumes:
+  - juju >= 3.6
+
 parts:
   charm:
     plugin: uv


### PR DESCRIPTION
This PR adds `assumes` to `charmcraft.yaml` in the `machine` and `kubernetes` profiles. We used to have `assumes` in the default (`simple`) profile, but I think this got lost during the transition to `kubernetes` as the default profile. I'm specifying a minimum Juju version of 3.6 as that's the current LTS version (see [Tool versions](https://documentation.ubuntu.com/ops/latest/explanation/versions/)).

Based on reading the docs and my own testing, `k8s-api` is important to specify for the `kubernetes` profile, so that Juju immediately rejects an attempt to deploy a K8s charm on a machine model. Otherwise, Juju can sit indefinitely with a waiting status.

---

- [X] I've followed the [contribution guidelines](https://github.com/canonical/charmcraft/blob/main/CONTRIBUTING.md).
- [X] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [X] I've successfully run `make lint && make test`.
- [ ] ~I've added or updated any relevant documentation.~
- [ ] I've updated the relevant release notes.
