### PR TITLE
docs: add documentation for django-secret-key-id

### DIFF
--- a/docs/howto/manage-web-app-charms/configure-web-app-charm.rst
+++ b/docs/howto/manage-web-app-charms/configure-web-app-charm.rst
@@ -308,8 +308,17 @@ Add the Juju secret ID to the application:
         - ``DJANGO_API_TOKEN_VALUE: "1234"``
         - ``DJANGO_API_TOKEN_OTHERVALUE: "5678"``
 
-            See also: `How to manage secrets
-            <https://juju.is/docs/juju/manage-secrets>`_
+        The ``DJANGO_SECRET_KEY`` environment variable is initialized to a
+        random value. You can override it using the built-in configuration option
+        ``django-secret-key-id``, which accepts a Juju secret whose ``value`` key
+        is exposed as the ``DJANGO_SECRET_KEY`` environment variable.
+        For example:
+
+        .. code-block:: bash
+
+            juju add-secret my-django-secret-key value=<secret-string>
+            juju grant-secret my-django-secret-key <app name>
+            juju config <app name> django-secret-key-id=secret:<secret id>
 
     .. tab-item:: Express
         :sync: express
@@ -319,9 +328,6 @@ Add the Juju secret ID to the application:
         - ``APP_API_TOKEN_VALUE: "1234"``
         - ``APP_API_TOKEN_OTHERVALUE: "5678"``
 
-            See also: `How to manage secrets
-            <https://juju.is/docs/juju/manage-secrets>`_
-
     .. tab-item:: FastAPI
         :sync: fastapi
 
@@ -329,9 +335,6 @@ Add the Juju secret ID to the application:
 
         - ``APP_API_TOKEN_VALUE: "1234"``
         - ``APP_API_TOKEN_OTHERVALUE: "5678"``
-
-            See also: `How to manage secrets
-            <https://juju.is/docs/juju/manage-secrets>`_
 
     .. tab-item:: Flask
         :sync: flask
@@ -341,9 +344,6 @@ Add the Juju secret ID to the application:
         - ``APP_API_TOKEN_VALUE: "1234"``
         - ``APP_API_TOKEN_OTHERVALUE: "5678"``
 
-            See also: `How to manage secrets
-            <https://juju.is/docs/juju/manage-secrets>`_
-
     .. tab-item:: Go
         :sync: go
 
@@ -351,9 +351,6 @@ Add the Juju secret ID to the application:
 
         - ``APP_API_TOKEN_VALUE: "1234"``
         - ``APP_API_TOKEN_OTHERVALUE: "5678"``
-
-            See also: `How to manage secrets
-            <https://juju.is/docs/juju/manage-secrets>`_
 
     .. tab-item:: Spring Boot
         :sync: spring-boot
@@ -363,8 +360,8 @@ Add the Juju secret ID to the application:
         - ``APP_API_TOKEN_VALUE: "1234"``
         - ``APP_API_TOKEN_OTHERVALUE: "5678"``
 
-            See also: `How to manage secrets
-            <https://juju.is/docs/juju/manage-secrets>`_
+.. seealso::
+   `How to manage secrets <https://juju.is/docs/juju/manage-secrets>`_
 
 .. _configure-12-factor-charms-async-flask:
 

--- a/docs/reference/extensions/django-framework-extension.rst
+++ b/docs/reference/extensions/django-framework-extension.rst
@@ -168,6 +168,12 @@ The ``<config option name>`` and ``<key inside the secret>`` keywords in
 the environment variable name will have the hyphens replaced by
 underscores and all the letters capitalised.
 
+The config option ``django-secret-key-id`` is automatically added by the
+``django-framework`` extension. The secret must contain a single key ``value``,
+which holds the actual Django secret key and is exposed as the
+``DJANGO_SECRET_KEY`` environment variable. If this config option is not set,
+``DJANGO_SECRET_KEY`` is automatically assigned a random value.
+
    See more: :external+juju:ref:`Juju | Secret <secret>`
 
 .. _django-grafana-graphs:

--- a/docs/reference/extensions/django-framework-extension.rst
+++ b/docs/reference/extensions/django-framework-extension.rst
@@ -168,10 +168,10 @@ The ``<config option name>`` and ``<key inside the secret>`` keywords in
 the environment variable name will have the hyphens replaced by
 underscores and all the letters capitalised.
 
-The config option ``django-secret-key-id`` is automatically added by the
+The configuration option ``django-secret-key-id`` is automatically added by the
 ``django-framework`` extension. The secret must contain a single key ``value``,
 which holds the actual Django secret key and is exposed as the
-``DJANGO_SECRET_KEY`` environment variable. If this config option is not set,
+``DJANGO_SECRET_KEY`` environment variable. If this configuration option is not set,
 ``DJANGO_SECRET_KEY`` is automatically assigned a random value.
 
    See more: :external+juju:ref:`Juju | Secret <secret>`


### PR DESCRIPTION
Add documentation for the django-framework for the config option `django-secret-key-id`.
---

- [X] I've followed the [contribution guidelines](https://github.com/canonical/charmcraft/blob/main/CONTRIBUTING.md).
- [X] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [X] I've successfully run `make lint && make test`.
- [X] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
