### PR TITLE
docs: re-enable 'Part properties'

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -115,9 +115,6 @@ extensions.extend(
 # endregion
 
 exclude_patterns = [
-    # Workaround for https://github.com/canonical/pydantic-kitbash/issues/49
-    "common/craft-parts/reference/part_properties.rst",
-
     "_build",
     "Thumbs.db",
     ".DS_Store",

--- a/docs/reference/parts/index.rst
+++ b/docs/reference/parts/index.rst
@@ -10,6 +10,7 @@ system that charmcraft uses.
 .. toctree::
    :maxdepth: 1
 
+   /common/craft-parts/reference/part_properties
    /common/craft-parts/reference/parts_steps
    /common/craft-parts/reference/step_execution_environment
    /common/craft-parts/explanation/filesets


### PR DESCRIPTION
Adds 'Part properties' back to the 'Parts' index. This should've been done after I resolved https://github.com/canonical/craft-parts/issues/1177 and https://github.com/canonical/pydantic-kitbash/issues/50.

Resolves https://github.com/canonical/charmcraft/issues/2378.

Partly resolves #2554.

---

- [X] I've followed the [contribution guidelines](https://github.com/canonical/charmcraft/blob/main/CONTRIBUTING.md).
- [X] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
~~I've successfully run `make lint && make test`.~~
~~I've added or updated any relevant documentation.~~
~~I've updated the relevant release notes.~~
