### PR TITLE
docs: Update documentation to add link to HTTP proxy configurator tutorial

### DIFF
--- a/docs/howto/manage-web-app-charms/integrate-web-app-charm.rst
+++ b/docs/howto/manage-web-app-charms/integrate-web-app-charm.rst
@@ -178,7 +178,7 @@ configure your 12-factor app.
 - ``HTTP_PROXY``
 - ``HTTPS_PROXY``
 
-For more information on how to deploy Squid forward proxy and integrate with HTTP proxy configurator, refer to the [official HTTP proxy configurator documentation](https://github.com/canonical/http-proxy-operators/files/http-proxy-configurator-operator/docs/tutorial/getting-started.md)
+For more information on how to deploy Squid forward proxy and integrate with HTTP proxy configurator, refer to the `official HTTP proxy configurator documentation <https://github.com/canonical/http-proxy-operators/files/http-proxy-configurator-operator/docs/tutorial/getting-started.md>`_
 
 .. _integrate-web-app-charm-integrate-s3:
 

--- a/docs/howto/manage-web-app-charms/integrate-web-app-charm.rst
+++ b/docs/howto/manage-web-app-charms/integrate-web-app-charm.rst
@@ -157,7 +157,10 @@ To supply them, your app should integrate with the `HTTP proxy configurator
 <https://github.com/canonical/http-proxy-operators/tree
 /main/http-proxy-configurator-operator>`_
 charm which relays this information to the Squid Forward Proxy charm.
-Add the following endpoint definition to your project file:
+To supply the domains and authentication modes to the Squid Forward Proxy charm, `deploy
+the HTTP proxy configurator charm
+<https://github.com/canonical/http-proxy-operators/blob/main/http-proxy-configurator-operator/docs/tutorial/getting-started.md>`__.
+Then, add the following endpoint definition to your project file:
 
 .. code-block:: yaml
 

--- a/docs/howto/manage-web-app-charms/integrate-web-app-charm.rst
+++ b/docs/howto/manage-web-app-charms/integrate-web-app-charm.rst
@@ -178,6 +178,8 @@ configure your 12-factor app.
 - ``HTTP_PROXY``
 - ``HTTPS_PROXY``
 
+For more information on how to deploy Squid forward proxy and integrate with HTTP proxy configurator, refer to the [official HTTP proxy configurator documentation](https://github.com/canonical/http-proxy-operators/files/http-proxy-configurator-operator/docs/tutorial/getting-started.md)
+
 .. _integrate-web-app-charm-integrate-s3:
 
 Integrate with S3

--- a/docs/howto/manage-web-app-charms/integrate-web-app-charm.rst
+++ b/docs/howto/manage-web-app-charms/integrate-web-app-charm.rst
@@ -181,8 +181,6 @@ configure your 12-factor app.
 - ``HTTP_PROXY``
 - ``HTTPS_PROXY``
 
-For more information on how to deploy Squid forward proxy and integrate with HTTP proxy configurator, refer to the `official HTTP proxy configurator documentation <https://github.com/canonical/http-proxy-operators/files/http-proxy-configurator-operator/docs/tutorial/getting-started.md>`_
-
 .. _integrate-web-app-charm-integrate-s3:
 
 Integrate with S3

--- a/docs/howto/manage-web-app-charms/integrate-web-app-charm.rst
+++ b/docs/howto/manage-web-app-charms/integrate-web-app-charm.rst
@@ -153,10 +153,6 @@ the proxy URI (i.e., it must support the format
 and authentication modes supported by your web app. However, the 12 factor
 framework currently does not provide a native way to set these values directly.
 
-To supply them, your app should integrate with the `HTTP proxy configurator
-<https://github.com/canonical/http-proxy-operators/tree
-/main/http-proxy-configurator-operator>`_
-charm which relays this information to the Squid Forward Proxy charm.
 To supply the domains and authentication modes to the Squid Forward Proxy charm, `deploy
 the HTTP proxy configurator charm
 <https://github.com/canonical/http-proxy-operators/blob/main/http-proxy-configurator-operator/docs/tutorial/getting-started.md>`__.


### PR DESCRIPTION
Describe your changes.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/charmcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
- [x] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
