### PR TITLE
docs: fix the title in the toc

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,8 +37,6 @@ else:  # Branch build
     rtd_version = os.environ.get("READTHEDOCS_VERSION", "latest")
     release = "dev" if rtd_version == "latest" else rtd_version
 
-html_title = project + " documentation"
-
 # Copyright string; shown at the bottom of the page
 copyright = "2023-%s, %s" % (datetime.date.today().year, author)
 


### PR DESCRIPTION
We don't use `html_title` anymore, bceause it interferes with the default theme processing.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/charmcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
