### PR TITLE
tests/spread: fix reactive spread tests on older channels

### DIFF
--- a/tests/spread/smoketests/reactive/reactivecharm/charmcraft.yaml
+++ b/tests/spread/smoketests/reactive/reactivecharm/charmcraft.yaml
@@ -13,8 +13,6 @@ parts:
     reactive-charm-build-arguments:
       - -v
       - --binary-wheels-from-source
-      - --upgrade-buildvenv-core-deps
-      - --ignore-requires-python
     build-snaps:
       - charm/CHARM_SNAP_CHANNEL
     build-packages: [python3-dev]


### PR DESCRIPTION
Removes `--upgrade-buildvenv-core-deps` and `--ignore-requires-python` from the base reactive charmcraft.yaml template, as they are not supported by charm-build in older snap channels (e.g. stable). They are still injected dynamically for 26.04 where the candidate channel of charm-tools supports them.