### PR TITLE
fix(plugins/uv): Avoid modifying already relocatable venv

### DIFF
--- a/charmcraft/parts/plugins/_uv.py
+++ b/charmcraft/parts/plugins/_uv.py
@@ -61,6 +61,9 @@ class UvPlugin(uv_plugin.UvPlugin):
         return [
             *super().get_build_commands(),
             *utils.get_venv_cleanup_commands(
-                self._get_venv_directory(), keep_bins=False
+                self._get_venv_directory(),
+                keep_bins=False,
+                # craft-parts already uses `uv venv --relocatable`
+                make_relocatable=False,
             ),
         ]


### PR DESCRIPTION
The uv plugin from craft-parts already uses `uv venv --relocatable` to create an activate script that has a portable path instead of an absolute path
https://github.com/canonical/craft-parts/blob/71291d50ec95aed813215e89463866dd09aaaa5e/craft_parts/plugins/uv_plugin.py#L108

Currently, charmcraft is overriding the relocatable path set by uv with its own relocatable path (since it's expecting `activate` to contain a hardcoded absolute path, like it does with `venv`)

This currently doesn't cause any issues, but could break in the future if the format of the activate script created by `uv venv` changes (since charmcraft is using `sed` to update the script)

Use the relocatable option provided by uv's public API instead of patching a private implementation detail
