### PR TITLE
docs: fix typo in plugin migration guide

### DIFF
--- a/docs/howto/migrate-plugins/charm-to-uv.rst
+++ b/docs/howto/migrate-plugins/charm-to-uv.rst
@@ -168,7 +168,7 @@ that uses the :ref:`craft_parts_dump_plugin`:
 
 .. code-block:: yaml
     :caption: charmcraft.yaml
-    :emphasize-lines: 9-13
+    :emphasize-lines: 9-14
 
     parts:
       my-charm:


### PR DESCRIPTION
Describe your changes.

---

- [ ] I've followed the [contribution guidelines](https://github.com/canonical/charmcraft/blob/main/CONTRIBUTING.md).
- [ ] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
