### PR TITLE
fix: support for Ubuntu 24.04 in supported bases

### DIFF
--- a/charmcraft/extensions/app.py
+++ b/charmcraft/extensions/app.py
@@ -97,7 +97,7 @@ class _AppBase(Extension):
     @override
     def get_supported_bases() -> list[tuple[str, str]]:
         """Return supported bases."""
-        return [("ubuntu", "22.04")]
+        return [("ubuntu", "22.04"), ("ubuntu", "24.04")]
 
     @staticmethod
     @override


### PR DESCRIPTION
Fix the support for Ubuntu 24.04 base in Flask and Django bases.

---

- [ ] I've followed the [contribution guidelines](https://github.com/canonical/charmcraft/blob/main/CONTRIBUTING.md).
- [ ] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
