### PR TITLE
docs: format doc version as major.minor

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,10 +31,13 @@ project_dir = pathlib.Path(__file__).parents[1].resolve()
 
 project = "Charmcraft"
 author = "Canonical"
+# The full version, including alpha/beta/rc tags
 release = charmcraft.__version__
 if ".post" in release:
-    # The commit hash in the dev release version confuses the spellchecker
     release = "dev"
+else:
+    major, minor, *_ = release.split(".")
+    release = f"{major}.{minor}"
 
 copyright = "2023-%s, %s" % (datetime.date.today().year, author)
 


### PR DESCRIPTION
What it says on the tin.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/charmcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
- [x] I've updated the relevant release notes.
