### PR TITLE
chore: fix bug and release 4.3.1

### DIFF
--- a/docs/release-notes/charmcraft-4.3.rst
+++ b/docs/release-notes/charmcraft-4.3.rst
@@ -111,10 +111,15 @@ Charmcraft 4.3 includes the following new and updated documentation:
 Fixed bugs and issues
 ---------------------
 
-The following issues have been resolved in Charmcraft 4.3:
+The following issues have been resolved in Charmcraft 4.3.0:
 
 - `#2600 <https://github.com/canonical/charmcraft/issues/2600>`__
   ``charmcraft pack -p`` and ``-o`` arguments did not work correctly together
+
+The following issues have been resolved in Charmcraft 4.3.1:
+
+- The poetry plugin was installing the ``python3-poetry-plugin-export`` package
+  even when a ``poetry-deps`` part was included.
 
 
 Known issues

--- a/docs/release-notes/charmcraft-4.3.rst
+++ b/docs/release-notes/charmcraft-4.3.rst
@@ -118,7 +118,7 @@ The following issues have been resolved in Charmcraft 4.3.0:
 
 The following issues have been resolved in Charmcraft 4.3.1:
 
-- The poetry plugin was installing the ``python3-poetry-plugin-export`` package
+- The Poetry plugin was installing the ``python3-poetry-plugin-export`` package
   even when a ``poetry-deps`` part was included.
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -983,7 +983,7 @@ wheels = [
 
 [[package]]
 name = "craft-parts"
-version = "2.34.0"
+version = "2.34.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "lxml" },
@@ -996,9 +996,9 @@ dependencies = [
     { name = "tomli", marker = "python_full_version < '3.11' or (extra == 'group-10-charmcraft-dev-jammy' and extra == 'group-10-charmcraft-dev-noble') or (extra == 'group-10-charmcraft-dev-jammy' and extra == 'group-10-charmcraft-dev-plucky') or (extra == 'group-10-charmcraft-dev-jammy' and extra == 'group-10-charmcraft-dev-questing') or (extra == 'group-10-charmcraft-dev-jammy' and extra == 'group-10-charmcraft-dev-resolute') or (extra == 'group-10-charmcraft-dev-jammy' and extra == 'group-10-charmcraft-dev-stonking') or (extra == 'group-10-charmcraft-dev-noble' and extra == 'group-10-charmcraft-dev-plucky') or (extra == 'group-10-charmcraft-dev-noble' and extra == 'group-10-charmcraft-dev-questing') or (extra == 'group-10-charmcraft-dev-noble' and extra == 'group-10-charmcraft-dev-resolute') or (extra == 'group-10-charmcraft-dev-noble' and extra == 'group-10-charmcraft-dev-stonking') or (extra == 'group-10-charmcraft-dev-plucky' and extra == 'group-10-charmcraft-dev-questing') or (extra == 'group-10-charmcraft-dev-plucky' and extra == 'group-10-charmcraft-dev-resolute') or (extra == 'group-10-charmcraft-dev-plucky' and extra == 'group-10-charmcraft-dev-stonking') or (extra == 'group-10-charmcraft-dev-questing' and extra == 'group-10-charmcraft-dev-resolute') or (extra == 'group-10-charmcraft-dev-questing' and extra == 'group-10-charmcraft-dev-stonking') or (extra == 'group-10-charmcraft-dev-resolute' and extra == 'group-10-charmcraft-dev-stonking')" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e1/dc/a024e00afcaac70a1741a342e4de7a9c715b230875779058b84c2f088099/craft_parts-2.34.0.tar.gz", hash = "sha256:644c1733d29fbabff0dbb088a18b877652b4099de07a9f90563ed1fb6e620ce7", size = 1013434, upload-time = "2026-06-11T12:04:01.725Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a0/be/c6ad74c8f947da14490a65e52e516776b9ba104e29754a5f92961c1c74a8/craft_parts-2.34.1.tar.gz", hash = "sha256:24addd15e9301fad982c980643b1570c11c6d341ff0aafacb1aac607db6707cc", size = 1018369, upload-time = "2026-07-09T15:54:12.695Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/29/a9/f344547c792d9f8dd93e130ba5be5c5dd7d120f8196393c51fd023f1861a/craft_parts-2.34.0-py3-none-any.whl", hash = "sha256:bfba031d8974c1b43c1266c1eb00f29f9eaef524ea59c95df9a7729b48eb18d1", size = 555932, upload-time = "2026-06-11T12:03:59.481Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/aa/1368d843bd8b5d3da4ed4f5c2dfb7a9384159c1601f648de773f7ccfe676/craft_parts-2.34.1-py3-none-any.whl", hash = "sha256:72633268c953994b5a81fb757b01c28272897198a821cbbdab4ef001546c64cf", size = 560744, upload-time = "2026-07-09T15:54:10.526Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The bug was in craft-parts so I've updated the patch release in uv.lock.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/charmcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
- [x] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [x] I've updated the relevant release notes.
