### PR TITLE
docs: add Canonical K8s instructions to web app charm how-tos

### DIFF
--- a/docs/howto/manage-web-app-charms/integrate-web-app-charm.rst
+++ b/docs/howto/manage-web-app-charms/integrate-web-app-charm.rst
@@ -101,13 +101,27 @@ You must prepare an ingress if you wish to integrate your 12-factor web app
 with the `Canonical Observability Stack
 (COS) <https://charmhub.io/topics/canonical-observability-stack>`_.
 COS relies on the Traefik ingress to expose, for example, Grafana.
-On MicroK8s, Traefik requires the MetalLB load balancer to be enabled which
-requires an IP range. Provide the IP range and enable the addon with:
+Traefik requires a load balancer to be enabled with an IP range. Provide the
+IP range and enable the load balancer with:
 
-.. code-block:: bash
+.. tab-set::
 
-    IPADDR=$(ip -4 -j route get 2.2.2.2 | jq -r '.[] | .prefsrc')
-    microk8s enable metallb:$IPADDR-$IPADDR
+    .. tab-item:: MicroK8s
+        :sync: microk8s
+
+        .. code-block:: bash
+
+            IPADDR=$(ip -4 -j route get 2.2.2.2 | jq -r '.[] | .prefsrc')
+            microk8s enable metallb:$IPADDR-$IPADDR
+
+    .. tab-item:: Canonical K8s
+        :sync: canonical-k8s
+
+        .. code-block:: bash
+
+            IPADDR=$(ip -4 -j route get 2.2.2.2 | jq -r '.[] | .prefsrc')
+            sudo k8s set load-balancer.l2-mode=true load-balancer.cidrs=$IPADDR-$IPADDR
+            sudo k8s enable load-balancer
 
 
 Deploy and integrate observability to the 12-factor app with:

--- a/docs/howto/manage-web-app-charms/use-web-app-charm.rst
+++ b/docs/howto/manage-web-app-charms/use-web-app-charm.rst
@@ -411,7 +411,7 @@ name of the web app with the ``-c`` option.
 
    - `MicroK8s | Troubleshooting <https://microk8s.io/docs/troubleshooting>`_
    - `Canonical Kubernetes | Troubleshoot
-     <https://documentation.ubuntu.com/canonical-kubernetes/latest/snap/troubleshooting/>`_
+     <https://documentation.ubuntu.com/canonical-kubernetes/latest/snap/howto/troubleshooting/>`_
 
 Check Juju logs
 ~~~~~~~~~~~~~~~

--- a/docs/howto/manage-web-app-charms/use-web-app-charm.rst
+++ b/docs/howto/manage-web-app-charms/use-web-app-charm.rst
@@ -244,24 +244,48 @@ of the container, for instance, ``/django/app``.
    <https://documentation.ubuntu.com/juju/latest/user/reference/
    juju-cli/list-of-juju-cli-commands/ssh/>`_
 
-Check MicroK8s pod services and logs
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Check Kubernetes pod services and logs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Check the currently deployed Kubernetes resources in the
 ``<model-namespace>``, which is the same as the Juju model name:
 
-.. code::
+.. tab-set::
 
-   microk8s.kubectl get all -n <model-namespace>
+    .. tab-item:: MicroK8s
+        :sync: microk8s
 
-This command outputs a list of all the MicroK8s resources in the web app's
+        .. code-block:: bash
+
+            microk8s.kubectl get all -n <model-namespace>
+
+    .. tab-item:: Canonical K8s
+        :sync: canonical-k8s
+
+        .. code-block:: bash
+
+            sudo k8s kubectl get all -n <model-namespace>
+
+This command outputs a list of all the Kubernetes resources in the web app's
 Juju model.
 
-Check the logs for a specific MicroK8s pod:
+Check the logs for a specific Kubernetes pod:
 
-.. code::
+.. tab-set::
 
-   microk8s kubectl logs <pod-name> -n <model-namespace>
+    .. tab-item:: MicroK8s
+        :sync: microk8s
+
+        .. code-block:: bash
+
+            microk8s kubectl logs <pod-name> -n <model-namespace>
+
+    .. tab-item:: Canonical K8s
+        :sync: canonical-k8s
+
+        .. code-block:: bash
+
+            sudo k8s kubectl logs <pod-name> -n <model-namespace>
 
 This command outputs the logs of the sidecar container pod. To fetch logs
 specific to the workload of the web app, you need to specify the container
@@ -272,48 +296,122 @@ name of the web app with the ``-c`` option.
     .. tab-item:: Django
         :sync: django
 
-        .. code-block:: bash
+        .. tab-set::
 
-            microk8s kubectl logs <pod-name> -n <model-namespace> -c django-app
+            .. tab-item:: MicroK8s
+                :sync: microk8s
+
+                .. code-block:: bash
+
+                    microk8s kubectl logs <pod-name> -n <model-namespace> -c django-app
+
+            .. tab-item:: Canonical K8s
+                :sync: canonical-k8s
+
+                .. code-block:: bash
+
+                    sudo k8s kubectl logs <pod-name> -n <model-namespace> -c django-app
 
     .. tab-item:: Express
         :sync: express
 
-        .. code-block:: bash
+        .. tab-set::
 
-            microk8s kubectl logs <pod-name> -n <model-namespace> -c app
+            .. tab-item:: MicroK8s
+                :sync: microk8s
+
+                .. code-block:: bash
+
+                    microk8s kubectl logs <pod-name> -n <model-namespace> -c app
+
+            .. tab-item:: Canonical K8s
+                :sync: canonical-k8s
+
+                .. code-block:: bash
+
+                    sudo k8s kubectl logs <pod-name> -n <model-namespace> -c app
 
     .. tab-item:: FastAPI
         :sync: fastapi
 
-        .. code-block:: bash
+        .. tab-set::
 
-            microk8s kubectl logs <pod-name> -n <model-namespace> -c app
+            .. tab-item:: MicroK8s
+                :sync: microk8s
+
+                .. code-block:: bash
+
+                    microk8s kubectl logs <pod-name> -n <model-namespace> -c app
+
+            .. tab-item:: Canonical K8s
+                :sync: canonical-k8s
+
+                .. code-block:: bash
+
+                    sudo k8s kubectl logs <pod-name> -n <model-namespace> -c app
 
     .. tab-item:: Flask
         :sync: flask
 
-        .. code-block:: bash
+        .. tab-set::
 
-            microk8s kubectl logs <pod-name> -n <model-namespace> -c flask-app
+            .. tab-item:: MicroK8s
+                :sync: microk8s
+
+                .. code-block:: bash
+
+                    microk8s kubectl logs <pod-name> -n <model-namespace> -c flask-app
+
+            .. tab-item:: Canonical K8s
+                :sync: canonical-k8s
+
+                .. code-block:: bash
+
+                    sudo k8s kubectl logs <pod-name> -n <model-namespace> -c flask-app
 
     .. tab-item:: Go
         :sync: go
 
-        .. code-block:: bash
+        .. tab-set::
 
-            microk8s kubectl logs <pod-name> -n <model-namespace> -c app
+            .. tab-item:: MicroK8s
+                :sync: microk8s
+
+                .. code-block:: bash
+
+                    microk8s kubectl logs <pod-name> -n <model-namespace> -c app
+
+            .. tab-item:: Canonical K8s
+                :sync: canonical-k8s
+
+                .. code-block:: bash
+
+                    sudo k8s kubectl logs <pod-name> -n <model-namespace> -c app
 
     .. tab-item:: Spring Boot
         :sync: spring-boot
 
-        .. code-block:: bash
+        .. tab-set::
 
-            microk8s kubectl logs <pod-name> -n <model-namespace> -c app
+            .. tab-item:: MicroK8s
+                :sync: microk8s
+
+                .. code-block:: bash
+
+                    microk8s kubectl logs <pod-name> -n <model-namespace> -c app
+
+            .. tab-item:: Canonical K8s
+                :sync: canonical-k8s
+
+                .. code-block:: bash
+
+                    sudo k8s kubectl logs <pod-name> -n <model-namespace> -c app
 
 .. seealso::
 
-   `MicroK8s | Troubleshooting <https://microk8s.io/docs/troubleshooting>`_
+   - `MicroK8s | Troubleshooting <https://microk8s.io/docs/troubleshooting>`_
+   - `Canonical Kubernetes | Troubleshoot
+     <https://documentation.ubuntu.com/canonical-kubernetes/latest/snap/troubleshooting/>`_
 
 Check Juju logs
 ~~~~~~~~~~~~~~~

--- a/docs/howto/manage-web-app-charms/use-web-app-charm.rst
+++ b/docs/howto/manage-web-app-charms/use-web-app-charm.rst
@@ -245,7 +245,7 @@ of the container, for instance, ``/django/app``.
    juju-cli/list-of-juju-cli-commands/ssh/>`_
 
 Check Kubernetes pod services and logs
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Check the currently deployed Kubernetes resources in the
 ``<model-namespace>``, which is the same as the Juju model name:


### PR DESCRIPTION
Migrate the MicroK8s-only steps in the `manage-web-app-charms` how-to guides to also cover Canonical K8s, following the tabbed pattern already used in the "Use a database with your 12-factor app charm" guide. MicroK8s instructions are kept and Canonical K8s equivalents are added alongside them in `MicroK8s` / `Canonical K8s` tabs.

Changes:
- `integrate-web-app-charm.rst`: the Traefik load balancer setup now offers a Canonical K8s tab (`sudo k8s set load-balancer...` / `sudo k8s enable load-balancer`) next to the MicroK8s MetalLB steps.
- `use-web-app-charm.rst`: the troubleshooting "Check Kubernetes pod services and logs" section now provides Canonical K8s `sudo k8s kubectl` equivalents, including per-framework log commands, plus a Canonical Kubernetes troubleshooting link.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/charmcraft/blob/main/CONTRIBUTING.md).
- [ ] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
