### PR TITLE
docs: pin versions in tutorials

### DIFF
--- a/docs/tutorial/code/django/requirements.txt
+++ b/docs/tutorial/code/django/requirements.txt
@@ -1,3 +1,3 @@
 # Make sure to update the version in the tutorial if you update the version here.
 Django==5.1.4
-psycopg2-binary
+psycopg2-binary==2.9.12

--- a/docs/tutorial/code/expressjs/task.yaml
+++ b/docs/tutorial/code/expressjs/task.yaml
@@ -41,6 +41,7 @@ execute: |
   mv *.yaml *.js *.sh $HOME/expressjs-hello-world
   cd  $HOME/expressjs-hello-world
 
+  # Make sure to update the version in the tutorial if you update express-generator version here.
   # [docs:install-init-expressjs]
   sudo apt update -y && sudo apt install npm -y
   sudo npm install -g express-generator@4

--- a/docs/tutorial/code/fastapi/requirements.txt
+++ b/docs/tutorial/code/fastapi/requirements.txt
@@ -1,3 +1,3 @@
 # Make sure to update the version in the tutorial if you update the version here.
 fastapi[standard]==0.136.1
-psycopg2-binary
+psycopg2-binary==2.9.12

--- a/docs/tutorial/code/flask/requirements.txt
+++ b/docs/tutorial/code/flask/requirements.txt
@@ -1,3 +1,3 @@
 # Make sure to update the version in the tutorial if you update the version here.
 Flask==3.1.3
-psycopg2-binary
+psycopg2-binary==2.9.12

--- a/docs/tutorial/code/spring-boot/task.yaml
+++ b/docs/tutorial/code/spring-boot/task.yaml
@@ -37,6 +37,7 @@ execute: |
   sudo apt update && sudo apt install -y openjdk-21-jdk
   # [docs:install-devpack-for-spring-end]
 
+  # Make sure to update the version in the tutorial if you update boot-version here.
   # [docs:init-spring-boot]
   devpack-for-spring boot start \
     --path spring-boot-hello-world \

--- a/docs/tutorial/kubernetes-charm-express.rst
+++ b/docs/tutorial/kubernetes-charm-express.rst
@@ -38,7 +38,7 @@ than the sufficient resources, the tutorial will take longer to complete.
 What you'll do
 --------------
 
-#. Create an Express app.
+#. Create an Express 4 app.
 #. Use that to create a rock with Rockcraft.
 #. Use that to create a charm with Charmcraft.
 #. Use that to test, deploy, configure, etc., your Express app on a local

--- a/docs/tutorial/kubernetes-charm-spring-boot.rst
+++ b/docs/tutorial/kubernetes-charm-spring-boot.rst
@@ -39,7 +39,7 @@ than the sufficient resources, the tutorial will take longer to complete.
 What you'll do
 --------------
 
-#. Create a Spring Boot app.
+#. Create a Spring Boot 3.5.10 app.
 #. Use that to create a rock with Rockcraft.
 #. Use that to create a charm with Charmcraft.
 #. Use that to test, deploy, configure, etc., your Spring Boot app on a local


### PR DESCRIPTION
Pinniung versions of dependencies in python tutorials (psycopg2-binary)

mentioning the version of express and spring-boot in the tutorials as with the other python frameworks.
---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/charmcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
- [x] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
