### PR TITLE
fix: correctly get project name for remote builds

### DIFF
--- a/charmcraft/application/commands/remote.py
+++ b/charmcraft/application/commands/remote.py
@@ -106,7 +106,7 @@ class RemoteBuild(ExtensibleCommand):
                 return 77  # permission denied from sysexits.h
 
         builder = self._services.remote_build
-        project = cast(models.Charm, self._services.project)
+        project = cast("models.Charm", self._services.get("project").get())
         config = cast(dict[str, Any], self.config)
         project_dir = (
             pathlib.Path(config.get("global_args", {}).get("project_dir") or ".")

--- a/docs/release-notes/charmcraft-4.2.rst
+++ b/docs/release-notes/charmcraft-4.2.rst
@@ -93,6 +93,11 @@ The following issues have been resolved in Charmcraft 4.2.1:
 - `#2620 <https://github.com/canonical/charmcraft/issues/2620>`__ Multi-base shorthand
   notation fails on v4.2.0
 
+The following issues have been resolved in Charmcraft 4.2.2:
+
+- `#2598 <https://github.com/canonical/charmcraft/issues/2598>`__ Remote build fails
+when getting project name
+
 Contributors
 ------------
 

--- a/tests/unit/commands/test_remote.py
+++ b/tests/unit/commands/test_remote.py
@@ -1,0 +1,47 @@
+# Copyright 2026 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For further info, check https://github.com/canonical/charmcraft
+
+"""Unit tests for remote-build"""
+
+import argparse
+
+from pytest_mock import MockerFixture
+
+from charmcraft import services
+from charmcraft.application import APP_METADATA
+from charmcraft.application.commands.remote import RemoteBuild
+from charmcraft.services.project import ProjectService
+
+
+def test_remote_build_project_name_attr_regression(
+    mocker: MockerFixture, service_factory: services.ServiceFactory
+) -> None:
+    """Regression test for https://github.com/canonical/charmcraft/issues/2598
+    The project service was being erroneously cast as the project model, causing
+    a later access to the `.name` field not be caught by linters.
+    """
+    remote_build_cmd = RemoteBuild({"app": APP_METADATA, "services": service_factory})
+    namespace = argparse.Namespace(
+        launchpad_accept_public_upload=True,
+        recover=False,
+        launchpad_timeout=0,
+    )
+    mocker.patch("charmcraft.services.remotebuild.RemoteBuildService")
+    project_spy = mocker.spy(ProjectService, "get")
+
+    remote_build_cmd.run(namespace)
+
+    project_spy.assert_called_once()


### PR DESCRIPTION
Fixes #2598.
CHARMCRAFT-690

---

- [ ] I've followed the [contribution guidelines](https://github.com/canonical/charmcraft/blob/main/CONTRIBUTING.md).
- [ ] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
