### PR TITLE
fix(Project): fix shorthand multi-base notation

### DIFF
--- a/docs/release-notes/charmcraft-4.2.rst
+++ b/docs/release-notes/charmcraft-4.2.rst
@@ -90,6 +90,8 @@ The following issues have been resolved in Charmcraft 4.2.1:
   ``charmcraft pack -o`` fails: ``FileNotFoundError``
 - `#2493 <https://github.com/canonical/charmcraft/issues/2493>`__ Packing fails when
   using a separate ``metadata.yaml`` file and the ``--project-dir`` argument
+- `#2620 <https://github.com/canonical/charmcraft/issues/2620>`__ Multi-base shorthand
+  notation fails on v4.2.0
 
 Contributors
 ------------

--- a/tests/integration/services/sample_projects/regression-test-2620/prime/actions.yaml
+++ b/tests/integration/services/sample_projects/regression-test-2620/prime/actions.yaml
@@ -1,0 +1,49 @@
+add-trusted-client:
+  description: The client certificate to add to the trusted list
+  params:
+    cert:
+      description: |
+        The raw X.509 PEM client certificate (required if cert-url isn't set).
+        -----BEGIN CERTIFICATE-----
+        <Client cert in PEM format to add to trust>
+        -----END CERTIFICATE-----
+        Pass the file with the certificate above as:
+        $ juju run --wait=2m lxd/leader add-trusted-client cert="$(cat client.crt)"
+      type: string
+    cert-url:
+      description: "The HTTP/HTTPS URL to fetch the client certificate from (required\
+        \ if cert isn\u2019t set)"
+      type: string
+    name:
+      description: The user-specified identifier (optional)
+      type: string
+    projects:
+      description: A comma separated list of projects to restrict the client certificate
+        to (optional)
+      type: string
+debug:
+  description: Collect useful information for bug reports (calls lxd.buginfo)
+get-client-token:
+  description: Return a client certificate add token to use by the client as `lxc
+    remote add <remote-name> <token>`
+  params:
+    name:
+      description: The user-specified identifier
+      type: string
+    projects:
+      description: A comma separated list of projects to restrict the client certificate
+        to (optional)
+      type: string
+remove-trusted-client:
+  description: The client certificate fingerprint (SHA256) to remove from the trusted
+    list
+  params:
+    fingerprint:
+      description: |
+        The fingerprint of the X.509 PEM client certificate. This will automatically ignore
+        `openssl`'s unneeded prefix (`sha256 Fingerprint=`) and extract the fingerprint.
+        $ juju run --wait=2m lxd/leader remove-trusted-client fingerprint="$(openssl x509 -noout -fingerprint -sha256 -in client.crt)"
+      type: string
+show-pending-config:
+  description: Show the currently pending configuration changes (queued for after
+    the reboot)

--- a/tests/integration/services/sample_projects/regression-test-2620/prime/config.yaml
+++ b/tests/integration/services/sample_projects/regression-test-2620/prime/config.yaml
@@ -1,0 +1,96 @@
+options:
+  kernel-hardening:
+    default: true
+    description: Restrict access to sensitive files/dirs (/proc/sched_debug, /sys/kernel/slab)
+    type: boolean
+  lxd-init-network:
+    default: true
+    description: Enable/disable the initialization of the default network
+    type: boolean
+  lxd-init-storage:
+    default: true
+    description: Enable/disable the initialization of the default storage pool
+    type: boolean
+  lxd-listen-bgp:
+    default: false
+    description: Enable/disable the BGP endpoint
+    type: boolean
+  lxd-listen-dns:
+    default: false
+    description: Enable/disable the authoritative DNS endpoint
+    type: boolean
+  lxd-listen-https:
+    default: false
+    description: Enable/disable the remote API (HTTPS)
+    type: boolean
+  lxd-listen-metrics:
+    default: false
+    description: Enable/disable the metrics endpoint
+    type: boolean
+  lxd-preseed:
+    description: Pass a YAML configuration to `lxd init` on initial start
+    type: string
+  mode:
+    default: standalone
+    description: Operate in `standalone` or `cluster` mode
+    type: string
+  snap-channel:
+    default: auto
+    description: The snap store channel for LXD to use or `auto` to use `lxd-installer`
+      if available with a fallback to the default channel
+    type: string
+  snap-config-ceph-builtin:
+    default: true
+    description: Use snap-specific ceph configuration
+    type: boolean
+  snap-config-ceph-external:
+    description: Use the system's ceph tools (ignores snap-config-ceph-builtin)
+    type: boolean
+  snap-config-criu-enable:
+    description: Enable experimental live-migration support
+    type: boolean
+  snap-config-daemon-debug:
+    description: Increase logging to debug level
+    type: boolean
+  snap-config-daemon-group:
+    description: Set group of users that can interact with LXD
+    type: string
+  snap-config-daemon-syslog:
+    description: Send LXD log events to syslog
+    type: boolean
+  snap-config-lvm-external:
+    description: Use the system's LVM tools
+    type: boolean
+  snap-config-lxcfs-cfs:
+    description: Consider CPU shares for CPU usage
+    type: boolean
+  snap-config-lxcfs-debug:
+    description: Increase logging to debug level
+    type: boolean
+  snap-config-lxcfs-loadavg:
+    description: Start tracking per-container load average
+    type: boolean
+  snap-config-lxcfs-pidfd:
+    description: Start per-container process tracking
+    type: boolean
+  snap-config-openvswitch-builtin:
+    description: Run a snap-specific OVS daemon
+    type: boolean
+  snap-config-openvswitch-external:
+    description: Use the system's OVS tools (ignores snap-config-openvswitch-builtin)
+    type: boolean
+  snap-config-ovn-builtin:
+    default: true
+    description: Use snap-specific OVN configuration
+    type: boolean
+  snap-config-shiftfs-enable:
+    description: Enable shiftfs support
+    type: string
+  snap-config-ui-enable:
+    default: false
+    description: Enable the experimental web interface
+    type: boolean
+  sysctl-tuning:
+    default: true
+    description: Apply production sysctl tuning
+    type: boolean

--- a/tests/integration/services/sample_projects/regression-test-2620/prime/manifest.yaml
+++ b/tests/integration/services/sample_projects/regression-test-2620/prime/manifest.yaml
@@ -1,0 +1,13 @@
+charmcraft-version: 3.0-test-version
+charmcraft-started-at: '2020-03-14T00:00:00+00:00'
+bases:
+- name: ubuntu
+  channel: '24.04'
+  architectures:
+  - amd64
+analysis:
+  attributes:
+  - name: language
+    result: unknown
+  - name: framework
+    result: unknown

--- a/tests/integration/services/sample_projects/regression-test-2620/prime/metadata.yaml
+++ b/tests/integration/services/sample_projects/regression-test-2620/prime/metadata.yaml
@@ -1,0 +1,66 @@
+description: |
+  LXD is a modern, secure and powerful system container and virtual machine manager.
+  It provides a unified experience for running and managing full Linux systems
+  inside containers or virtual machines.
+extra-bindings:
+  fan: null
+issues:
+- https://github.com/canonical/charm-lxd/issues
+name: lxd
+peers:
+  cluster:
+    interface: lxd-cluster
+provides:
+  bgp:
+    interface: lxd-bgp
+  dns:
+    interface: lxd-dns
+  grafana-dashboard:
+    interface: grafana-dashboard
+  grafana-dashboard-k8s:
+    interface: grafana_dashboard
+  https:
+    interface: lxd-https
+  metrics:
+    interface: lxd-metrics
+  metrics-endpoint:
+    interface: prometheus_scrape
+  prometheus-manual:
+    interface: prometheus-manual
+requires:
+  ceph:
+    interface: ceph-client
+    optional: true
+  certificates:
+    interface: tls-certificates
+  logging:
+    interface: loki_push_api
+  ovsdb-cms:
+    interface: ovsdb-cms
+resources:
+  lxd-binary:
+    description: |
+      A debug version of the LXD binary or a tarball of architecture specific
+      binaries. In the case of a tarball, the binaries should be at the root
+      and be named as "lxd_${ARCH}".
+
+      Attaching an empty file will undo the sideloading.
+    filename: lxd
+    type: file
+  lxd-snap:
+    description: |
+      A custom LXD snap or tarball of architecture specific snaps to install.
+      In the case of a tarball, the snaps should be at the root and be
+      named as "lxd_${ARCH}.snap".
+
+      Attaching an empty file will undo the sideloading.
+    filename: lxd.snap
+    type: file
+storage:
+  local:
+    description: Local storage pool for LXD
+    minimum-size: 10G
+    multiple:
+      range: 0-1
+    type: block
+summary: Powerful system container and virtual machine manager

--- a/tests/integration/services/sample_projects/regression-test-2620/project/charmcraft.yaml
+++ b/tests/integration/services/sample_projects/regression-test-2620/project/charmcraft.yaml
@@ -1,0 +1,267 @@
+# Copied from https://github.com/canonical/charm-lxd/blob/abf5e49f5ff15f6e54e9fdb9ffec59b7521cd3d2/charmcraft.yaml
+# Regression test for https://github.com/canonical/charmcraft/issues/2620
+name: lxd
+summary: Powerful system container and virtual machine manager
+links:
+  issues:
+  - https://github.com/canonical/charm-lxd/issues
+description: |
+  LXD is a modern, secure and powerful system container and virtual machine manager.
+  It provides a unified experience for running and managing full Linux systems
+  inside containers or virtual machines.
+resources:
+  lxd-binary:
+    type: file
+    filename: lxd
+    description: |
+      A debug version of the LXD binary or a tarball of architecture specific
+      binaries. In the case of a tarball, the binaries should be at the root
+      and be named as "lxd_${ARCH}".
+
+      Attaching an empty file will undo the sideloading.
+  lxd-snap:
+    type: file
+    filename: lxd.snap
+    description: |
+      A custom LXD snap or tarball of architecture specific snaps to install.
+      In the case of a tarball, the snaps should be at the root and be
+      named as "lxd_${ARCH}.snap".
+
+      Attaching an empty file will undo the sideloading.
+storage:
+  local:
+    type: block
+    description: Local storage pool for LXD
+    minimum-size: 10G
+    multiple:
+      range: 0-1
+extra-bindings:
+  # the FAN underlay network to use
+  fan:
+peers:
+  cluster:
+    interface: lxd-cluster
+provides:
+  bgp:
+    interface: lxd-bgp
+  dns:
+    interface: lxd-dns
+  grafana-dashboard:
+    interface: grafana-dashboard
+  grafana-dashboard-k8s:
+    interface: grafana_dashboard
+  https:
+    interface: lxd-https
+  metrics:
+    interface: lxd-metrics
+  prometheus-manual:
+    interface: prometheus-manual
+  metrics-endpoint:
+    interface: prometheus_scrape
+requires:
+  ceph:
+    interface: ceph-client
+    optional: true
+  certificates:
+    interface: tls-certificates
+  logging:
+    interface: loki_push_api
+  ovsdb-cms:
+    interface: ovsdb-cms
+
+type: charm
+platforms:
+  ubuntu@24.04:amd64:
+  ubuntu@24.04:arm64:
+  ubuntu@24.04:armhf:
+  ubuntu@24.04:ppc64el:
+  ubuntu@24.04:s390x:
+  ubuntu@22.04:amd64:
+  ubuntu@22.04:arm64:
+  ubuntu@22.04:armhf:
+  ubuntu@22.04:ppc64el:
+  ubuntu@22.04:s390x:
+
+charm-libs:
+  - lib: grafana-k8s.grafana_dashboard
+    version: "0"
+  - lib: loki-k8s.loki_push_api
+    version: "0"
+
+parts:
+  charm:
+    build-packages:
+    - ca-certificates
+    - cargo-1.85  # 22.04/24.04 bases comes with cargo==1.75.0 in main which is too old for python cryptography
+    - git
+    - libffi-dev
+    - libssl-dev
+    - pkg-config
+    - python3-dev
+    - rustc-1.85  # 22.04/24.04 bases comes with rustc==1.75.0 in main which is too old for python cryptography
+  grafana-dashboard:
+    build-packages:
+    - wget
+    override-pull: |-
+      mkdir -p src/grafana_dashboards
+      wget --https-only https://grafana.com/api/dashboards/19131/revisions/latest/download -O src/grafana_dashboards/LXD.json
+      sed -i 's/{DS_LXD}/{prometheusds}/g' src/grafana_dashboards/LXD.json
+    plugin: dump
+    source: .
+
+actions:
+ add-trusted-client:
+   description: The client certificate to add to the trusted list
+   params:
+     name:
+       description: The user-specified identifier (optional)
+       type: string
+     cert:
+       description: |
+         The raw X.509 PEM client certificate (required if cert-url isn't set).
+         -----BEGIN CERTIFICATE-----
+         <Client cert in PEM format to add to trust>
+         -----END CERTIFICATE-----
+         Pass the file with the certificate above as:
+         $ juju run --wait=2m lxd/leader add-trusted-client cert="$(cat client.crt)"
+       type: string
+     cert-url:
+       description: The HTTP/HTTPS URL to fetch the client certificate from (required if cert isn’t set)
+       type: string
+     projects:
+       description: A comma separated list of projects to restrict the client certificate to (optional)
+       type: string
+
+ debug:
+   description: Collect useful information for bug reports (calls lxd.buginfo)
+
+ get-client-token:
+   description: Return a client certificate add token to use by the client as `lxc remote add <remote-name> <token>`
+   params:
+     name:
+       description: The user-specified identifier
+       type: string
+     projects:
+       description: A comma separated list of projects to restrict the client certificate to (optional)
+       type: string
+
+ remove-trusted-client:
+   description: The client certificate fingerprint (SHA256) to remove from the trusted list
+   params:
+     fingerprint:
+       description: |
+         The fingerprint of the X.509 PEM client certificate. This will automatically ignore
+         `openssl`'s unneeded prefix (`sha256 Fingerprint=`) and extract the fingerprint.
+         $ juju run --wait=2m lxd/leader remove-trusted-client fingerprint="$(openssl x509 -noout -fingerprint -sha256 -in client.crt)"
+       type: string
+
+ show-pending-config:
+   description: Show the currently pending configuration changes (queued for after the reboot)
+
+config:
+  options:
+    kernel-hardening:
+      type: boolean
+      default: true
+      description: Restrict access to sensitive files/dirs (/proc/sched_debug, /sys/kernel/slab)
+
+    lxd-init-network:
+      type: boolean
+      default: true
+      description: Enable/disable the initialization of the default network
+
+    lxd-init-storage:
+      type: boolean
+      default: true
+      description: Enable/disable the initialization of the default storage pool
+
+    lxd-listen-bgp:
+      type: boolean
+      default: false
+      description: Enable/disable the BGP endpoint
+
+    lxd-listen-dns:
+      type: boolean
+      default: false
+      description: Enable/disable the authoritative DNS endpoint
+
+    lxd-listen-https:
+      type: boolean
+      default: false
+      description: Enable/disable the remote API (HTTPS)
+
+    lxd-listen-metrics:
+      type: boolean
+      default: false
+      description: Enable/disable the metrics endpoint
+
+    lxd-preseed:
+      type: string
+      description: Pass a YAML configuration to `lxd init` on initial start
+
+    mode:
+      type: string
+      default: "standalone"
+      description: Operate in `standalone` or `cluster` mode
+
+    snap-channel:
+      type: string
+      default: "auto"
+      description: The snap store channel for LXD to use or `auto` to use `lxd-installer` if available with a fallback to the default channel
+
+    snap-config-ceph-builtin:
+      type: boolean
+      description: Use snap-specific ceph configuration
+      default: true
+    snap-config-ceph-external:
+      type: boolean
+      description: Use the system's ceph tools (ignores snap-config-ceph-builtin)
+    snap-config-criu-enable:
+      type: boolean
+      description: Enable experimental live-migration support
+    snap-config-daemon-debug:
+      type: boolean
+      description: Increase logging to debug level
+    snap-config-daemon-group:
+      type: string
+      description: Set group of users that can interact with LXD
+    snap-config-daemon-syslog:
+      type: boolean
+      description: Send LXD log events to syslog
+    snap-config-lvm-external:
+      type: boolean
+      description: Use the system's LVM tools
+    snap-config-lxcfs-pidfd:
+      type: boolean
+      description: Start per-container process tracking
+    snap-config-lxcfs-loadavg:
+      type: boolean
+      description: Start tracking per-container load average
+    snap-config-lxcfs-cfs:
+      type: boolean
+      description: Consider CPU shares for CPU usage
+    snap-config-lxcfs-debug:
+      type: boolean
+      description: Increase logging to debug level
+    snap-config-openvswitch-builtin:
+      type: boolean
+      description: Run a snap-specific OVS daemon
+    snap-config-openvswitch-external:
+      type: boolean
+      description: Use the system's OVS tools (ignores snap-config-openvswitch-builtin)
+    snap-config-ovn-builtin:
+      type: boolean
+      description: Use snap-specific OVN configuration
+      default: true
+    snap-config-shiftfs-enable:
+      type: string
+      description: Enable shiftfs support
+    snap-config-ui-enable:
+      type: boolean
+      description: Enable the experimental web interface
+      default: false
+
+    sysctl-tuning:
+      type: boolean
+      default: true
+      description: Apply production sysctl tuning

--- a/uv.lock
+++ b/uv.lock
@@ -1093,16 +1093,16 @@ wheels = [
 
 [[package]]
 name = "craft-platforms"
-version = "0.11.0"
+version = "0.11.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types" },
     { name = "distro" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/be/f0/00dd4b4f0529eeb399fbaf1a9e536fd98f1ee0ba3e9a8febde94914ccd0b/craft_platforms-0.11.0.tar.gz", hash = "sha256:2e795922f471220e08c202881da761793e1f28961e77e0b476b1dbaa62860e7a", size = 299115, upload-time = "2026-03-05T18:58:41.961Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/93/b9/b7bef735949e73756910d85c1d4178e5c6523b70e5dbe5477ab0c2fd8d81/craft_platforms-0.11.1.tar.gz", hash = "sha256:5807e2b727c0cb9c7c85e5ecaf4181ed1b3f89e6232464736369dcb871ae9339", size = 355329, upload-time = "2026-04-09T14:07:58.52Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/51/1a645a07233087b253b922f30ebaef70818d9fb6a8c3e8cea8c0627ba735/craft_platforms-0.11.0-py3-none-any.whl", hash = "sha256:5c917233729870882cd4e3dfd13c6adc0165c2dbafe9f04337360fc0cad70277", size = 37828, upload-time = "2026-03-05T18:58:40.476Z" },
+    { url = "https://files.pythonhosted.org/packages/42/77/d2a19bde5e05ec30eef8f63f6f6e1cde9c4f07be5da7fb71a675e159eec2/craft_platforms-0.11.1-py3-none-any.whl", hash = "sha256:740dc7ba7f508a2fe8f3f8f8a6784fd70d48b36a2930a418a19c69cefe68d398", size = 37897, upload-time = "2026-04-09T14:07:56.931Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This brings in a newer craft-platforms to fix the multi-base shorthand notation for craft-application 6 and adds a test case for it.

Fixes: #2620
CHARMCRAFT-691

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/charmcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
- [x] I've updated the relevant release notes.
