### PR TITLE
docs: update tutorial terminal blocks with correct metadata

### DIFF
--- a/docs/tutorial/kubernetes-charm-django.rst
+++ b/docs/tutorial/kubernetes-charm-django.rst
@@ -1,5 +1,8 @@
 .. _write-your-first-kubernetes-charm-for-a-django-app:
 
+.. meta::
+    :description: Learn how to build and deploy a Kubernetes charm for a Django app using Charmcraft, Rockcraft, and Juju. Uses the django-framework profile.
+
 Write your first Kubernetes charm for a Django app
 ==================================================
 

--- a/docs/tutorial/kubernetes-charm-django.rst
+++ b/docs/tutorial/kubernetes-charm-django.rst
@@ -1,7 +1,7 @@
 .. _write-your-first-kubernetes-charm-for-a-django-app:
 
 .. meta::
-    :description: Learn the process of building and deploying a Kubernetes charm for a Django app. In this tutorial, we use the django-framework extension to package and orchestrate the application.
+    :description: Learn the process of building and deploying a Kubernetes charm for a Django app. In this tutorial, we use the django-framework extension to package and orchestrate the app.
 
 Write your first Kubernetes charm for a Django app
 ==================================================

--- a/docs/tutorial/kubernetes-charm-django.rst
+++ b/docs/tutorial/kubernetes-charm-django.rst
@@ -494,6 +494,9 @@ the deployment using ``juju status`` which should be similar to the
 following output:
 
 .. terminal::
+    :user: ubuntu
+    :host: charm-dev
+    :dir: ~/django-tutorial/charm
 
     juju status
 

--- a/docs/tutorial/kubernetes-charm-django.rst
+++ b/docs/tutorial/kubernetes-charm-django.rst
@@ -1,7 +1,7 @@
 .. _write-your-first-kubernetes-charm-for-a-django-app:
 
 .. meta::
-    :description: Learn how to build and deploy a Kubernetes charm for a Django app using Charmcraft, Rockcraft, and Juju. Uses the django-framework profile.
+    :description: Learn the process of building and deploying a Kubernetes charm for a Django app. In this tutorial, we use the django-framework extension to package and orchestrate the application.
 
 Write your first Kubernetes charm for a Django app
 ==================================================

--- a/docs/tutorial/kubernetes-charm-express.rst
+++ b/docs/tutorial/kubernetes-charm-express.rst
@@ -1,7 +1,7 @@
 .. _write-your-first-kubernetes-charm-for-a-expressjs-app:
 
 .. meta::
-    :description: Learn how to build and deploy a Kubernetes charm for an Express app using Charmcraft, Rockcraft, and Juju. Uses the express-framework profile.
+    :description: Learn the process of building and deploying a Kubernetes charm for an Express app. In this tutorial, we use the express-framework extension to package and orchestrate the application.
 
 Write your first Kubernetes charm for an Express app
 ======================================================

--- a/docs/tutorial/kubernetes-charm-express.rst
+++ b/docs/tutorial/kubernetes-charm-express.rst
@@ -1,7 +1,7 @@
 .. _write-your-first-kubernetes-charm-for-a-expressjs-app:
 
 .. meta::
-    :description: Learn the process of building and deploying a Kubernetes charm for an Express app. In this tutorial, we use the express-framework extension to package and orchestrate the application.
+    :description: Learn the process of building and deploying a Kubernetes charm for an Express app. In this tutorial, we use the express-framework extension to package and orchestrate the app.
 
 Write your first Kubernetes charm for an Express app
 ======================================================

--- a/docs/tutorial/kubernetes-charm-express.rst
+++ b/docs/tutorial/kubernetes-charm-express.rst
@@ -373,6 +373,9 @@ the deployment using ``juju status``, which should be similar to the
 following output:
 
 .. terminal::
+    :user: ubuntu
+    :host: charm-dev
+    :dir: ~/expressjs-hello-world/charm
 
     juju status
 
@@ -740,12 +743,18 @@ This should be incremented each time the root endpoint is requested. If we
 repeat this process, the output should be as follows:
 
 .. terminal::
+    :user: ubuntu
+    :host: charm-dev
+    :dir: ~/expressjs-hello-world/charm
 
     curl http://expressjs-hello-world --resolve expressjs-hello-world:80:127.0.0.1
 
     Hi!
 
 .. terminal::
+    :user: ubuntu
+    :host: charm-dev
+    :dir: ~/expressjs-hello-world/charm
 
     curl http://expressjs-hello-world/visitors --resolve expressjs-hello-world:80:127.0.0.1
 

--- a/docs/tutorial/kubernetes-charm-express.rst
+++ b/docs/tutorial/kubernetes-charm-express.rst
@@ -1,5 +1,8 @@
 .. _write-your-first-kubernetes-charm-for-a-expressjs-app:
 
+.. meta::
+    :description: Learn how to build and deploy a Kubernetes charm for an Express app using Charmcraft, Rockcraft, and Juju. Uses the express-framework profile.
+
 Write your first Kubernetes charm for an Express app
 ======================================================
 

--- a/docs/tutorial/kubernetes-charm-fastapi.rst
+++ b/docs/tutorial/kubernetes-charm-fastapi.rst
@@ -407,6 +407,9 @@ the deployment using ``juju status``, which should be similar to the following
 output:
 
 .. terminal::
+    :user: ubuntu
+    :host: charm-dev
+    :dir: ~/fastapi-hello-world/charm
 
     juju status
 
@@ -717,12 +720,18 @@ be incremented each time the root endpoint is requested. If we repeat
 this process, the output should be as follows:
 
 .. terminal::
+    :user: ubuntu
+    :host: charm-dev
+    :dir: ~/fastapi-hello-world/charm
 
     curl http://fastapi-hello-world --resolve fastapi-hello-world:80:127.0.0.1
 
     {"message":"Hi!"}
 
 .. terminal::
+    :user: ubuntu
+    :host: charm-dev
+    :dir: ~/fastapi-hello-world/charm
 
     curl http://fastapi-hello-world/visitors --resolve fastapi-hello-world:80:127.0.0.1
 

--- a/docs/tutorial/kubernetes-charm-fastapi.rst
+++ b/docs/tutorial/kubernetes-charm-fastapi.rst
@@ -1,5 +1,7 @@
 .. _write-your-first-kubernetes-charm-for-a-fastapi-app:
 
+.. meta::
+    :description: Learn how to build and deploy a Kubernetes charm for a FastAPI app using Charmcraft, Rockcraft, and Juju. Uses the fastapi-framework profile.
 
 Write your first Kubernetes charm for a FastAPI app
 ===================================================

--- a/docs/tutorial/kubernetes-charm-fastapi.rst
+++ b/docs/tutorial/kubernetes-charm-fastapi.rst
@@ -1,7 +1,7 @@
 .. _write-your-first-kubernetes-charm-for-a-fastapi-app:
 
 .. meta::
-    :description: Learn the process of building and deploying a Kubernetes charm for a FastAPI app. In this tutorial, we use the fastapi-framework extension to package and orchestrate the application.
+    :description: Learn the process of building and deploying a Kubernetes charm for a FastAPI app. In this tutorial, we use the fastapi-framework extension to package and orchestrate the app.
 
 Write your first Kubernetes charm for a FastAPI app
 ===================================================

--- a/docs/tutorial/kubernetes-charm-fastapi.rst
+++ b/docs/tutorial/kubernetes-charm-fastapi.rst
@@ -1,7 +1,7 @@
 .. _write-your-first-kubernetes-charm-for-a-fastapi-app:
 
 .. meta::
-    :description: Learn how to build and deploy a Kubernetes charm for a FastAPI app using Charmcraft, Rockcraft, and Juju. Uses the fastapi-framework profile.
+    :description: Learn the process of building and deploying a Kubernetes charm for a FastAPI app. In this tutorial, we use the fastapi-framework extension to package and orchestrate the application.
 
 Write your first Kubernetes charm for a FastAPI app
 ===================================================

--- a/docs/tutorial/kubernetes-charm-flask.rst
+++ b/docs/tutorial/kubernetes-charm-flask.rst
@@ -352,6 +352,9 @@ the deployment using ``juju status`` which should be similar to the
 following output:
 
 .. terminal::
+    :user: ubuntu
+    :host: charm-dev
+    :dir: ~/flask-hello-world/charm
 
     juju status
 
@@ -657,12 +660,18 @@ This should be incremented each time the root endpoint is requested. If we
 repeat this process, the output should be as follows:
 
 .. terminal::
+    :user: ubuntu
+    :host: charm-dev
+    :dir: ~/flask-hello-world/charm
 
     curl http://flask-hello-world --resolve flask-hello-world:80:127.0.0.1
 
     Hi!
 
 .. terminal::
+    :user: ubuntu
+    :host: charm-dev
+    :dir: ~/flask-hello-world/charm
 
     curl http://flask-hello-world/visitors --resolve flask-hello-world:80:127.0.0.1
 

--- a/docs/tutorial/kubernetes-charm-flask.rst
+++ b/docs/tutorial/kubernetes-charm-flask.rst
@@ -1,7 +1,7 @@
 .. _write-your-first-kubernetes-charm-for-a-flask-app:
 
 .. meta::
-    :description: Learn the process of building and deploying a Kubernetes charm for a Flask app. In this tutorial, we use the flask-framework extension to package and orchestrate the application.
+    :description: Learn the process of building and deploying a Kubernetes charm for a Flask app. In this tutorial, we use the flask-framework extension to package and orchestrate the app.
 
 Write your first Kubernetes charm for a Flask app
 =================================================

--- a/docs/tutorial/kubernetes-charm-flask.rst
+++ b/docs/tutorial/kubernetes-charm-flask.rst
@@ -1,7 +1,7 @@
 .. _write-your-first-kubernetes-charm-for-a-flask-app:
 
 .. meta::
-    :description: Learn how to build and deploy a Kubernetes charm for a Flask app using Charmcraft, Rockcraft, and Juju. Uses the flask-framework profile.
+    :description: Learn the process of building and deploying a Kubernetes charm for a Flask app. In this tutorial, we use the flask-framework extension to package and orchestrate the application.
 
 Write your first Kubernetes charm for a Flask app
 =================================================

--- a/docs/tutorial/kubernetes-charm-flask.rst
+++ b/docs/tutorial/kubernetes-charm-flask.rst
@@ -1,5 +1,8 @@
 .. _write-your-first-kubernetes-charm-for-a-flask-app:
 
+.. meta::
+    :description: Learn how to build and deploy a Kubernetes charm for a Flask app using Charmcraft, Rockcraft, and Juju. Uses the flask-framework profile.
+
 Write your first Kubernetes charm for a Flask app
 =================================================
 

--- a/docs/tutorial/kubernetes-charm-go.rst
+++ b/docs/tutorial/kubernetes-charm-go.rst
@@ -1,7 +1,7 @@
 .. _write-your-first-kubernetes-charm-for-a-go-app:
 
 .. meta::
-    :description: Learn how to build and deploy a Kubernetes charm for a Go app using Charmcraft, Rockcraft, and Juju. Uses the go-framework profile.
+    :description: Learn the process of building and deploying a Kubernetes charm for a Go app. In this tutorial, we use the go-framework extension to package and orchestrate the application.
 
 Write your first Kubernetes charm for a Go app
 ==============================================

--- a/docs/tutorial/kubernetes-charm-go.rst
+++ b/docs/tutorial/kubernetes-charm-go.rst
@@ -1,7 +1,7 @@
 .. _write-your-first-kubernetes-charm-for-a-go-app:
 
 .. meta::
-    :description: Learn the process of building and deploying a Kubernetes charm for a Go app. In this tutorial, we use the go-framework extension to package and orchestrate the application.
+    :description: Learn the process of building and deploying a Kubernetes charm for a Go app. In this tutorial, we use the go-framework extension to package and orchestrate the app.
 
 Write your first Kubernetes charm for a Go app
 ==============================================

--- a/docs/tutorial/kubernetes-charm-go.rst
+++ b/docs/tutorial/kubernetes-charm-go.rst
@@ -389,6 +389,9 @@ the deployment using ``juju status``, which should be similar to the
 following output:
 
 .. terminal::
+    :user: ubuntu
+    :host: charm-dev
+    :dir: ~/go-hello-world/charm
 
     juju status
 
@@ -733,12 +736,18 @@ This should be incremented each time the root endpoint is requested. If we
 repeat this process, the output should be as follows:
 
 .. terminal::
+    :user: ubuntu
+    :host: charm-dev
+    :dir: ~/go-hello-world/charm
 
     curl http://go-hello-world --resolve go-hello-world:80:127.0.0.1
 
     Hi!
 
 .. terminal::
+    :user: ubuntu
+    :host: charm-dev
+    :dir: ~/go-hello-world/charm
 
     curl http://go-hello-world/visitors --resolve go-hello-world:80:127.0.0.1
 

--- a/docs/tutorial/kubernetes-charm-go.rst
+++ b/docs/tutorial/kubernetes-charm-go.rst
@@ -1,5 +1,8 @@
 .. _write-your-first-kubernetes-charm-for-a-go-app:
 
+.. meta::
+    :description: Learn how to build and deploy a Kubernetes charm for a Go app using Charmcraft, Rockcraft, and Juju. Uses the go-framework profile.
+
 Write your first Kubernetes charm for a Go app
 ==============================================
 

--- a/docs/tutorial/kubernetes-charm-spring-boot.rst
+++ b/docs/tutorial/kubernetes-charm-spring-boot.rst
@@ -382,6 +382,9 @@ the deployment using ``juju status``, which should be similar to the
 following output:
 
 .. terminal::
+    :user: ubuntu
+    :host: charm-dev
+    :dir: ~/spring-boot-hello-world/charm
 
     juju status
 
@@ -735,12 +738,18 @@ This should be incremented each time the root endpoint is requested. If we
 repeat this process, the output should be as follows:
 
 .. terminal::
+    :user: ubuntu
+    :host: charm-dev
+    :dir: ~/spring-boot-hello-world/charm
 
     curl http://spring-boot-hello-world --resolve spring-boot-hello-world:80:127.0.0.1
 
     Hi!
 
 .. terminal::
+    :user: ubuntu
+    :host: charm-dev
+    :dir: ~/spring-boot-hello-world/charm
 
     curl http://spring-boot-hello-world/visitors --resolve spring-boot-hello-world:80:127.0.0.1
 

--- a/docs/tutorial/kubernetes-charm-spring-boot.rst
+++ b/docs/tutorial/kubernetes-charm-spring-boot.rst
@@ -1,7 +1,7 @@
 .. _write-your-first-kubernetes-charm-for-a-spring-boot-app:
 
 .. meta::
-    :description: Learn how to build and deploy a Kubernetes charm for a Spring Boot app using Charmcraft, Rockcraft, and Juju. Uses the spring-boot-framework profile.
+    :description: Learn the process of building and deploying a Kubernetes charm for a Spring Boot app. In this tutorial, we use the spring-boot-framework extension to package and orchestrate the application.
 
 Write your first Kubernetes charm for a Spring Boot app
 =======================================================

--- a/docs/tutorial/kubernetes-charm-spring-boot.rst
+++ b/docs/tutorial/kubernetes-charm-spring-boot.rst
@@ -1,5 +1,8 @@
 .. _write-your-first-kubernetes-charm-for-a-spring-boot-app:
 
+.. meta::
+    :description: Learn how to build and deploy a Kubernetes charm for a Spring Boot app using Charmcraft, Rockcraft, and Juju. Uses the spring-boot-framework profile.
+
 Write your first Kubernetes charm for a Spring Boot app
 =======================================================
 

--- a/docs/tutorial/kubernetes-charm-spring-boot.rst
+++ b/docs/tutorial/kubernetes-charm-spring-boot.rst
@@ -1,7 +1,7 @@
 .. _write-your-first-kubernetes-charm-for-a-spring-boot-app:
 
 .. meta::
-    :description: Learn the process of building and deploying a Kubernetes charm for a Spring Boot app. In this tutorial, we use the spring-boot-framework extension to package and orchestrate the application.
+    :description: Learn the process of building and deploying a Kubernetes charm for a Spring Boot app. In this tutorial, we use the spring-boot-framework extension to package and orchestrate the app.
 
 Write your first Kubernetes charm for a Spring Boot app
 =======================================================


### PR DESCRIPTION
This PR standardizes the terminal block metadata (user, host, and directory) across the tutorial documentation to provide a clear, step-by-step path for the user. Resolves Jira ticket: [ISD-5216](https://warthogs.atlassian.net/browse/ISD-5216)

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/charmcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
- [x] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [x] I've updated the relevant release notes. *(N/A - doc formatting only)*.


[ISD-5216]: https://warthogs.atlassian.net/browse/ISD-5216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ