### PR TITLE
docs: encourage use of dependency groups in uv migration guide

### DIFF
--- a/docs/howto/migrate-plugins/charm-to-uv.rst
+++ b/docs/howto/migrate-plugins/charm-to-uv.rst
@@ -38,27 +38,48 @@ List the charm's dependencies
 -----------------------------
 
 If the project directory doesn't already contain a :ref:`pyproject-toml-file`, create
-one. Next, list the charm's dependencies in the file's ``dependencies`` key.
+one. Next, list the charm's dependencies in a
+`dependency group <dependency groups_>`_ called ``main``.
 
 .. code-block:: toml
     :caption: pyproject.toml
-    :emphasize-lines: 6-9
 
-    [project]
-    name = "my-charm"
-    version = "0.0.1"
-    requires-python = ">=3.10"
-
-    # Dependencies of the charm code.
-    dependencies = [
+    [dependency-groups]
+    main = [
         "ops>=3,<4",
     ]
+
+    [tool.uv]
+    default-groups = ["main"]
+
+    [tool.uv.dependency-groups]
+    main = {requires-python = ">=3.10"}
 
 You can also add dependencies to your project's ``pyproject.toml`` file by running:
 
 .. code-block:: bash
 
-    uv add <dependency>
+    uv add --group main <dependency>
+
+.. warning::
+    Dependencies can also be placed in the ``dependencies`` key,
+    but the presence of the ``[project]`` table without a ``[build-system]``
+    is non-standard and will confuse workflow tools other than uv.
+    Use at your own risk.
+
+    .. code-block:: toml
+        :caption: pyproject.toml
+        :emphasize-lines: 6-9
+
+        [project]
+        name = "my-charm"
+        version = "0.0.1"
+        requires-python = ">=3.10"
+
+        # Dependencies of the charm code.
+        dependencies = [
+            "ops>=3,<4",
+        ]
 
 List charm library dependencies
 -------------------------------
@@ -78,27 +99,16 @@ running the following command at the root of the charm project:
 
     find lib -name "*.py" -exec awk '/PYDEPS = \[/,/\]/' {} +
 
-Next, in ``pyproject.toml``, list them in the ``dependencies`` key.
-
-.. code-block:: toml
-    :caption: pyproject.toml
-    :emphasize-lines: 4-6
-
-    # Dependencies of the charm code and PYDEPS from libraries.
-    dependencies = [
-        "ops>=3,<4",
-        "cosl",
-        "pydantic",
-        "cryptography",
-    ]
-
-Alternatively, you could list the library dependencies in a
+Next, in ``pyproject.toml``, list them in a
 `dependency group <dependency groups_>`_ called ``charmlibs-pydeps``.
 
 .. code-block:: toml
     :caption: pyproject.toml
 
     [dependency-groups]
+    main = [
+        "ops>=3,<4",
+    ]
     # PYDEPS from libraries that the charm uses.
     charmlibs-pydeps = [
         "cosl",
@@ -137,7 +147,7 @@ Add dependency groups
 ---------------------
 
 If the charm has dependency groups that should be included when creating the virtual
-environment, such as one for charm libraries, the
+environment, the
 :ref:`uv plugin's <craft_parts_uv_plugin>` ``uv-groups`` key can be set to include them:
 
 .. code-block:: yaml
@@ -151,10 +161,8 @@ environment, such as one for charm libraries, the
         build-snaps:
           - astral-uv
         uv-groups:
+          - main
           - charmlibs-pydeps
-
-Likewise, optional dependencies under the ``pyproject.toml`` key
-``project.optional-dependencies`` can be added with the ``uv-extras`` key.
 
 .. _howto-migrate-to-uv-include-extra-files:
 


### PR DESCRIPTION
Charms are generally not meant to be [packaged](https://discourse.ubuntu.com/t/how-does-python-packaging-really-work/84670?u=astrojuanlu). As in: uploaded to PyPI or served for other Python projects to depend on.

uv chose to use PEP 518 `[project]` table even for source trees that don't intend to be packaged. However, [the uv team admits](https://github.com/astral-sh/uv/issues/8311#issuecomment-2420772882) that this is non-standard according to [PEP 517](https://peps.python.org/pep-0517/#:~:text=If%20the%20pyproject.toml%20file%20is%20absent%2C%20or%20the%20build%2Dbackend%20key%20is%20missing%2C%20the%20source%20tree%20is%20not%20using%20this%20specification):

> If [...] the `build-backend` key is missing [from `pyproject.toml`], the source tree is not using this specification, and tools should revert to the legacy behaviour of running `setup.py` (either directly, or by implicitly invoking the `setuptools.build_meta:__legacy__` backend).

We were bitten by this in the Charmed MySQL team: we initially moved the dependencies to the `[project.dependencies]` key https://github.com/canonical/mysql-k8s-operator/pull/680, but because the team was still using Poetry back then, the tool would try to package the charm, which led to the creation of setuptools `*.egg-info` folders and other minor annoyances.

This proposes a change in the uv migration guide so that only standards-compliant `pyproject.toml` files are declared. This requires using dependency groups for all dependencies and using some uv-specific tools for declaring the minimum Python version. The upside is that users don't need to specify dummy project names and versions.

Open for discussion.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/charmcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
