### PR TITLE
fix(ci): fix 26.04 spread tests in Google

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -138,6 +138,9 @@ prepare: |
     fi
   fi
 
+  # Needed because some cloud instances, e.g. 26.04, don't have packages cached.
+  apt-get update
+
   tests.pkgs install snapd
   tests.pkgs install unzip
 


### PR DESCRIPTION
This change fixes the fact that the 26.04 image we're using in Google spread runners doesn't have its apt package cache filled.

CHARMCRAFT-689

---

- [ ] I've followed the [contribution guidelines](https://github.com/canonical/charmcraft/blob/main/CONTRIBUTING.md).
- [ ] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] I've updated the relevant release notes.
