### PR TITLE
feat(profiles): use Ubuntu image for kubernetes integration tests

### DIFF
--- a/charmcraft/templates/init-kubernetes/charmcraft.yaml.j2
+++ b/charmcraft/templates/init-kubernetes/charmcraft.yaml.j2
@@ -68,4 +68,4 @@ resources:
     # used by the 'canonical/charming-actions' GitHub action for automated releases.
     # The test_deploy function in tests/integration/test_charm.py reads upstream-source
     # to determine which OCI image to use when running the charm's integration tests.
-    upstream-source: docker.io/library/ubuntu:24.04  # Change this to your OCI image.
+    upstream-source: docker.io/library/ubuntu:26.04  # Change this to your OCI image.

--- a/charmcraft/templates/init-kubernetes/charmcraft.yaml.j2
+++ b/charmcraft/templates/init-kubernetes/charmcraft.yaml.j2
@@ -64,8 +64,8 @@ resources:
     type: oci-image
     description: OCI image for the 'some-container' container
     # The upstream-source field is ignored by Charmcraft and Juju, but it can be
-    # useful to developers in identifying the source of the OCI image.  It is also
+    # useful to developers in identifying the source of the OCI image. It is also
     # used by the 'canonical/charming-actions' GitHub action for automated releases.
     # The test_deploy function in tests/integration/test_charm.py reads upstream-source
     # to determine which OCI image to use when running the charm's integration tests.
-    upstream-source: some-repo/some-image:some-tag
+    upstream-source: docker.io/library/ubuntu:24.04  # Change this to your OCI image.

--- a/charmcraft/templates/init-kubernetes/charmcraft.yaml.j2
+++ b/charmcraft/templates/init-kubernetes/charmcraft.yaml.j2
@@ -43,7 +43,7 @@ config:
     # An example config option to customise the log level of the workload
     log-level:
       description: |
-        Configures the log level of gunicorn.
+        Configures the log level of the workload.
 
         Acceptable values are: "info", "debug", "warning", "error" and "critical"
       default: "info"

--- a/charmcraft/templates/init-kubernetes/src/charm.py.j2
+++ b/charmcraft/templates/init-kubernetes/src/charm.py.j2
@@ -30,6 +30,8 @@ class {{ class_name }}(ops.CharmBase):
         self.unit.status = ops.MaintenanceStatus("starting workload")
         # To start the workload, we'll add a Pebble layer to the workload container.
         # The layer specifies which service to run.
+        # The charm expects the service to have a long-running command. Don't use a command that
+        # starts the workload as a daemon then exits, otherwise self.wait_for_ready() will fail.
         layer: ops.pebble.LayerDict = {
             "services": {
                 SERVICE_NAME: {

--- a/charmcraft/templates/init-kubernetes/src/charm.py.j2
+++ b/charmcraft/templates/init-kubernetes/src/charm.py.j2
@@ -31,7 +31,8 @@ class {{ class_name }}(ops.CharmBase):
         # To start the workload, we'll add a Pebble layer to the workload container.
         # The layer specifies which service to run.
         # The charm expects the service to have a long-running command. Don't use a command that
-        # starts the workload as a daemon then exits, otherwise self.wait_for_ready() will fail.
+        # starts the workload as a daemon then exits, otherwise Pebble either reports the service
+        # as stopped (if the command exits quickly) or keeps restarting the service.
         layer: ops.pebble.LayerDict = {
             "services": {
                 SERVICE_NAME: {

--- a/charmcraft/templates/init-kubernetes/src/charm.py.j2
+++ b/charmcraft/templates/init-kubernetes/src/charm.py.j2
@@ -35,7 +35,7 @@ class {{ class_name }}(ops.CharmBase):
                 SERVICE_NAME: {
                     "override": "replace",
                     "summary": "A service that runs in the workload container",
-                    "command": "/bin/foo",  # Change this!
+                    "command": "sleep infinity",  # Change this!
                     "startup": "enabled",
                 }
             }

--- a/charmcraft/templates/init-machine/charmcraft.yaml.j2
+++ b/charmcraft/templates/init-machine/charmcraft.yaml.j2
@@ -42,7 +42,7 @@ config:
     # An example config option to customise the log level of the workload
     log-level:
       description: |
-        Configures the log level of gunicorn.
+        Configures the log level of the workload.
 
         Acceptable values are: "info", "debug", "warning", "error" and "critical"
       default: "info"


### PR DESCRIPTION
Currently, integration tests fail for a charm generated from the `kubernetes` profile, because `charmcraft.yaml` specifies a dummy OCI image.

This PR switches to the base [Ubuntu image](https://hub.docker.com/_/ubuntu), as a placeholder for the charmer's real image. The charm code needed to be adjusted too, so that the Pebble layer uses a placeholder command that really exists in the container.

I've verified that integration tests now pass.

---

This PR includes one small drive-by: In `charmcraft.yaml` for the `kubernetes` and `machine` profiles, we have a sample config option. The description mentions gunicorn, but nothing else in the charms is related to gunicorn. I'm making the description more generic.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/charmcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [ ] ~I've added or updated any relevant documentation.~
- [ ] ~In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.~
- [ ] I've updated the relevant release notes.
