### PR TITLE
test: Platform shorthand notation and charm plugin

### DIFF
--- a/tests/unit/services/test_project.py
+++ b/tests/unit/services/test_project.py
@@ -189,3 +189,41 @@ def test_get_platforms_correct(
     service.configure(platform=None, build_for=None)
     service.get()
     assert service.get().marshal()["platforms"] == expected
+
+
+@pytest.mark.parametrize(
+    ("platforms", "expected"),
+    [
+        pytest.param(
+            {
+                "ubuntu@20.04:amd64": None,
+            },
+            {
+                "ubuntu@20.04:amd64": {
+                    "build-on": ["ubuntu@20.04:amd64"],
+                    "build-for": ["ubuntu@20.04:amd64"],
+                },
+            },
+            id="short-charm-plugin",
+        ),
+    ],
+)
+def test_platforms_short_charm_plugin(project_path, service, platforms, expected):
+    (project_path / "charmcraft.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "name": "platforms-test",
+                "type": "charm",
+                "summary": "a summary",
+                "description": "a description",
+                "parts": {"something": {"plugin": "charm", "source": "."}},
+                "platforms": platforms,
+            }
+        )
+    )
+
+    assert service.get_platforms() == expected
+    # Check that it renders.
+    service.configure(platform=None, build_for=None)
+    service.get()
+    assert service.get().marshal()["platforms"] == expected


### PR DESCRIPTION
Explicitly test the combination of platform shorthand notation and charm plugin. Earlier versions of craft-platforms were breaking this combination.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/charmcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] I've updated the relevant release notes.
