### PR TITLE
docs(pack): refer to inline charmcraft.yaml metadata in pack help

### DIFF
--- a/charmcraft/application/commands/lifecycle.py
+++ b/charmcraft/application/commands/lifecycle.py
@@ -62,10 +62,10 @@ class PackCommand(lifecycle.PackCommand):
         upload it to Charmhub with `charmcraft upload`.
 
         For the charm you must be inside a charm directory with a valid
-        `metadata.yaml`, `requirements.txt` including the `ops` package
-        for the Python operator framework, and an operator entrypoint,
-        usually `src/charm.py`.  See `charmcraft init` to create a
-        template charm directory structure.
+        `charmcraft.yaml` containing the charm metadata, a `requirements.txt`
+        including the `ops` package for the Python operator framework, and an
+        operator entrypoint, usually `src/charm.py`.  See `charmcraft init`
+        to create a template charm directory structure.
         """
     )
 

--- a/charmcraft/application/commands/lifecycle.py
+++ b/charmcraft/application/commands/lifecycle.py
@@ -64,7 +64,7 @@ class PackCommand(lifecycle.PackCommand):
         For the charm you must be inside a charm directory with a valid
         `charmcraft.yaml` containing the charm metadata, a `requirements.txt`
         including the `ops` package for the Python operator framework, and an
-        operator entrypoint, usually `src/charm.py`.  See `charmcraft init`
+        operator entrypoint, usually `src/charm.py`.  See `charmcraft help init`
         to create a template charm directory structure.
         """
     )

--- a/docs/release-notes/charmcraft-4.2.rst
+++ b/docs/release-notes/charmcraft-4.2.rst
@@ -92,6 +92,8 @@ The following issues have been resolved in Charmcraft 4.2.1:
   using a separate ``metadata.yaml`` file and the ``--project-dir`` argument
 - `#2620 <https://github.com/canonical/charmcraft/issues/2620>`__ Multi-base shorthand
   notation fails on v4.2.0
+- The ``charmcraft pack`` help text now refers to inline ``charmcraft.yaml``
+  metadata instead of the legacy ``metadata.yaml`` split-file format.
 
 The following issues have been resolved in Charmcraft 4.2.2:
 

--- a/docs/release-notes/charmcraft-4.2.rst
+++ b/docs/release-notes/charmcraft-4.2.rst
@@ -92,7 +92,7 @@ The following issues have been resolved in Charmcraft 4.2.1:
   using a separate ``metadata.yaml`` file and the ``--project-dir`` argument
 - `#2620 <https://github.com/canonical/charmcraft/issues/2620>`__ Multi-base shorthand
   notation fails on v4.2.0
-- The ``charmcraft pack`` help text now refers to inline ``charmcraft.yaml``
+- `#2705 <https://github.com/canonical/charmcraft/pull/2705>`__ refer to inline charmcraft.yaml metadata in pack help
   metadata instead of the legacy ``metadata.yaml`` split-file format.
 
 The following issues have been resolved in Charmcraft 4.2.2:


### PR DESCRIPTION
The `pack --help` overview instructs users to ensure a valid `metadata.yaml` exists. That is the legacy split-file format; modern charms put metadata inline in `charmcraft.yaml`, so the stale guidance sends readers looking for a file that should not exist.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/charmcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
- [x] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [x] I've updated the relevant release notes.
