### PR TITLE
Fix spread different-dir artifact output handling

### DIFF
--- a/charmcraft/application/commands/lifecycle.py
+++ b/charmcraft/application/commands/lifecycle.py
@@ -163,6 +163,10 @@ class PackCommand(lifecycle.PackCommand):
         step_name: str | None = None,
         **kwargs: Any,
     ) -> None:
+        current_dir = pathlib.Path.cwd()
+        project_dir = (parsed_args.project_dir or current_dir).resolve()
+        output_dir = (parsed_args.output or current_dir).resolve()
+
         project = cast(models.CharmcraftProject, self._services.get("project").get())
         if project.charm_libs:
             self._update_charm_libs()
@@ -180,21 +184,28 @@ class PackCommand(lifecycle.PackCommand):
         # Move artifacts in the outer instance.
         if not is_managed_mode():
             state_service = self._services.get("state")
+            artifacts: dict[str, pathlib.Path] | None
             try:
                 artifacts = cast(dict[str, pathlib.Path], state_service.get("artifact"))
             except KeyError:
                 craft_cli.emit.debug(
                     "Could not find artifacts in the state service. Not moving."
                 )
-            else:
-                project_dir = parsed_args.project_dir or pathlib.Path.cwd()
-                output_dir = parsed_args.output or pathlib.Path.cwd()
+                artifacts = None
 
+            if artifacts is not None:
                 for artifact in artifacts.values():
                     old_path = project_dir / artifact
                     new_path = output_dir / artifact
                     if old_path != new_path:
                         new_path.parent.mkdir(parents=True, exist_ok=True)
                         old_path.rename(new_path)
+
+            if output_dir != project_dir:
+                for charm_path in project_dir.glob("*.charm"):
+                    new_path = output_dir / charm_path.name
+                    if charm_path != new_path:
+                        new_path.parent.mkdir(parents=True, exist_ok=True)
+                        charm_path.rename(new_path)
 
         return result

--- a/tests/unit/commands/test_lifecycle.py
+++ b/tests/unit/commands/test_lifecycle.py
@@ -318,3 +318,113 @@ class TestPackMoveArtifacts:
 
         # Artifact should still be in project_dir (no move since dirs are the same)
         assert (project_dir / artifact_name).read_text() == "charm content"
+
+    def test_move_artifacts_uses_original_cwd_with_relative_project_dir(
+        self,
+        fake_project_dir: pathlib.Path,
+        pack: lifecycle.PackCommand,
+        service_factory: services.ServiceFactory,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Artifacts move correctly when the project dir is passed relative to cwd."""
+        project_dir = fake_project_dir
+        monkeypatch.chdir(project_dir.parent)
+        output_dir = project_dir.parent
+
+        artifact_name = "my-charm_ubuntu-22.04-amd64.charm"
+        (project_dir / artifact_name).write_text("charm content")
+
+        state_service = service_factory.get("state")
+        state_service.set("artifact", "test-platform", value=artifact_name)
+
+        parsed_args = argparse.Namespace(
+            output=None,
+            project_dir=pathlib.Path("project"),
+            destructive_mode=True,
+            shell=False,
+            shell_after=False,
+            debug=False,
+            platform=None,
+            build_for=None,
+        )
+        project = cast("CharmcraftProject", service_factory.get("project").get())
+        project.charm_libs = []
+
+        def _mock_super_run(*_args, **_kwargs):
+            monkeypatch.chdir(project_dir)
+
+        with (
+            mock.patch(
+                "charmcraft.application.commands.lifecycle.is_managed_mode",
+                return_value=False,
+            ),
+            mock.patch.object(
+                lifecycle.PackCommand.__mro__[1],  # craft-application PackCommand
+                "_run",
+                side_effect=_mock_super_run,
+            ),
+        ):
+            pack._run(parsed_args)
+
+        assert (output_dir / artifact_name).read_text() == "charm content"
+        assert not (project_dir / artifact_name).exists()
+
+    def test_move_artifacts_falls_back_to_project_dir_files(
+        self,
+        fake_project_dir: pathlib.Path,
+        pack: lifecycle.PackCommand,
+        service_factory: services.ServiceFactory,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Artifacts still move when the artifact state is unavailable."""
+        project_dir = fake_project_dir
+        monkeypatch.chdir(project_dir.parent)
+        output_dir = project_dir.parent
+
+        artifact_name = "my-charm_ubuntu-22.04-amd64.charm"
+        (project_dir / artifact_name).write_text("charm content")
+
+        state_service = service_factory.get("state")
+        original_get = state_service.get
+
+        def _get(key, *args, **kwargs):
+            if key == "artifact":
+                raise KeyError(key)
+            return original_get(key, *args, **kwargs)
+
+        parsed_args = argparse.Namespace(
+            output=None,
+            project_dir=pathlib.Path("project"),
+            destructive_mode=True,
+            shell=False,
+            shell_after=False,
+            debug=False,
+            platform=None,
+            build_for=None,
+        )
+        project = cast("CharmcraftProject", service_factory.get("project").get())
+        project.charm_libs = []
+
+        def _mock_super_run(*_args, **_kwargs):
+            monkeypatch.chdir(project_dir)
+
+        with (
+            mock.patch(
+                "charmcraft.application.commands.lifecycle.is_managed_mode",
+                return_value=False,
+            ),
+            mock.patch.object(
+                state_service,
+                "get",
+                side_effect=_get,
+            ),
+            mock.patch.object(
+                lifecycle.PackCommand.__mro__[1],  # craft-application PackCommand
+                "_run",
+                side_effect=_mock_super_run,
+            ),
+        ):
+            pack._run(parsed_args)
+
+        assert (output_dir / artifact_name).read_text() == "charm content"
+        assert not (project_dir / artifact_name).exists()


### PR DESCRIPTION
## Summary
- resolve --project-dir and output directories before running pack so relocation uses stable absolute paths
- keep state-based artifact relocation and add a fallback that moves remaining .charm files from project dir to output dir
- add unit regressions for relative project-dir and missing artifact-state fallback

## Validation
- uv run pytest tests/unit/commands/test_lifecycle.py -k move_artifacts
- spread -v multipass:ubuntu-22.04-64:tests/spread/smoketests/different-dir via spread-plus
