### PR TITLE
fix(templates): in kubernetes unit tests, clarify the mock layer and improve style

### DIFF
--- a/charmcraft/templates/init-kubernetes/tests/unit/test_charm.py.j2
+++ b/charmcraft/templates/init-kubernetes/tests/unit/test_charm.py.j2
@@ -11,12 +11,15 @@ from charm import SERVICE_NAME, {{ class_name }}
 
 CHECK_NAME = "service-ready"  # Name of Pebble check in the mock workload container.
 
+# A minimal Pebble layer for our testing.Container objects.
+# Our charm doesn't retrieve the service command or the check URL
+# from Pebble, so this layer doesn't need a real command or URL.
 MOCK_LAYER = ops.pebble.Layer(
     {
         "services": {
             SERVICE_NAME: {
                 "override": "replace",
-                "command": "/bin/foo",  # The specific command isn't important for unit tests.
+                "command": "mock-command",
                 "startup": "enabled",
             }
         },
@@ -27,7 +30,7 @@ MOCK_LAYER = ops.pebble.Layer(
                 "threshold": 3,
                 "startup": "enabled",
                 "http": {
-                    "url": "http://localhost:8000/version",  # The specific URL isn't important.
+                    "url": "http://localhost:1234/mock-endpoint",
                 },
             }
         },


### PR DESCRIPTION
This PR fixes some documentation & style issues in the unit tests of the `kubernetes` profile. The main change is to clarify why it's appropriate for the Pebble layer to contain mock data ([reviewed here](https://github.com/canonical/charmcraft-profile-tools/pull/15#discussion_r2703063224)).

---

- [X] I've followed the [contribution guidelines](https://github.com/canonical/charmcraft/blob/main/CONTRIBUTING.md).
- [X] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [X] I've successfully run `make lint && make test`.
- [ ] ~I've added or updated any relevant documentation.~
- [ ] I've updated the relevant release notes.
