### PR TITLE
docs: mention plugin differences in guide about managing icons

### DIFF
--- a/docs/howto/manage-icons.rst
+++ b/docs/howto/manage-icons.rst
@@ -1,5 +1,8 @@
 .. _manage-icons:
 
+.. meta::
+    :description: How to create, validate, and add an icon to a charm's Charmhub page, including a demo of using Inkscape to draw the icon.
+
 Manage icons
 ============
 

--- a/docs/howto/manage-icons.rst
+++ b/docs/howto/manage-icons.rst
@@ -78,8 +78,16 @@ page checks the most basic issues that prevent icons working.
 Add an icon to its charm's Charmhub page
 ----------------------------------------
 
-To add the icon to the charm's Charmhub page, save it as ``icon.svg``, place it
-in the root directory of the charm, and then :ref:`publish the charm to a channel <publish-a-charm>`
+To add the icon to the charm's Charmhub page, first save the icon as ``icon.svg`` in
+the root directory of the charm.
+
+If the charm uses the Charm plugin, Charmcraft automatically includes the icon when
+you pack the charm. Otherwise, use the Dump plugin to include the icon. See guidance
+for the :ref:`Poetry plugin <howto-migrate-to-poetry-include-extra-files>`,
+:ref:`Python plugin <howto-migrate-to-python-include-extra-files>`, or
+:ref:`uv plugin <howto-migrate-to-uv-include-extra-files>`.
+
+Next, :ref:`publish the charm to a channel <publish-a-charm>`
 of the form ``<track>/stable`` (e.g., ``latest/stable``). Note that the
 track that you publish the icon to needs to be the default track for the
 icon to be displayed on Charmhub. Please raise a

--- a/docs/howto/manage-icons.rst
+++ b/docs/howto/manage-icons.rst
@@ -1,7 +1,7 @@
 .. _manage-icons:
 
 .. meta::
-    :description: How to create, validate, and add an icon to a charm's Charmhub page, including a demo of using Inkscape to draw the icon.
+    :description: How to create, validate, and add an icon to a charm's Charmhub page. Includes a demo of using Inkscape to draw the icon.
 
 Manage icons
 ============
@@ -84,8 +84,8 @@ Add an icon to its charm's Charmhub page
 To add the icon to the charm's Charmhub page, first save the icon as ``icon.svg`` in
 the root directory of the charm.
 
-If the charm uses the Charm plugin, Charmcraft automatically includes the icon when
-you pack the charm. Otherwise, use the Dump plugin to include the icon. See guidance
+If the charm uses the Charm plugin, the icon will be included in it.
+Otherwise, use the Dump plugin to include the icon. See guidance
 for the :ref:`Poetry plugin <howto-migrate-to-poetry-include-extra-files>`,
 :ref:`Python plugin <howto-migrate-to-python-include-extra-files>`, or
 :ref:`uv plugin <howto-migrate-to-uv-include-extra-files>`.

--- a/docs/howto/migrate-plugins/charm-to-poetry.rst
+++ b/docs/howto/migrate-plugins/charm-to-poetry.rst
@@ -84,6 +84,8 @@ that can find these is::
 If run from the base directory of a charm, this will show all the PYDEPS declarations
 from all loaded charmlibs.
 
+.. _howto-migrate-to-poetry-include-extra-files:
+
 Include extra files
 -------------------
 

--- a/docs/howto/migrate-plugins/charm-to-python.rst
+++ b/docs/howto/migrate-plugins/charm-to-python.rst
@@ -105,6 +105,8 @@ If run from the base directory of a charm, this will show all the PYDEPS declara
 from all loaded charmlibs, which can be used to help generate the input for a tool
 that generates ``requirements.txt``.
 
+.. _howto-migrate-to-python-include-extra-files:
+
 Include extra files
 -------------------
 

--- a/docs/howto/migrate-plugins/charm-to-uv.rst
+++ b/docs/howto/migrate-plugins/charm-to-uv.rst
@@ -156,6 +156,8 @@ environment, such as one for charm libraries, the
 Likewise, optional dependencies under the ``pyproject.toml`` key
 ``project.optional-dependencies`` can be added with the ``uv-extras`` key.
 
+.. _howto-migrate-to-uv-include-extra-files:
+
 Include extra files
 -------------------
 


### PR DESCRIPTION
This PR updates "Manage icons" to mention that there's a difference in how plugins treat the icon file.

This continues (finishes?) work on https://github.com/canonical/charmcraft/issues/2593. Related work: https://github.com/canonical/operator/pull/2451.

**[Preview docs](https://canonical-ubuntu-documentation-library--2711.com.readthedocs.build/charmcraft/2711/howto/manage-icons/#add-an-icon-to-its-charm-s-charmhub-page)**

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/charmcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
- [x] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
