### PR TITLE
fix(docs): update broken Multipass documentation links

### DIFF
--- a/docs/howto/manage-charmcraft.rst
+++ b/docs/howto/manage-charmcraft.rst
@@ -108,7 +108,7 @@ In an isolated environment
 Another way to install Charmcraft is via `Multipass`_. This is a good way to install it
 on any platform, as it will give you an isolated development environment.
 
-First, `install Multipass <https://multipass.run/docs/how-to-install-multipass>`_.
+First, `install Multipass <https://documentation.ubuntu.com/multipass/stable/how-to-guides/install-multipass/>`_.
 
 Second, use Multipass to provision a virtual machine. The following command will launch
 a fresh new VM with 4 cores, 8GB RAM and a 20GB disk and the name ‘charm-dev':

--- a/docs/reuse/links.txt
+++ b/docs/reuse/links.txt
@@ -13,7 +13,7 @@
 .. _`OCI layers`: https://github.com/opencontainers/image-spec/blob/main/layer.md
 .. _`Operator framework`: https://documentation.ubuntu.com/ops/latest/
 .. _LXD: https://canonical.com/lxd
-.. _Multipass: https://multipass.run/docs
+.. _Multipass: https://documentation.ubuntu.com/multipass/
 .. _`Open Container Initiative`: https://opencontainers.org/
 .. _Rockcraft: https://documentation.ubuntu.com/rockcraft/
 .. _snapd: https://snapcraft.io/docs/installing-snapd


### PR DESCRIPTION
This PR fixes the broken Multipass documentation links which were causing the documentation link checks to fail in CI.