### PR TITLE
ci: always discard spread workers in snap-store-tests

### DIFF
--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -136,3 +136,11 @@ jobs:
           CHARM_DEFAULT_NAME: gh-ci-charmcraft-charm
         run: |
           spread google:ubuntu-22.04-64:tests/spread/store/
+
+      - name: Discard spread workers
+        if: always()
+        run: |
+          shopt -s nullglob
+          for r in .spread-reuse.*.yaml; do
+            spread -discard -reuse-pid="$(echo "$r" | grep -o -E '[0-9]+')"
+          done


### PR DESCRIPTION
This PR adds the 'Discard spread workers' cleanup step to the 'snap-store-tests' job in the 'spread.yaml' workflow.

Without this step, if the job is cancelled or crashes, the remote Google Cloud VM instances allocated by 'spread' are not discarded, causing them to leak and run until the halt timeout (2h). Adding this step mirrors the cleanup behavior in the other jobs of the workflow.