### PR TITLE
docs: fix versioning logic

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,8 +35,7 @@ if os.environ.get("READTHEDOCS_VERSION_TYPE", "external") == "external":  # PR o
     major, minor, *_ = charmcraft.__version__.split(".")
     release = f"{major}.{minor}"
 else:  # Branch build
-    rtd_version = os.environ.get("READTHEDOCS_VERSION", "latest")
-    release = "dev" if rtd_version == "latest" else rtd_version
+    release = os.environ.get("READTHEDOCS_VERSION", "latest")
 
 # Copyright string; shown at the bottom of the page
 copyright = "2023-%s, %s" % (datetime.date.today().year, author)


### PR DESCRIPTION
Fix the version name for branch-based docs builds.

---

- [X] I've followed the [contribution guidelines](https://github.com/canonical/charmcraft/blob/main/CONTRIBUTING.md).
- [X] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
