### PR TITLE
docs: use microk8s 1.34-strict instead of 1.31-strict

### DIFF
--- a/docs/reuse/tutorial/setup_edge.rst
+++ b/docs/reuse/tutorial/setup_edge.rst
@@ -54,7 +54,7 @@ Initialize LXD:
     lxd init --auto
 
 MicroK8s is required to deploy the |12FactorApp| application on Kubernetes.
-Let's install MicroK8s using the ``1.34-strict/stable`` track, add the current
+Let's install MicroK8s using the ``1.34-strict/stable`` channel, add the current
 user to the group, and activate the changes:
 
 .. code-block:: text
@@ -86,7 +86,7 @@ If successful, the terminal will output ``microk8s is running``
 along with a list of enabled and disabled add-ons.
 
 Juju is required to deploy the |12FactorApp| application.
-We'll install Juju using the ``3.6/stable`` track. Since the snap is
+We'll install Juju using the ``3.6/stable`` channel. Since the snap is
 sandboxed, we'll also manually create a directory to contain
 its files. Once Juju is ready, we initialize it by bootstrapping a
 development controller:

--- a/docs/reuse/tutorial/setup_edge.rst
+++ b/docs/reuse/tutorial/setup_edge.rst
@@ -54,12 +54,12 @@ Initialize LXD:
     lxd init --auto
 
 MicroK8s is required to deploy the |12FactorApp| application on Kubernetes.
-Let's install MicroK8s using the ``1.31-strict/stable`` track, add the current
+Let's install MicroK8s using the ``1.34-strict/stable`` track, add the current
 user to the group, and activate the changes:
 
 .. code-block:: text
 
-    sudo snap install microk8s --channel 1.31-strict/stable
+    sudo snap install microk8s --channel 1.34-strict/stable
     sudo adduser $USER snap_microk8s
     newgrp snap_microk8s
 

--- a/docs/reuse/tutorial/setup_stable.rst
+++ b/docs/reuse/tutorial/setup_stable.rst
@@ -49,7 +49,7 @@ Initialize LXD:
     lxd init --auto
 
 MicroK8s is required to deploy the |12FactorApp| application on Kubernetes.
-Let's install MicroK8s using the ``1.34-strict/stable`` track, add the current
+Let's install MicroK8s using the ``1.34-strict/stable`` channel, add the current
 user to the group, and activate the changes:
 
 .. code-block:: text
@@ -82,7 +82,7 @@ If successful, the terminal will output ``microk8s is running``
 along with a list of enabled and disabled add-ons.
 
 Juju is required to deploy the |12FactorApp| application.
-We'll install Juju using the ``3.6/stable`` track. Since the snap is
+We'll install Juju using the ``3.6/stable`` channel. Since the snap is
 sandboxed, we'll also manually create a directory to contain
 its files. Once Juju is ready, we initialize it by bootstrapping a
 development controller:

--- a/docs/reuse/tutorial/setup_stable.rst
+++ b/docs/reuse/tutorial/setup_stable.rst
@@ -49,12 +49,12 @@ Initialize LXD:
     lxd init --auto
 
 MicroK8s is required to deploy the |12FactorApp| application on Kubernetes.
-Let's install MicroK8s using the ``1.31-strict/stable`` track, add the current
+Let's install MicroK8s using the ``1.34-strict/stable`` track, add the current
 user to the group, and activate the changes:
 
 .. code-block:: text
 
-    sudo snap install microk8s --channel 1.31-strict/stable
+    sudo snap install microk8s --channel 1.34-strict/stable
     sudo adduser $USER snap_microk8s
     newgrp snap_microk8s
 


### PR DESCRIPTION
Use microk8s 1.34-strict/stable instead 1.31-strict/stable.

Microk8s 1.31 is EOL, and it does not work correctly in Ubuntu 26.04.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/charmcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
