### PR TITLE
ci: filter in qa workflow

### DIFF
--- a/.github/workflows/policy.yaml
+++ b/.github/workflows/policy.yaml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   filter:
+    runs-on: ubuntu-slim
     outputs:
       source-files: ${{ steps.filter.outputs.source-files }}
     steps:

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   filter:
+    runs-on: ubuntu-slim
     outputs:
       source-files: ${{ steps.filter.outputs.source-files }}
     steps:

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -11,12 +11,27 @@ on:
   merge_group:
 
 jobs:
+  filter:
+    outputs:
+      source-files: ${{ steps.filter.outputs.source-files }}
+    steps:
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        with:
+          # Combine multiple negation checks into a union (¬A ∧ ¬B ∧ ¬C), because individual entries are checked independently (A ∨ B ∨ C).
+          # If we ever need to filter only for docs, glob 'docs/**/*' and '**/*.md'
+          filters: |
+            source-files:
+              - '!({docs/**,*.md,**/*.md,.readthedocs.yaml})'
   lint:
     uses: canonical/starflow/.github/workflows/lint-python.yaml@main
+    needs: filter
+    with:
+      source-files: ${{ needs.filter.output.source-files }}
   test:
     uses: canonical/starflow/.github/workflows/test-python.yaml@main
-    needs: lint
-    if: ${{ needs.lint.output.source-files == 'true' }}
+    needs: filter
+    if: ${{ needs.filter.output.source-files == 'true' }}
     with:
       # Limiting to amd64 is a workaround for https://github.com/canonical/charmcraft/issues/2018
       # Once that's resolved we should run fast and slow tests on ARM64 Ubuntu too.

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -32,8 +32,8 @@ jobs:
   test:
     uses: canonical/starflow/.github/workflows/test-python.yaml@main
     needs: filter
-    if: ${{ needs.filter.output.source-files == 'true' }}
     with:
+      source-files: ${{ needs.filter.output.source-files }}
       # Limiting to amd64 is a workaround for https://github.com/canonical/charmcraft/issues/2018
       # Once that's resolved we should run fast and slow tests on ARM64 Ubuntu too.
       # Disabled macos tests because of https://github.com/canonical/charmcraft/issues/2605


### PR DESCRIPTION
Add the filter to the workflow directly, and pass it on to the called lint workflow.

Depends on https://github.com/canonical/starflow/pull/141 and https://github.com/canonical/starflow/pull/143.

For CRAFT-5161.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/charmcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
