### PR TITLE
docs: clarify external documentation support and update example URL

### DIFF
--- a/docs/howto/manage-charms.rst
+++ b/docs/howto/manage-charms.rst
@@ -236,7 +236,7 @@ published automatically in respective tabs.
 
 To provide your main user documentation, include its URL in your charm's project file
 under the :ref:`links.documentation <charmcraft-yaml-key-documentation>` key.
-Charmcraft supports both native `Discourse <https://discourse.charmhub.io/>`_ topics
+Charmhub supports both `Discourse <https://discourse.charmhub.io/>`_ topics
 and externally hosted documentation sites.
 
 .. note::

--- a/docs/howto/manage-charms.rst
+++ b/docs/howto/manage-charms.rst
@@ -1,7 +1,7 @@
 .. _manage-charms:
 
 .. meta::
-    :description: Learn how to manage the full life cycle of a Juju charm with Charmcraft. This tutorial covers initializing, configuring, packing, publishing to Charmhub, and managing channel revisions.
+    :description: How to manage the full life cycle of a Juju charm with Charmcraft. This guide covers initializing, configuring, packing, publishing to Charmhub, and managing channel revisions.
 
 Manage charms
 =============
@@ -237,15 +237,13 @@ If you publish your charm on Charmhub, reference documentation about the charm's
 resources, actions, configurations, relations, and libraries is generated and
 published automatically in respective tabs.
 
-To provide your main user documentation, include its URL in your charm's project file
-under the :ref:`links.documentation <charmcraft-yaml-key-documentation>` key.
 Charmhub supports both `Discourse <https://discourse.charmhub.io/>`__ topics
-and externally hosted documentation sites.
+and externally hosted documentation sites. With an externally-hosted site,
+Charmhub displays a **Read documentation** button that redirects users to the specified URL.
+The **Description** tab displays your charm's basic metadata summary.
 
-.. note::
-    With an externally-hosted site, Charmhub displays a **Read documentation** button
-    that redirects users to the specified URL. The **Description** tab displays your
-    charm's basic metadata summary.
+To provide your main user documentation, include its URL in your charm's project file
+under the :ref:`links.documentation <charmcraft-yaml-key-documentation>` key. E.g.,
 
 .. code-block:: yaml
 

--- a/docs/howto/manage-charms.rst
+++ b/docs/howto/manage-charms.rst
@@ -1,3 +1,6 @@
+.. meta::
+    :description: Learn about initializing, configuring, packing, and publishing Juju charms with Charmcraft and releasing channel revisions on Charmhub.
+
 .. _manage-charms:
 
 Manage charms

--- a/docs/howto/manage-charms.rst
+++ b/docs/howto/manage-charms.rst
@@ -239,8 +239,8 @@ published automatically in respective tabs.
 
 Charmhub supports both `Discourse <https://discourse.charmhub.io/>`__ topics
 and externally hosted documentation sites. With an externally-hosted site,
-Charmhub displays a **Read documentation** button that redirects users to the specified URL.
-The **Description** tab displays your charm's basic metadata summary.
+Charmhub displays a **Read documentation** button that redirects users to the specified URL,
+while the **Description** tab displays your charm's basic metadata summary.
 
 To provide your main user documentation, include its URL in your charm's project file
 under the :ref:`links.documentation <charmcraft-yaml-key-documentation>` key. E.g.,

--- a/docs/howto/manage-charms.rst
+++ b/docs/howto/manage-charms.rst
@@ -1,7 +1,7 @@
-.. meta::
-    :description: Learn about initializing, configuring, packing, and publishing Juju charms with Charmcraft and releasing channel revisions on Charmhub.
-
 .. _manage-charms:
+
+.. meta::
+    :description: Learn how to manage the full lifecycle of a Juju charm with Charmcraft. Covers initialising, configuring, packing, publishing to Charmhub, and managing channel revisions.
 
 Manage charms
 =============
@@ -239,12 +239,12 @@ published automatically in respective tabs.
 
 To provide your main user documentation, include its URL in your charm's project file
 under the :ref:`links.documentation <charmcraft-yaml-key-documentation>` key.
-Charmhub supports both `Discourse <https://discourse.charmhub.io/>`_ topics
+Charmhub supports both `Discourse <https://discourse.charmhub.io/>`__ topics
 and externally hosted documentation sites.
 
 .. note::
-    When using an externally hosted site, Charmhub will display a **Read documentation** button
-    that will redirect users to the specified URL. The **Description** tab will display your
+    With an externally-hosted site, Charmhub displays a **Read documentation** button
+    that redirects users to the specified URL. The **Description** tab displays your
     charm's basic metadata summary.
 
 .. code-block:: yaml

--- a/docs/howto/manage-charms.rst
+++ b/docs/howto/manage-charms.rst
@@ -234,15 +234,20 @@ If you publish your charm on Charmhub, reference documentation about the charm's
 resources, actions, configurations, relations, and libraries is generated and
 published automatically in respective tabs.
 
-To add content to the **Description** tab,
-create a `Discourse <https://discourse.charmhub.io/>`_ topic and include its URL
-in your charm's project file under the
-:ref:`links.documentation <charmcraft-yaml-key-documentation>` key:
+To provide your main user documentation, include its URL in your charm's project file
+under the :ref:`links.documentation <charmcraft-yaml-key-documentation>` key.
+Charmcraft supports both native `Discourse <https://discourse.charmhub.io/>`_ topics
+and externally hosted documentation sites.
+
+.. note::
+    When using an externally hosted site, Charmhub will display a **Read documentation** button
+    that will redirect users to the specified URL. The **Description** tab will display your
+    charm's basic metadata summary.
 
 .. code-block:: yaml
 
     links:
-      documentation: https://discourse.charmhub.io/t/traefik-k8s-docs-index/10778
+      documentation: https://documentation.ubuntu.com/traefik-k8s-charm
 
 ..
 

--- a/docs/howto/manage-charms.rst
+++ b/docs/howto/manage-charms.rst
@@ -1,7 +1,7 @@
 .. _manage-charms:
 
 .. meta::
-    :description: Learn how to manage the full lifecycle of a Juju charm with Charmcraft. Covers initialising, configuring, packing, publishing to Charmhub, and managing channel revisions.
+    :description: Learn how to manage the full life cycle of a Juju charm with Charmcraft. This tutorial covers initializing, configuring, packing, publishing to Charmhub, and managing channel revisions.
 
 Manage charms
 =============

--- a/docs/howto/manage-charms.rst
+++ b/docs/howto/manage-charms.rst
@@ -238,7 +238,7 @@ resources, actions, configurations, relations, and libraries is generated and
 published automatically in respective tabs.
 
 Charmhub supports both `Discourse <https://discourse.charmhub.io/>`__ topics
-and externally hosted documentation sites. With an externally-hosted site,
+and externally-hosted documentation sites. With an externally-hosted site,
 Charmhub displays a **Read documentation** button that redirects users to the specified URL,
 while the **Description** tab displays your charm's basic metadata summary.
 


### PR DESCRIPTION
Updated the 'Add docs' section in the Manage Charms page to clarify Charmhub's support for external documentation sites and replaced the outdated Traefik example URL. Resolves [ISD-5245](https://warthogs.atlassian.net/browse/ISD-5245).

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/charmcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
- [x] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [x] I've updated the relevant release notes.


[ISD-5245]: https://warthogs.atlassian.net/browse/ISD-5245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ