### PR TITLE
ci: disable macos tests

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -18,10 +18,11 @@ jobs:
     with:
       # Limiting to amd64 is a workaround for https://github.com/canonical/charmcraft/issues/2018
       # Once that's resolved we should run fast and slow tests on ARM64 Ubuntu too.
-      fast-test-platforms: '["ubuntu-22.04", "ubuntu-24.04", "macos-13", "macos-14-large"]'
+      # Disabled macos tests because of https://github.com/canonical/charmcraft/issues/2605
+      fast-test-platforms: '["ubuntu-22.04", "ubuntu-24.04"]'
       fast-test-python-versions: '["3.10", "3.12"]'
       # Slow tests run on noble to avoid an issue with old skopeo versions.
-      slow-test-platforms: '["ubuntu-24.04", "macos-14-large"]'
+      slow-test-platforms: '["ubuntu-24.04"]'
       slow-test-python-versions: '["3.10", "3.12"]'
       # Lowest tests run on noble to avoid an issue with old skopeo versions.
       lowest-python-platform: ubuntu-24.04

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -86,55 +86,56 @@ jobs:
           snap: ${{ steps.snap-name.outputs.snap }}
           release: edge/pr-${{ github.event.number }}
 
-  macos-smoke-test:
-    strategy:
-      matrix:
-        os: [macos-13, macos-14-large]
-    runs-on: ${{ matrix.os }}
-    steps:
-      # Installing and caching homebrew using the action should speed up subsequent CI:
-      # https://github.com/Homebrew/actions/tree/master/setup-homebrew
-      - name: Set up Homebrew
-        id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@master
-      - name: Cache Homebrew Bundler RubyGems
-        id: cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.set-up-homebrew.outputs.gems-path }}
-          key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
-          restore-keys: ${{ runner.os }}-rubygems-
-      - name: Install Homebrew Bundler RubyGems
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: brew install-bundler-gems
-      - name: Install dependencies with homebrew
-        run: |
-          brew install multipass
-          brew install libgit2@1.7  # For building pygit2
-      - name: Checkout code
-        uses: actions/checkout@v6
-      - name: Set up uv with caching
-        id: setup-uv
-        uses: astral-sh/setup-uv@v7
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-          cache: "pip"
-      - name: Build and install Charmcraft
-        run: |
-          uv sync --no-dev
-      - name: Check for fully-configured multipass
-        run: |
-          while ! multipass version; do
-            sleep 1
-          done
-      - name: Init and pack
-        run: |
-          source .venv/bin/activate
-          mkdir test-charm
-          cd test-charm
-          export CRAFT_VERBOSITY_LEVEL=trace
-          charmcraft init --profile=machine
-          charmcraft pack
-          test -f *.charm
+  # Disabled macos tests because of https://github.com/canonical/charmcraft/issues/2605
+  # macos-smoke-test:
+  #   strategy:
+  #     matrix:
+  #       os: [macos-13, macos-14-large]
+  #   runs-on: ${{ matrix.os }}
+  #   steps:
+  #     # Installing and caching homebrew using the action should speed up subsequent CI:
+  #     # https://github.com/Homebrew/actions/tree/master/setup-homebrew
+  #     - name: Set up Homebrew
+  #       id: set-up-homebrew
+  #       uses: Homebrew/actions/setup-homebrew@master
+  #     - name: Cache Homebrew Bundler RubyGems
+  #       id: cache
+  #       uses: actions/cache@v4
+  #       with:
+  #         path: ${{ steps.set-up-homebrew.outputs.gems-path }}
+  #         key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
+  #         restore-keys: ${{ runner.os }}-rubygems-
+  #     - name: Install Homebrew Bundler RubyGems
+  #       if: steps.cache.outputs.cache-hit != 'true'
+  #       run: brew install-bundler-gems
+  #     - name: Install dependencies with homebrew
+  #       run: |
+  #         brew install multipass
+  #         brew install libgit2@1.7  # For building pygit2
+  #     - name: Checkout code
+  #       uses: actions/checkout@v6
+  #     - name: Set up uv with caching
+  #       id: setup-uv
+  #       uses: astral-sh/setup-uv@v7
+  #     - name: Set up Python
+  #       uses: actions/setup-python@v6
+  #       with:
+  #         python-version: "3.12"
+  #         cache: "pip"
+  #     - name: Build and install Charmcraft
+  #       run: |
+  #         uv sync --no-dev
+  #     - name: Check for fully-configured multipass
+  #       run: |
+  #         while ! multipass version; do
+  #           sleep 1
+  #         done
+  #     - name: Init and pack
+  #       run: |
+  #         source .venv/bin/activate
+  #         mkdir test-charm
+  #         cd test-charm
+  #         export CRAFT_VERBOSITY_LEVEL=trace
+  #         charmcraft init --profile=machine
+  #         charmcraft pack
+  #         test -f *.charm


### PR DESCRIPTION
We'll need to re-enable macos CI to solve https://github.com/canonical/charmcraft/issues/2605

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/charmcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] I've updated the relevant release notes.
