### PR TITLE
ci: configure Renovate to ignore docs updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,3 +1,4 @@
 {
   extends: ["github>canonical/starflow:renovate.json5"],
+  ignorePaths: ["docs/**"],
 }


### PR DESCRIPTION
Configure Renovate with ignorePaths for docs/** so docs-only dependency update PRs are not created.