### PR TITLE
docs: Redo in-page links for: Mange charm revisions, Manage the current charmhub user, and Manage tracks

### DIFF
--- a/docs/howto/manage-revisions.rst
+++ b/docs/howto/manage-revisions.rst
@@ -3,28 +3,26 @@
 Manage charm revisions
 ======================
 
+This guide shows you how to create, view, and promote charm revisions,
+and how to release a charm revision into a channel.
+
 .. raw:: html
 
     <!--As opposed to resource revisions.-->
 
-
 Create a charm revision
 -----------------------
 
-A charm revision is created implicitly every time you upload a charm to
-Charmhub (unless you're uploading the exact same file again).
-
-    See more: :ref:`publish-a-charm`
-
+A charm revision is created implicitly every time you
+:ref:`upload a charm on Charmhub <publish-a-charm>` (unless you're
+uploading the exact same file again).
 
 View the existing charm revisions
 ---------------------------------
 
-To inspect the existing charm revisions, run ``charmcraft revisions``
-followed by the name of the charm.
-
-    See more: :ref:`ref_commands_revisions`
-
+To inspect the existing charm revisions, run
+:ref:`charmcraft revisions <ref_commands_revisions>`, followed by the name
+of the charm.
 
 Promote a charm revision to a better risk level
 -----------------------------------------------
@@ -65,14 +63,14 @@ maintained separately from Charmcraft.
         3.6/beta:       ↑
         3.6/edge:       100  2023-02-03  (100)  860kB  amd64  ubuntu@20.04, ubuntu@18.04
 
-
 .. _release-a-revision-into-a-channel:
 
 Release a charm revision into a channel
 ---------------------------------------
 
-To release a specific charm revision to a channel, run ``charmcraft release`` followed
-by the name of the charm and flags specifying the revision and its target channel. E.g.,
+To :ref:`ref_commands_release` a specific charm revision to a channel, run ``charmcraft release``,
+followed by the name of the charm and flags specifying the revision and
+its target channel. For example,
 
 .. code-block:: bash
 
@@ -82,16 +80,10 @@ by the name of the charm and flags specifying the revision and its target channe
 
     Revision 1 of charm 'my-awesome-charm' released to beta
 
-..
-
-    See more: :ref:`ref_commands_release`
-
-This opens the channel you're releasing to.
-
-    See more: :ref:`manage-channels`
+This opens the channel you're releasing to. For more information on
+managing channels, see :ref:`manage-channels`.
 
 Following the release, Charmhub will display the charm's information at
 ``charmhub.io/<charm-name>``. (The default information displayed is obtained from the
 most stable channel.) Your charm will also become available for download.
-
-    See more: :external+juju:ref:`Juju | Manage charms <manage-charms>`
+For more information on managing charms, see :external+juju:ref:`manage-charms`.

--- a/docs/howto/manage-revisions.rst
+++ b/docs/howto/manage-revisions.rst
@@ -86,4 +86,3 @@ managing channels, see :ref:`manage-channels`.
 Following the release, Charmhub will display the charm's information at
 ``charmhub.io/<charm-name>``. (The default information displayed is obtained from the
 most stable channel.) Your charm will also become available for download.
-For more information on managing charms, see :external+juju:ref:`manage-charms`.

--- a/docs/howto/manage-the-current-charmhub-user.rst
+++ b/docs/howto/manage-the-current-charmhub-user.rst
@@ -3,17 +3,18 @@
 Manage the current Charmhub user
 ================================
 
-    See first: `Charmhub`_
-
+This guide explains how to log in to  `Charmhub`_, check the currently
+logged-in user, and log out.
 
 Log in to Charmhub
 ------------------
 
+How you log in depends on whether you're working in a local or remote environment.
 
 Local environments
 ~~~~~~~~~~~~~~~~~~
 
-To log in to Charmhub, run ``charmcraft login``:
+To log in to Charmhub, run :ref:`charmcraft login <ref_commands_login>`:
 
 .. code-block:: bash
 
@@ -24,11 +25,6 @@ To log in to Charmhub, run ``charmcraft login``:
     Opening an authorization web page in your browser.
     If it does not open, please open this URL:
     ...
-
-..
-
-   See more: :ref:`ref_commands_login`
-
 
 Remote environments
 ~~~~~~~~~~~~~~~~~~~
@@ -136,18 +132,12 @@ will push and release a charm could be:
         ...
         charmcraft upload my-super-charm.charm --release edge
 
-
 Check the currently logged in user
 ----------------------------------
 
-To check the currently logged in user, run ``charmcraft whoami``.
-
-    See more: :ref:`ref_commands_whoami`
-
+To check the currently logged in user, run :ref:`charmcraft whoami <ref_commands_whoami>`.
 
 Log out of Charmhub
 -------------------
 
-To log out of Charmhub, run ``charmcraft logout``.
-
-    See more: :ref:`ref_commands_logout`
+To log out of Charmhub, run :ref:`charmcraft logout <ref_commands_logout>`.

--- a/docs/howto/manage-the-current-charmhub-user.rst
+++ b/docs/howto/manage-the-current-charmhub-user.rst
@@ -135,7 +135,7 @@ will push and release a charm could be:
 Check the currently logged in user
 ----------------------------------
 
-To check the currently logged in user, run :ref:`charmcraft whoami <ref_commands_whoami>`.
+To check the currently logged-in user, run :ref:`charmcraft whoami <ref_commands_whoami>`.
 
 Log out of Charmhub
 -------------------

--- a/docs/howto/manage-tracks.rst
+++ b/docs/howto/manage-tracks.rst
@@ -118,7 +118,7 @@ To create a new track yourself, follow the steps below:
 
    Of course, the tracks must conform to the existing guardrail for the charm.
 
-   For more information on the API endpoint to create a new track, see
+   For the API reference for creating a new track, see
    `create_tracks <https://api.charmhub.io/docs/default/#create-tracks>`__
 
 That's it, you now have a new track for your charm!

--- a/docs/howto/manage-tracks.rst
+++ b/docs/howto/manage-tracks.rst
@@ -3,26 +3,23 @@
 Manage tracks
 =============
 
-    See first: :external+juju:ref:`Juju | Charm channel track <charm-channel-track>`
+This guide shows you how to request a track guardrail and create new
+:external+juju:ref:`tracks <charm-channel-track>` for your charm on Charmhub.
 
 When you register a charm name on Charmhub, you automatically get 4 channels, all with
 track ``latest``. However, as your charm evolves, you'll likely want to customise the
 shape of this track (e.g., to align with the workload) and then create new tracks in the
 new pattern. This document shows you how.
 
-
 .. _request-a-track-guardrail:
 
 Request a track guardrail
 -------------------------
 
-    See first: :external+juju:ref:`Juju | Charm channel track guardrail
-    <charm-channel-track-guardrail>`
-
-To request a track guardrail, contact a Charmhub admin by creating a post on Discourse
-under the **charmhub requests** category, that is, here:
+To request a :external+juju:ref:`track guardrail <charm-channel-track-guardrail>`,
+contact a Charmhub admin by creating a post on Discourse under the
+**charmhub requests** category, that is, here:
 :literalref:`https://discourse.charmhub.io/c/charmhub-requests`.
-
 
 .. _create-a-track:
 
@@ -34,7 +31,6 @@ your charm -- you can keep contacting a Charmhub admin every time or you can
 self-service. For most cases the latter option is likely to be more convenient and
 faster.
 
-
 Ask a Charmhub admin
 ~~~~~~~~~~~~~~~~~~~~
 
@@ -42,7 +38,6 @@ To create a new track by contacting a Charmhub admin, create a post on Discourse
 the `charmhub requests  category
 <https://discourse.charmhub.io/c/charmhub-requests/46>`_. The admin will create the new
 track that fits within the track guardrail you've set up for your charm.
-
 
 Create it yourself
 ~~~~~~~~~~~~~~~~~~
@@ -85,7 +80,7 @@ To create a new track yourself, follow the steps below:
       At this point you can use this variable in ``curl`` commands -- just make sure to
       specify the correct ``Content-Type``.
 
-2. Use curl to view the existing guardrails and tracks.** To view the guardrails and
+2. Use curl to view the existing guardrails and tracks. To view the guardrails and
    tracks associated with your charm, issue an HTTP ``GET`` request to
    ``/v1/<namespace>/<name>``. For example, for a charm named ``hello-world-charm``:
 
@@ -94,23 +89,22 @@ To create a new track yourself, follow the steps below:
        curl https://api.charmhub.io/v1/charm/hello-world-charm -H'Content-type: application/json' -H "$CHARMHUB_MACAROON_HEADER"
 
    The guardrails and tracks of the package will be under the ``track-guardrails``
-   and ``tracks`` keys of ``metadata``. Now you know what the new track may look like.
-
-    See more: `Charmhub API docs > package\_metadata
-    <https://api.charmhub.io/docs/default/#package-metadata>`__
+   and ``tracks`` keys of ``metadata``. For more information on the API endpoint to
+   view the existing guardrails and tracks, see
+   `package\_metadata <https://api.charmhub.io/docs/default/#package-metadata>`__
 
    .. important::
 
-       If you want to view the guardrails and tracks for all published charms,Issue an
+       If you want to view the guardrails and tracks for all published charms, issue an
        HTTP ``GET`` request to ``/v1/<namespace>``, as below.
 
        .. code-block:: bash
 
            curl https://api.charmhub.io/v1/charm -H'Content-type: application/json' -H "$CHARMHUB_MACAROON_HEADER"
 
-       See more: `Charmhub API docs > list_registered_names
+       For more information on the API endpoint to view the guardrails
+       and tracks for all published charms, see `list_registered_names
        <https://api.charmhub.io/docs/default/#list-registered-names>`__.
-
 
 3. Use ``curl`` to create a new track. Finally, to create a new track for your
    charm, issue an HTTP ``POST`` request to ``/v1/<namespace>/<name>/tracks``,
@@ -124,7 +118,7 @@ To create a new track yourself, follow the steps below:
 
    Of course, the tracks must conform to the existing guardrail for the charm.
 
-       See more: `Charmhub API docs > create_tracks
-       <https://api.charmhub.io/docs/default/#create-tracks>`__
+   For more information on the API endpoint to create a new track, see
+   `create_tracks <https://api.charmhub.io/docs/default/#create-tracks>`__
 
 That's it, you now have a new track for your charm!


### PR DESCRIPTION
This PR fixes the in-page links for some pages in the How to guides section of the documentation by moving single-link block references into the main text. It also adds introductory sentences to some sections to make the docs more user friendly.

This is the `#4` in a series of PRs addressing [Open Documentation Academy issue #302](https://github.com/canonical/open-documentation-academy/issues/302).

## Docs pages covered

* [Manage charm revisions](https://github.com/canonical/charmcraft/blob/main/docs/howto/manage-revisions.rst)
* [Manage the current Charmhub user](https://github.com/canonical/charmcraft/blob/main/docs/howto/manage-the-current-charmhub-user.rst)
* [Manage tracks](https://github.com/canonical/charmcraft/blob/main/docs/howto/manage-tracks.rst)

## Note

Skipped the [Manage parts](https://github.com/canonical/charmcraft/blob/main/docs/howto/manage-parts.rst) docs as it currently contains `TBA (To Be Added)` placeholders.