### PR TITLE
docs: linkchecker stopgap fix

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -154,6 +154,9 @@ linkcheck_ignore = [
     "https://matrix.to",
     "https://www.npmjs.com/",
     r"^https://www.mysql.com/$",
+    # 2026-06-03: Ignore Canonical sites until filtering is resolved
+    "https://snapcraft.io",
+    "https://juju.is",
 ]
 
 # Give linkcheck multiple tries on failure

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -137,18 +137,15 @@ rediraffe_redirects = "redirects.txt"
 linkcheck_anchors_ignore = [
     "#",
     ":",
-    r"https://github\.com/.*",
 ]
 linkcheck_ignore = [
-    # Ignore releases, since we'll include the next release before it exists.
-    r"^https://github.com/canonical/[a-z]*craft[a-z-]*/releases/.*",
     # Entire domains to ignore due to flakiness or issues
+    "https://github.com",
     r"^https://www.gnu.org/",
     r"^https://crates.io/",
     r"^https://([\w-]*\.)?npmjs.org",
     r"^https://rsync.samba.org",
     r"^https://ubuntu.com",
-    r"https://github.com/.*#",
     "http://django-hello-world",
     "http://www.inkscape.org",
     "https://matrix.to",


### PR DESCRIPTION
2026-06-23: We have ongoing intermittent errors with link checks to snapcraft.io and juju.is. Ignore them until availability is restored.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/charmcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
