### PR TITLE
docs: add common remote build pages

### DIFF
--- a/docs/howto/build-remotely.rst
+++ b/docs/howto/build-remotely.rst
@@ -1,0 +1,5 @@
+.. |star| replace:: charm
+.. |app-command| replace:: charmcraft
+.. |Starcraft| replace:: Charmcraft
+
+.. include:: ../common/craft-application/how-to-guides/build-remotely.rst

--- a/docs/howto/index.rst
+++ b/docs/howto/index.rst
@@ -61,7 +61,7 @@ migration guide for your charm:
 
 
 .. toctree::
-   :hidden:
+    :hidden:
 
     manage-charmcraft
     manage-charms

--- a/docs/howto/index.rst
+++ b/docs/howto/index.rst
@@ -39,6 +39,7 @@ Publish charms and manage releases
 When you're ready to distribute your charm, Charmcraft provides commands to register it,
 publish it to Charmhub, and manage its releases.
 
+- :ref:`how-to-build-remotely`
 - :ref:`manage-the-current-charmhub-user`
 - :ref:`manage-names`
 - :ref:`manage-icons`
@@ -62,18 +63,19 @@ migration guide for your charm:
 .. toctree::
    :hidden:
 
-   manage-charmcraft
-   manage-charms
-   Manage 12-factor app charms <manage-web-app-charms/index>
-   manage-extensions
-   manage-resources
-   manage-libraries
-   manage-parts
-   manage-the-current-charmhub-user
-   manage-names
-   manage-revisions
-   manage-channels
-   manage-tracks
-   manage-icons
-   Migrate plugins <migrate-plugins/index>
-   Build <build-guides/index>
+    manage-charmcraft
+    manage-charms
+    Manage 12-factor app charms <manage-web-app-charms/index>
+    manage-extensions
+    manage-resources
+    manage-libraries
+    manage-parts
+    build-remotely
+    manage-the-current-charmhub-user
+    manage-names
+    manage-revisions
+    manage-channels
+    manage-tracks
+    manage-icons
+    Migrate plugins <migrate-plugins/index>
+    Build <build-guides/index>

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -72,4 +72,5 @@ applications.
     parts/index
     platforms
     profile
+    remote-builds
     changelog

--- a/docs/reference/remote-builds.rst
+++ b/docs/reference/remote-builds.rst
@@ -1,0 +1,5 @@
+.. |star| replace:: charm
+.. |app-command| replace:: charmcraft
+.. |Starcraft| replace:: Charmcraft
+
+.. include:: ../common/craft-application/reference/remote-builds.rst


### PR DESCRIPTION
Add the common remote build how-to and reference pages.

---

- [X] I've followed the [contribution guidelines](https://github.com/canonical/charmcraft/blob/main/CONTRIBUTING.md).
- [X] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [X] I've successfully run `make lint && make test`.
- [X] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
