### PR TITLE
docs: improve versioning logic

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,13 +29,13 @@ project = "Charmcraft"
 author = "Canonical"
 
 # Version string in sidebar
-if os.environ.get("READTHEDOCS_VERSION_TYPE", "external") != "external":
-    rtd_version = os.environ.get("READTHEDOCS_VERSION", "latest")
-    release = rtd_version if rtd_version != "latest" else "dev"
-else:
+if os.environ.get("READTHEDOCS_VERSION_TYPE", "external") == "external":  # PR or local build
     # Because of Autotools, we can safely assume the version starts with `n.n`
-    major, minor, *_ = charmcraft.__version__.split(".")
+    major, minor, *_ = snapcraft.__version__.split(".")
     release = f"{major}.{minor}"
+else:  # Branch build
+    rtd_version = os.environ.get("READTHEDOCS_VERSION", "latest")
+    release = "dev" if rtd_version == "latest" else rtd_version
 
 html_title = project + " documentation"
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,10 +28,14 @@ import charmcraft
 project = "Charmcraft"
 author = "Canonical"
 
-# The commit hash in the dev release version confuses the spellchecker
-release = os.environ.get("READTHEDOCS_VERSION", charmcraft.__version__)
-if ".post" in release:
-    release = "dev"
+# Version string in sidebar
+if os.environ.get("READTHEDOCS_VERSION_TYPE", "external") != "external":
+    rtd_version = os.environ.get("READTHEDOCS_VERSION", "latest")
+    release = rtd_version if rtd_version != "latest" else "dev"
+else:
+    # Because of Autotools, we can safely assume the version starts with `n.n`
+    major, minor, *_ = charmcraft.__version__.split(".")
+    release = f"{major}.{minor}"
 
 html_title = project + " documentation"
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,7 +31,7 @@ author = "Canonical"
 # Version string in sidebar
 if os.environ.get("READTHEDOCS_VERSION_TYPE", "external") == "external":  # PR or local build
     # Because of Autotools, we can safely assume the version starts with `n.n`
-    major, minor, *_ = snapcraft.__version__.split(".")
+    major, minor, *_ = charmcraft.__version__.split(".")
     release = f"{major}.{minor}"
 else:  # Branch build
     rtd_version = os.environ.get("READTHEDOCS_VERSION", "latest")

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,15 +28,10 @@ import charmcraft
 project = "Charmcraft"
 author = "Canonical"
 
-# Sidebar documentation title; best kept reasonably short
-# The full version, including alpha/beta/rc tags
-release = charmcraft.__version__
 # The commit hash in the dev release version confuses the spellchecker
+release = os.environ.get("READTHEDOCS_VERSION", charmcraft.__version__)
 if ".post" in release:
     release = "dev"
-else:
-    major, minor, *_ = release.split(".")
-    release = f"{major}.{minor}"
 
 html_title = project + " documentation"
 


### PR DESCRIPTION
No versions but 'latest' should be labeled 'Charmcraft dev documentation'.

---

- [X] I've followed the [contribution guidelines](https://github.com/canonical/charmcraft/blob/main/CONTRIBUTING.md).
- [X] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
