### PR TITLE
fix: match Juju's action name validation rules

### DIFF
--- a/charmcraft/models/actions.py
+++ b/charmcraft/models/actions.py
@@ -18,9 +18,36 @@
 
 import keyword
 import re
+from typing import Any
 
 import pydantic
 from craft_application.models import CraftBaseModel
+
+# Must match the action name regex in Juju's charm library:
+# https://github.com/juju/charm/blob/6b348d6033da7feecfc7272c6eb752b2e8df2e1e/actions.go#L20
+# Action names must be lowercase, may contain digits and internal hyphens,
+# and may not contain underscores.
+_ACTION_NAME_REGEX = re.compile(r"^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$")
+
+
+def validate_action_names_and_bodies(actions: dict[str, Any]) -> None:
+    """Validate Juju action names and bodies.
+
+    Raises ValueError or TypeError if any action is invalid.
+    """
+    if not isinstance(actions, dict):
+        raise TypeError("actions.yaml is not a valid actions configuration")
+    for name, body in actions.items():
+        if keyword.iskeyword(name):
+            raise ValueError(
+                f"'{name}' is a reserved keyword and cannot be used as an action name"
+            )
+        if _ACTION_NAME_REGEX.match(name) is None:
+            raise ValueError(f"'{name}' is not a valid action name")
+        if not isinstance(body, dict):
+            raise TypeError(f"action '{name}' must be a mapping")
+        if "description" not in body:
+            raise ValueError(f"action '{name}' is missing a description")
 
 
 class JujuActions(CraftBaseModel):
@@ -29,31 +56,10 @@ class JujuActions(CraftBaseModel):
     See also: https://juju.is/docs/sdk/actions
     """
 
-    _action_name_regex = re.compile(r"^[a-zA-Z_][a-zA-Z0-9-_]*$")
     actions: dict[str, dict] | None
 
     @pydantic.field_validator("actions", mode="after")
     def validate_actions(cls, actions):
         """Verify actions names and descriptions."""
-        if not isinstance(actions, dict):
-            raise TypeError("actions.yaml is not a valid actions configuration")
-        for action in actions:
-            if keyword.iskeyword(action):
-                raise ValueError(
-                    f"'{action}' is a reserved keyword and cannot be used as an action name"
-                )
-            if cls._action_name_regex.match(action) is None:
-                raise ValueError(f"'{action}' is not a valid action name")
-
+        validate_action_names_and_bodies(actions)
         return actions
-
-    @pydantic.field_validator("actions", mode="after")
-    def _validate_actions(cls, action):
-        """Verify actions names and descriptions."""
-        if not isinstance(action, dict):
-            raise TypeError(f"'{action}' is not a dictionary")
-
-        if "description" not in action:
-            raise ValueError(f"'{action}' is missing a description")
-
-        return action

--- a/charmcraft/models/project.py
+++ b/charmcraft/models/project.py
@@ -46,6 +46,7 @@ from charmcraft.const import (
     BuildBaseStr,
 )
 from charmcraft.models import charmcraft
+from charmcraft.models.actions import validate_action_names_and_bodies
 from charmcraft.models.charmcraft import (
     AnalysisConfig,
     BasesConfiguration,
@@ -792,6 +793,15 @@ class CharmProject(CharmcraftProject):
             },
         ],
     )
+
+    @pydantic.field_validator("actions", mode="after")
+    @classmethod
+    def _validate_actions(cls, actions: dict[str, Any] | None) -> dict[str, Any] | None:
+        """Validate action names and bodies against Juju's rules."""
+        if actions is None:
+            return actions
+        validate_action_names_and_bodies(actions)
+        return actions
 
 
 def _check_base_is_legacy(base: charmcraft.BaseDict) -> bool:

--- a/docs/reference/files/actions-yaml-file.rst
+++ b/docs/reference/files/actions-yaml-file.rst
@@ -1,5 +1,8 @@
 .. _actions-yaml-file:
 
+.. _meta::
+    :description: Reference for the ``actions.yaml`` file, including the structure, keys, and naming rules for declaring Juju actions that a charm exposes to operators.
+
 ``actions.yaml`` file
 =====================
 

--- a/docs/reference/files/actions-yaml-file.rst
+++ b/docs/reference/files/actions-yaml-file.rst
@@ -109,10 +109,12 @@ charm.
 **Structure:**
 
 *Name:* The name of the key (``<action name>``) is defined by the charm
-author. It must be a valid Python :external+python:ref:`identifier <identifiers>`
-that does not collide with Python :external+python:ref:`keywords <keywords>`
-except that it may contain hyphens (which will be mapped to underscores in the Python
-event handler).
+author. It must match the regular expression
+``^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$`` (lowercase ASCII letters and digits,
+with internal hyphens permitted) and must not collide with a Python
+:external+python:ref:`keyword <keywords>`. Underscores are not permitted;
+hyphens in the action name are mapped to underscores in the Python event
+handler.
 
 *Type:* Map.
 

--- a/docs/reference/files/actions-yaml-file.rst
+++ b/docs/reference/files/actions-yaml-file.rst
@@ -1,7 +1,7 @@
 .. _actions-yaml-file:
 
-.. _meta::
-    :description: Reference for the ``actions.yaml`` file, including the structure, keys, and naming rules for declaring Juju actions that a charm exposes to operators.
+.. meta::
+    :description: Reference for the ``actions.yaml`` file, with descriptions for each of the keys used to declare a charm's supported actions.
 
 ``actions.yaml`` file
 =====================

--- a/docs/reference/files/actions-yaml-file.rst
+++ b/docs/reference/files/actions-yaml-file.rst
@@ -112,12 +112,9 @@ charm.
 **Structure:**
 
 *Name:* The name of the key (``<action name>``) is defined by the charm
-author. It must match the regular expression
-``^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$`` (lowercase ASCII letters and digits,
-with internal hyphens permitted) and must not collide with a Python
-:external+python:ref:`keyword <keywords>`. Underscores are not permitted;
-hyphens in the action name are mapped to underscores in the Python event
-handler.
+author. It must consist only of lowercase ASCII letters, numbers, and hyphens (-).
+A hyphen can't be the first or last character. It must not consist entirely of a
+:external+python:ref:`Python keyword <keywords`.
 
 *Type:* Map.
 

--- a/docs/reference/files/charmcraft-yaml-file.rst
+++ b/docs/reference/files/charmcraft-yaml-file.rst
@@ -1,7 +1,7 @@
 .. _charmcraft-yaml-file:
 
-.. _meta::
-    :description: Reference for the ``charmcraft.yaml`` project file, covering every supported top-level key, nested structures, and the inline charm metadata, actions, and configuration that Charmcraft consumes when packing a charm.
+.. meta::
+    :description: Reference for the Charmcraft project file, with descriptions and examples of each of its keys.
 
 ``charmcraft.yaml`` file
 ========================

--- a/docs/reference/files/charmcraft-yaml-file.rst
+++ b/docs/reference/files/charmcraft-yaml-file.rst
@@ -57,10 +57,8 @@ The value of this key is the contents of :ref:`actions-yaml-file`.
 .. admonition:: Best practice
     :class: hint
 
-    Prefer lowercase alphanumeric action names, and use hyphens (-) to separate words.
-    For charms that have already standardised on underscores, it is not necessary to
-    change them, and it is better to be consistent within a charm then to have
-    some action names be dashed and some be underscored.
+    Prefer lowercase alphanumeric action names, and use hyphens (-) to separate
+    words. Juju does not permit underscores in action names.
 
 .. admonition:: Best practice
     :class: hint

--- a/docs/reference/files/charmcraft-yaml-file.rst
+++ b/docs/reference/files/charmcraft-yaml-file.rst
@@ -1,5 +1,8 @@
 .. _charmcraft-yaml-file:
 
+.. _meta::
+    :description: Reference for the ``charmcraft.yaml`` project file, covering every supported top-level key, nested structures, and the inline charm metadata, actions, and configuration that Charmcraft consumes when packing a charm.
+
 ``charmcraft.yaml`` file
 ========================
 

--- a/docs/release-notes/charmcraft-4.2.rst
+++ b/docs/release-notes/charmcraft-4.2.rst
@@ -102,7 +102,7 @@ The following issues have been resolved in Charmcraft 4.2.2:
 
 - `#2598 <https://github.com/canonical/charmcraft/issues/2598>`__ Remote build fails
 when getting project name
-- `#TODO <https://github.com/canonical/charmcraft/pull/TODO>`__ Match Juju's
+- `#2723 <https://github.com/canonical/charmcraft/pull/2723>`__ Match Juju's
   action name validation rules
 
 Contributors

--- a/docs/release-notes/charmcraft-4.2.rst
+++ b/docs/release-notes/charmcraft-4.2.rst
@@ -1,5 +1,8 @@
 .. _release-4.2:
 
+.. _meta::
+    :description: Release notes for Charmcraft 4.2, listing the new features, behavioural changes, deprecations, and bug fixes shipped in the 4.2.x patch series.
+
 Charmcraft 4.2 release notes
 ============================
 

--- a/docs/release-notes/charmcraft-4.2.rst
+++ b/docs/release-notes/charmcraft-4.2.rst
@@ -99,6 +99,8 @@ The following issues have been resolved in Charmcraft 4.2.2:
 
 - `#2598 <https://github.com/canonical/charmcraft/issues/2598>`__ Remote build fails
 when getting project name
+- `#TODO <https://github.com/canonical/charmcraft/pull/TODO>`__ Match Juju's
+  action name validation rules
 
 Contributors
 ------------

--- a/tests/unit/models/test_actions.py
+++ b/tests/unit/models/test_actions.py
@@ -64,3 +64,14 @@ def test_invalid_action_names_rejected(name):
 def test_python_keyword_action_names_rejected(name):
     with pytest.raises(ValueError, match="reserved keyword"):
         JujuActions(actions=_actions(name))
+
+
+@pytest.mark.parametrize("body", ["a string", 42, None, ["a", "list"]])
+def test_non_mapping_action_body_rejected(body):
+    with pytest.raises(ValueError, match="valid dictionary"):
+        JujuActions(actions={"do-thing": body})
+
+
+def test_action_body_missing_description_rejected():
+    with pytest.raises(ValueError, match="missing a description"):
+        JujuActions(actions={"do-thing": {}})

--- a/tests/unit/models/test_actions.py
+++ b/tests/unit/models/test_actions.py
@@ -1,0 +1,66 @@
+# Copyright 2026 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For further info, check https://github.com/canonical/charmcraft
+"""Tests for the JujuActions model."""
+
+import pytest
+
+from charmcraft.models.actions import JujuActions
+
+
+def _actions(name):
+    return {name: {"description": "x"}}
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "snapshot",
+        "backup-database",
+        "do-the-thing",
+        "a",
+        "a1",
+        "step-1",
+        "action2",
+    ],
+)
+def test_valid_action_names(name):
+    JujuActions(actions=_actions(name))
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "snake_case",
+        "_leading-underscore",
+        "trailing_",
+        "Uppercase",
+        "camelCase",
+        "-leading-hyphen",
+        "trailing-hyphen-",
+        "has space",
+        "with.dot",
+        "",
+    ],
+)
+def test_invalid_action_names_rejected(name):
+    with pytest.raises(ValueError, match="is not a valid action name"):
+        JujuActions(actions=_actions(name))
+
+
+@pytest.mark.parametrize("name", ["if", "for", "class", "return"])
+def test_python_keyword_action_names_rejected(name):
+    with pytest.raises(ValueError, match="reserved keyword"):
+        JujuActions(actions=_actions(name))

--- a/tests/unit/models/test_project.py
+++ b/tests/unit/models/test_project.py
@@ -692,6 +692,20 @@ def test_instantiate_bases_charm_error(
         project.BasesCharm(**values)
 
 
+@pytest.mark.parametrize("name", ["snake_case", "Uppercase", "-leading-hyphen"])
+def test_invalid_action_name_rejected_at_project_level(name: str):
+    values = {
+        "type": "charm",
+        "name": "test-charm",
+        "summary": "A test charm",
+        "description": "A test charm with an invalid action name.",
+        "bases": [SIMPLE_BASE_CONFIG_DICT],
+        "actions": {name: {"description": "x"}},
+    }
+    with pytest.raises(pydantic.ValidationError, match="is not a valid action name"):
+        project.BasesCharm(**values)
+
+
 @pytest.mark.parametrize("base", const.SUPPORTED_BASE_STRINGS)
 def test_supported_base_works_with_its_own_build_base(base: str):
     project.PlatformCharm.unmarshal(


### PR DESCRIPTION
The documentation implies that a Juju action name may contain underscores, but [that is not the case](https://github.com/juju/charm/blob/v12/actions.go#L20), and Juju will refuse to deploy a charm that does have one. This PR updates the documentation to be clearer what the real rules are.

It's also better for charmcraft to fail rather than Juju, so the Juju regular expression is also copied over to the charmcraft validation. Also, the validation wasn't hooked up, even though other fields (like name) are, which seems like a bug, so adjusted that too.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/charmcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've 'successfully' run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
- [x] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [x] I've updated the relevant release notes.
