### PR TITLE
fix(templates): match 'uv add' order of lint fields in pyproject.toml

### DIFF
--- a/charmcraft/templates/init-kubernetes/pyproject.toml.j2
+++ b/charmcraft/templates/init-kubernetes/pyproject.toml.j2
@@ -63,8 +63,8 @@ lint.ignore = [
     "D409",
     "D413",
 ]
-extend-exclude = ["__pycache__", "*.egg_info"]
 lint.per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
+extend-exclude = ["__pycache__", "*.egg_info"]
 
 [tool.ruff.lint.mccabe]
 max-complexity = 10

--- a/charmcraft/templates/init-machine/pyproject.toml.j2
+++ b/charmcraft/templates/init-machine/pyproject.toml.j2
@@ -62,8 +62,8 @@ lint.ignore = [
     "D409",
     "D413",
 ]
-extend-exclude = ["__pycache__", "*.egg_info"]
 lint.per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
+extend-exclude = ["__pycache__", "*.egg_info"]
 
 [tool.ruff.lint.mccabe]
 max-complexity = 10


### PR DESCRIPTION
This PR fixes a tiny issue with the `kubernetes` and `machine` profiles. Currently, running `uv add <package>` in a charm project causes an unrelated field ordering change in `pyproject.toml`. That can result in unnecessary diffs, so I'm switching the profiles to the "correct" field ordering.

---

- [X] I've followed the [contribution guidelines](https://github.com/canonical/charmcraft/blob/main/CONTRIBUTING.md).
- [X] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [X] I've successfully run `make lint && make test`.
- [ ] ~I've added or updated any relevant documentation.~
- [ ] I've updated the relevant release notes.
