### PR TITLE
ci: fix qa workflow conditional

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -16,6 +16,10 @@ jobs:
     outputs:
       source-files: ${{ steps.filter.outputs.source-files }}
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -28,12 +28,12 @@ jobs:
     uses: canonical/starflow/.github/workflows/lint-python.yaml@main
     needs: filter
     with:
-      source-files: ${{ needs.filter.output.source-files }}
+      source-files: ${{ needs.filter.outputs.source-files }}
   test:
     uses: canonical/starflow/.github/workflows/test-python.yaml@main
     needs: filter
     with:
-      source-files: ${{ needs.filter.output.source-files }}
+      source-files: ${{ needs.filter.outputs.source-files }}
       # Limiting to amd64 is a workaround for https://github.com/canonical/charmcraft/issues/2018
       # Once that's resolved we should run fast and slow tests on ARM64 Ubuntu too.
       # Disabled macos tests because of https://github.com/canonical/charmcraft/issues/2605


### PR DESCRIPTION
Correct a typo that locked up the workflow.

Won't completely fix the workflows until https://github.com/canonical/starflow/pull/146 is merged.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/charmcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
