### PR TITLE
docs: improve charm naming docs, with links to detailed guidance

### DIFF
--- a/docs/howto/manage-charms.rst
+++ b/docs/howto/manage-charms.rst
@@ -56,7 +56,7 @@ with ``-operator``. Otherwise, your charm's name will end with ``-operator`` too
         ls -R
 
         .:
-        charmcraft.yaml  pyproject.toml  requirements.txt  src  tox.ini
+        charmcraft.yaml  pyproject.toml  src  tox.ini
 
         ./src:
         charm.py

--- a/docs/howto/manage-charms.rst
+++ b/docs/howto/manage-charms.rst
@@ -21,27 +21,28 @@ up a Git repository, name the repository ``<charm name>-operator``. Use a differ
 naming convention if your charm doesn't operate a workload. For detailed guidance, see
 :external+ops:ref:`Ops | How to initialise your project <init-charm>`.
 
-To initialise a charm project, create a directory for your charm, enter it, then run
-``charmcraft init`` with the ``--profile`` flag followed by a suitable profile name (for
-machine charms: ``machine``; for Kubernetes charms: ``kubernetes`` or
-``flask-framework``); that will create all the necessary files and even prepopulate them
-with useful content.
+To initialise a charm project, create a repository or directory for your charm, enter it,
+then run ``charmcraft init`` with the ``--profile`` flag followed by a suitable profile
+name: For a machine charm, ``machine``. For a Kubernetes charm, ``kubernetes`` or a
+12-factor app profile such as ``flask-framework``. This will create all the necessary
+files and even prepopulate them with useful content.
 
 .. code-block:: bash
 
-    charmcraft init --profile <profile>
+    charmcraft init --name <charm name> --profile <profile>
+
+It's important to specify ``--name`` if the name of the repository or directory ends
+with ``-operator``. Otherwise, your charm's name will end with ``-operator`` too.
 
 .. dropdown:: Example session
 
-    .. code-block:: bash
-
-        mkdir my-flask-app-k8s
-        cd my-flask-app-k8s/
-        charmcraft init --profile flask-framework
-
     .. terminal::
+        :dir: ~/my-flask-app-k8s-operator
 
-        Charmed operator package file and directory tree initialised
+        charmcraft init --name my-flask-app-k8s --profile flask-framework
+
+        Charmed operator package file and directory tree initialised.
+
         Now edit the following package files to provide fundamental charm metadata
         and other information:
 
@@ -49,24 +50,21 @@ with useful content.
         src/charm.py
         README.md
 
-    .. code-block:: bash
+    .. terminal::
+        :dir: ~/my-flask-app-k8s-operator
 
         ls -R
 
-    .. terminal::
-
         .:
-        charmcraft.yaml  requirements.txt  src
+        charmcraft.yaml  pyproject.toml  requirements.txt  src  tox.ini
 
         ./src:
         charm.py
 
-The command also allows you to not specify any profile (in that case you get the
-``kubernetes`` profile -- a minimal profile with scaffolding for a Kubernetes charm)
-and has flags that you can use to specify a different directory to operate
-in, a charm name different from the name of the root directory, etc.
+The command also allows you to not specify any profile. In that case you get the
+``kubernetes`` profile -- a minimal profile with scaffolding for a Kubernetes charm.
 
-    See more: :ref:`ref_commands_revisions`, :ref:`profile`, :ref:`files`
+    See more: :ref:`ref_commands_init`, :ref:`profile`, :ref:`files`
 
     See more: :ref:`manage-extensions`
 

--- a/docs/howto/manage-charms.rst
+++ b/docs/howto/manage-charms.rst
@@ -28,7 +28,7 @@ your charm's repository), then run ``charmcraft init``:
 
     charmcraft init --name <charm name> --profile <profile>
 
-This will create all the necessary files and even prepopulate them with useful content.
+This will create all the necessary files and populate them with useful content.
 
 If the charm name you want is different from the current directory name, don't skip the
 ``--name`` argument. Otherwise the charm name will match the directory name.

--- a/docs/howto/manage-charms.rst
+++ b/docs/howto/manage-charms.rst
@@ -21,17 +21,21 @@ naming convention if your charm doesn't operate a workload. For detailed guidanc
 :external+ops:ref:`Ops | How to initialise your project <init-charm>`. The Ops guidance
 also explains how to name your charm's Git repository.
 
-To initialise a charm project, enter your working directory (likely your charm's
-repository), then run ``charmcraft init`` with the ``--profile`` flag followed by a
-suitable profile name: For a machine charm, ``machine``. For a Kubernetes charm,
-``kubernetes`` or a 12-factor app profile such as ``flask-framework``. This will create
-all the necessary files and even prepopulate them with useful content.
+To initialise a charm project, enter the directory that will contain your charm (likely
+your charm's repository), then run ``charmcraft init``:
 
 .. code-block:: bash
 
     charmcraft init --name <charm name> --profile <profile>
 
-It's important to specify ``--name`` if the directory name and charm name are different.
+This will create all the necessary files and even prepopulate them with useful content.
+
+If the charm name you want is different from the current directory name, don't skip the
+``--name`` argument. Otherwise the charm name will match the directory name.
+
+``<profile>`` can be ``kubernetes`` for a Kubernetes charm, ``machine`` for a machine
+charm, or a 12-factor app profile such as ``flask-framework``. If you don't specify a
+profile, you get the ``kubernetes`` profile.
 
 .. dropdown:: Example session
 
@@ -59,9 +63,6 @@ It's important to specify ``--name`` if the directory name and charm name are di
 
         ./src:
         charm.py
-
-The command also allows you to not specify any profile. In that case you get the
-``kubernetes`` profile -- a minimal profile with scaffolding for a Kubernetes charm.
 
     See more: :ref:`ref_commands_init`, :ref:`profile`, :ref:`files`
 

--- a/docs/howto/manage-charms.rst
+++ b/docs/howto/manage-charms.rst
@@ -16,16 +16,16 @@ Initialise a charm
 
 Before you initialise a charm project, decide what to call your charm.
 
-A charm's name is typically based on the name of the charm's workload. If you're setting
-up a Git repository, name the repository ``<charm name>-operator``. Use a different
+A charm's name is typically based on the name of the charm's workload. Use a different
 naming convention if your charm doesn't operate a workload. For detailed guidance, see
-:external+ops:ref:`Ops | How to initialise your project <init-charm>`.
+:external+ops:ref:`Ops | How to initialise your project <init-charm>`. The Ops guidance
+also explains how to name your charm's Git repository.
 
-To initialise a charm project, create a repository or directory for your charm, enter it,
-then run ``charmcraft init`` with the ``--profile`` flag followed by a suitable profile
-name: For a machine charm, ``machine``. For a Kubernetes charm, ``kubernetes`` or a
-12-factor app profile such as ``flask-framework``. This will create all the necessary
-files and even prepopulate them with useful content.
+To initialise a charm project, enter your working directory (likely your charm's
+repository), then run ``charmcraft init`` with the ``--profile`` flag followed by a
+suitable profile name: For a machine charm, ``machine``. For a Kubernetes charm,
+``kubernetes`` or a 12-factor app profile such as ``flask-framework``. This will create
+all the necessary files and even prepopulate them with useful content.
 
 .. code-block:: bash
 

--- a/docs/howto/manage-charms.rst
+++ b/docs/howto/manage-charms.rst
@@ -22,7 +22,7 @@ naming convention if your charm doesn't operate a workload. For detailed guidanc
 also explains how to name your charm's Git repository.
 
 To initialise a charm project, enter the directory that will contain your charm (likely
-your charm's repository), then run ``charmcraft init``:
+in your charm's repository), then run ``charmcraft init``:
 
 .. code-block:: bash
 

--- a/docs/howto/manage-charms.rst
+++ b/docs/howto/manage-charms.rst
@@ -31,8 +31,7 @@ files and even prepopulate them with useful content.
 
     charmcraft init --name <charm name> --profile <profile>
 
-It's important to specify ``--name`` if the name of the repository or directory ends
-with ``-operator``. Otherwise, your charm's name will end with ``-operator`` too.
+It's important to specify ``--name`` if the directory name and charm name are different.
 
 .. dropdown:: Example session
 

--- a/docs/howto/manage-charms.rst
+++ b/docs/howto/manage-charms.rst
@@ -14,11 +14,12 @@ Manage charms
 Initialise a charm
 ------------------
 
-.. admonition:: Best practice
-    :class: hint
+Before you initialise a charm project, decide what to call your charm.
 
-    If you're setting up a ``git`` repository: name it using the pattern
-    ``<charm name>-operator``. For the charm name, see :ref:`specify-a-name`.
+A charm's name is typically based on the name of the charm's workload. If you're setting
+up a Git repository, name the repository ``<charm name>-operator``. Use a different
+naming convention if your charm doesn't operate a workload. For detailed guidance, see
+:external+ops:ref:`Ops | How to initialise your project <init-charm>`.
 
 To initialise a charm project, create a directory for your charm, enter it, then run
 ``charmcraft init`` with the ``--profile`` flag followed by a suitable profile name (for

--- a/docs/reference/files/charmcraft-yaml-file.rst
+++ b/docs/reference/files/charmcraft-yaml-file.rst
@@ -636,7 +636,7 @@ determines the name administrators will ultimately use to deploy the charm. E.g.
     name: <name>
 
 **Value:** Slug-oriented (ASCII lowercase letters, numbers, and hyphens) following the
-pattern ``<workload name in full>[<function>][-k8s]``.
+pattern ``<workload name>[<function>][-k8s]``.
 For example, ``argo-server-k8s``. Use a different pattern if the charm doesn't
 operate a workload. See :external+ops:ref:`Ops | Decide your charm's name <decide-your-charms-name>`.
 

--- a/docs/reference/files/charmcraft-yaml-file.rst
+++ b/docs/reference/files/charmcraft-yaml-file.rst
@@ -635,28 +635,16 @@ determines the name administrators will ultimately use to deploy the charm. E.g.
 
     name: <name>
 
+**Value:** Slug-oriented (ASCII lowercase letters, numbers, and hyphens) following the
+pattern ``<workload name in full>[<function>][-k8s]``.
+For example, ``argo-server-k8s``. Use a different pattern if the charm doesn't
+operate a workload. See :external+ops:ref:`Ops | Decide your charm's name <decide-your-charms-name>`.
+
 **Example:**
 
 .. literalinclude:: charmcraft-sample-charm.yaml
         :start-at: name:
         :end-before: parts:
-
-.. admonition:: Best practice
-    :class: hint
-
-    The charm name should be slug-oriented (ASCII lowercase letters, numbers, and
-    hyphens) and follow the pattern ``<workload name in full>[<function>][-k8s]``.
-    For example, ``argo-server-k8s``.
-
-    Include the ``-k8s`` suffix on all charms that run on a Kubernetes cloud,
-    unless the charm has no workload or you know that there will never be
-    a machine version of the charm.
-
-    Don't include an organization or publisher in the name.
-
-    Don't add an ``operator`` or ``charm`` prefix or suffix. For naming a
-    repository, see :ref:`initialise-a-charm`.
-
 
 .. _charmcraft-yaml-key-parts:
 

--- a/docs/reference/files/charmcraft-yaml-file.rst
+++ b/docs/reference/files/charmcraft-yaml-file.rst
@@ -635,10 +635,9 @@ determines the name administrators will ultimately use to deploy the charm. E.g.
 
     name: <name>
 
-**Value:** Slug-oriented (ASCII lowercase letters, numbers, and hyphens) following the
-pattern ``<workload name>[<function>][-k8s]``.
-For example, ``argo-server-k8s``. Use a different pattern if the charm doesn't
-operate a workload. See :external+ops:ref:`Ops | Decide your charm's name <decide-your-charms-name>`.
+**Value:** ``<workload name>[<function>][-k8s]``, using only ASCII lowercase letters,
+numbers, and hyphens. For example, ``argo-server-k8s``. Use a different pattern if the
+charm doesn't operate a workload. See :external+ops:ref:`Ops | Decide your charm's name <decide-your-charms-name>`.
 
 **Example:**
 


### PR DESCRIPTION
This PR fixes #2582.

I'm updating two docs:

- [charmcraft.yaml file > name](https://documentation.ubuntu.com/charmcraft/latest/reference/files/charmcraft-yaml-file/#name) (**[Preview doc](https://canonical-charmcraft--2748.com.readthedocs.build/2748/reference/files/charmcraft-yaml-file/#name)**) - Removed the best practice note after the example. Added a "Value" block before the example to describe the name format and link to more detailed guidance in the Ops docs. The removed info about `-k8s` suffix and organization/publisher name was added to the Ops docs by [operator#2610](https://github.com/canonical/operator/pull/2610).

- [Manage charms > Initialise a charm](https://documentation.ubuntu.com/charmcraft/latest/howto/manage-charms/#initialise-a-charm) (**[Preview doc](https://canonical-charmcraft--2748.com.readthedocs.build/2748/howto/manage-charms/#initialise-a-charm)**):
    - Removed the best practice note about naming a Git repo.
    - Added a summary of how charms and repos are typically named, with a link to more detailed guidance in the Ops docs.
    - Tidied up the subsequent info about how to use the `init` command. Mainly to clarify that we recommend specifying `--name` (and why). Also updated the example session to use terminal directives in the latest supported way.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/charmcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
