### PR TITLE
ci: Fix CI filter job and linting issues

### DIFF
--- a/.github/workflows/policy.yaml
+++ b/.github/workflows/policy.yaml
@@ -13,6 +13,10 @@ jobs:
     outputs:
       source-files: ${{ steps.filter.outputs.source-files }}
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:

--- a/tests/unit/commands/test_lifecycle.py
+++ b/tests/unit/commands/test_lifecycle.py
@@ -89,7 +89,7 @@ def test_pack_update_charm_libs_empty(
 
     libs_service = cast("CharmLibsService", service_factory.get("charm_libs"))
     mock_write = mock.Mock(wraps=libs_service.write)
-    libs_service.write = mock_write  # ty: ignore[invalid-assignment]
+    libs_service.write = mock_write
 
     pack._update_charm_libs()
 


### PR DESCRIPTION
This PR fixes two issues:
1. Added missing checkout step to policy.yaml workflow to resolve git error in filter job
2. Removed unused ty: ignore comment that was causing linting failure

---

- [ ] I've followed the [contribution guidelines](https://github.com/canonical/charmcraft/blob/main/CONTRIBUTING.md).
- [ ] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
