### PR TITLE
docs: fix version string for 3.x

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,13 +32,8 @@ project = "Charmcraft"
 author = "Canonical"
 
 # Version string in sidebar
-if os.environ.get("READTHEDOCS_VERSION_TYPE", "external") == "external":  # PR or local build
-    # Because of Autotools, we can safely assume the version starts with `n.n`
-    major, minor, *_ = charmcraft.__version__.split(".")
-    release = f"{major}.{minor}"
-else:  # Branch build
-    rtd_version = os.environ.get("READTHEDOCS_VERSION", "latest")
-    release = "dev" if rtd_version == "latest" else rtd_version
+major, minor, *_ = charmcraft.__version__.split(".")
+release = "dev" if os.environ.get("READTHEDOCS_VERSION") == "latest" else f"{major}.{minor}"
 
 copyright = "2023-%s, %s" % (datetime.date.today().year, author)
 


### PR DESCRIPTION
With this change, all local, PR, and branch builds will show the major and minor version in the docs title. The only exception is the 'latest' branch build, which will show 'dev' as the version.

This was brought about by the simplification of our RTD version slugs.

---

- [X] I've followed the [contribution guidelines](https://github.com/canonical/charmcraft/blob/main/CONTRIBUTING.md).
- [X] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
