### PR TITLE
fix(plugins): use part_build_subdir for charm source copy

### DIFF
--- a/charmcraft/parts/plugins/_poetry.py
+++ b/charmcraft/parts/plugins/_poetry.py
@@ -76,7 +76,7 @@ class PoetryPlugin(poetry_plugin.PoetryPlugin):
         return [
             *super()._get_package_install_commands(),
             *utils.get_charm_copy_commands(
-                self._part_info.part_build_dir, self._part_info.part_install_dir
+                self._part_info.part_build_subdir, self._part_info.part_install_dir
             ),
         ]
 

--- a/charmcraft/parts/plugins/_python.py
+++ b/charmcraft/parts/plugins/_python.py
@@ -79,7 +79,7 @@ class PythonPlugin(python_plugin.PythonPlugin):
             f"{pip} install --no-deps {install_params}",
             f"{pip} check",
             *utils.get_charm_copy_commands(
-                self._part_info.part_build_dir, self._part_info.part_install_dir
+                self._part_info.part_build_subdir, self._part_info.part_install_dir
             ),
         ]
 

--- a/charmcraft/parts/plugins/_uv.py
+++ b/charmcraft/parts/plugins/_uv.py
@@ -48,7 +48,7 @@ class UvPlugin(uv_plugin.UvPlugin):
         return [
             *orig_cmds,
             *utils.get_charm_copy_commands(
-                self._part_info.part_build_dir, self._part_info.part_install_dir
+                self._part_info.part_build_subdir, self._part_info.part_install_dir
             ),
         ]
 

--- a/docs/release-notes/charmcraft-4.5.rst
+++ b/docs/release-notes/charmcraft-4.5.rst
@@ -102,8 +102,7 @@ Fixed bugs and issues
 The following issues have been resolved in Charmcraft 4.5.
 
 - `#2839 <https://github.com/canonical/charmcraft/issues/2839>`__
-  Fixed an issue where the ``poetry``, ``python``, and ``uv`` charm plugins failed
-  to find and copy ``src/`` and ``lib/`` directories when ``source-subdir`` was used.
+  Charm plugins fail to copy source and lib when source-subdir is used
 
 
 Known issues

--- a/docs/release-notes/charmcraft-4.5.rst
+++ b/docs/release-notes/charmcraft-4.5.rst
@@ -101,7 +101,10 @@ Fixed bugs and issues
 
 The following issues have been resolved in Charmcraft 4.5.
 
-- No entries yet.
+- The ``poetry``, ``python``, and ``uv`` charm plugins now copy charm source and
+  library files from ``part_build_subdir`` rather than ``part_build_dir``,
+  resolving an issue where charms using ``source-subdir`` (such as in monorepo
+  structures) failed to find and copy their ``src/`` and ``lib/`` directories.
 
 
 Known issues

--- a/docs/release-notes/charmcraft-4.5.rst
+++ b/docs/release-notes/charmcraft-4.5.rst
@@ -101,10 +101,9 @@ Fixed bugs and issues
 
 The following issues have been resolved in Charmcraft 4.5.
 
-- The ``poetry``, ``python``, and ``uv`` charm plugins now copy charm source and
-  library files from ``part_build_subdir`` rather than ``part_build_dir``,
-  resolving an issue where charms using ``source-subdir`` (such as in monorepo
-  structures) failed to find and copy their ``src/`` and ``lib/`` directories.
+- `#2839 <https://github.com/canonical/charmcraft/issues/2839>`__
+  Fixed an issue where the ``poetry``, ``python``, and ``uv`` charm plugins failed
+  to find and copy ``src/`` and ``lib/`` directories when ``source-subdir`` was used.
 
 
 Known issues

--- a/tests/integration/parts/plugins/test_poetry.py
+++ b/tests/integration/parts/plugins/test_poetry.py
@@ -80,3 +80,52 @@ def test_poetry_plugin(
     assert (stage_path / "src" / "charm.py").read_text() == "# Charm file"
     assert (stage_path / "venv" / "lib").is_dir()
     assert not (stage_path / "venv" / "lib64").is_symlink()
+
+
+@pytest.mark.slow
+def test_poetry_plugin_source_subdir(
+    service_factory: craft_application.ServiceFactory,
+    project_path: pathlib.Path,
+    tmp_path: pathlib.Path,
+):
+    subdir = project_path / "charm_dir"
+    subdir.mkdir(parents=True)
+    subprocess.run(
+        [
+            "poetry",
+            "init",
+            "--name=test-charm",
+            f"--python={platform.python_version()}",
+            f"--directory={subdir}",
+            "--no-interaction",
+        ],
+        cwd=subdir,
+        capture_output=True,
+        check=True,
+    )
+    source_dir = subdir / "src"
+    source_dir.mkdir()
+    (source_dir / "charm.py").write_text("# Charm file in subdir")
+
+    service_factory.get("project").get().parts = {
+        "my-charm": {
+            "plugin": "poetry",
+            "source": str(project_path),
+            "source-subdir": "charm_dir",
+            "source-type": "local",
+        }
+    }
+
+    install_path = tmp_path / "parts" / "my-charm" / "install"
+    stage_path = tmp_path / "stage"
+
+    service_factory.lifecycle.run("stage")
+
+    # Check that the part install directory looks correct.
+    assert (install_path / "src" / "charm.py").read_text() == "# Charm file in subdir"
+    assert (install_path / "venv" / "lib").is_dir()
+
+    # Check that the stage directory looks correct.
+    assert (stage_path / "src" / "charm.py").read_text() == "# Charm file in subdir"
+    assert (stage_path / "venv" / "lib").is_dir()
+    assert not (stage_path / "venv" / "lib64").is_symlink()

--- a/tests/integration/parts/plugins/test_poetry.py
+++ b/tests/integration/parts/plugins/test_poetry.py
@@ -19,6 +19,7 @@ import pathlib
 import platform
 import subprocess
 import sys
+import typing
 
 import craft_application
 import pytest
@@ -28,45 +29,43 @@ pytestmark = [
 ]
 
 
-@pytest.fixture(autouse=True)
-def add_part(
-    service_factory: craft_application.ServiceFactory, project_path: pathlib.Path
+@pytest.mark.slow
+@pytest.mark.parametrize("source_subdir", [None, "charm_dir"])
+def test_poetry_plugin(
+    service_factory: craft_application.ServiceFactory,
+    project_path: pathlib.Path,
+    tmp_path: pathlib.Path,
+    source_subdir: str | None,
 ):
-    service_factory.get("project").get().parts = {
-        "my-charm": {
-            "plugin": "poetry",
-            "source": str(project_path),
-            "source-type": "local",
-        }
-    }
-
-
-@pytest.fixture
-def poetry_project(project_path: pathlib.Path) -> None:
+    charm_dir = project_path / source_subdir if source_subdir else project_path
+    charm_dir.mkdir(parents=True, exist_ok=True)
     subprocess.run(
         [
             "poetry",
             "init",
             "--name=test-charm",
             f"--python={platform.python_version()}",
-            f"--directory={project_path}",
+            f"--directory={charm_dir}",
             "--no-interaction",
         ],
-        cwd=project_path,
+        cwd=charm_dir,
         capture_output=True,
         check=True,
     )
-    source_dir = project_path / "src"
-    source_dir.mkdir()
+    source_dir = charm_dir / "src"
+    source_dir.mkdir(parents=True, exist_ok=True)
     (source_dir / "charm.py").write_text("# Charm file")
 
+    part_def: dict[str, typing.Any] = {
+        "plugin": "poetry",
+        "source": str(project_path),
+        "source-type": "local",
+    }
+    if source_subdir:
+        part_def["source-subdir"] = source_subdir
 
-@pytest.mark.slow
-@pytest.mark.usefixtures("poetry_project")
-def test_poetry_plugin(
-    service_factory: craft_application.ServiceFactory,
-    tmp_path: pathlib.Path,
-):
+    service_factory.get("project").get().parts = {"my-charm": part_def}
+
     install_path = tmp_path / "parts" / "my-charm" / "install"
     stage_path = tmp_path / "stage"
 
@@ -78,54 +77,5 @@ def test_poetry_plugin(
 
     # Check that the stage directory looks correct.
     assert (stage_path / "src" / "charm.py").read_text() == "# Charm file"
-    assert (stage_path / "venv" / "lib").is_dir()
-    assert not (stage_path / "venv" / "lib64").is_symlink()
-
-
-@pytest.mark.slow
-def test_poetry_plugin_source_subdir(
-    service_factory: craft_application.ServiceFactory,
-    project_path: pathlib.Path,
-    tmp_path: pathlib.Path,
-):
-    subdir = project_path / "charm_dir"
-    subdir.mkdir(parents=True)
-    subprocess.run(
-        [
-            "poetry",
-            "init",
-            "--name=test-charm",
-            f"--python={platform.python_version()}",
-            f"--directory={subdir}",
-            "--no-interaction",
-        ],
-        cwd=subdir,
-        capture_output=True,
-        check=True,
-    )
-    source_dir = subdir / "src"
-    source_dir.mkdir()
-    (source_dir / "charm.py").write_text("# Charm file in subdir")
-
-    service_factory.get("project").get().parts = {
-        "my-charm": {
-            "plugin": "poetry",
-            "source": str(project_path),
-            "source-subdir": "charm_dir",
-            "source-type": "local",
-        }
-    }
-
-    install_path = tmp_path / "parts" / "my-charm" / "install"
-    stage_path = tmp_path / "stage"
-
-    service_factory.lifecycle.run("stage")
-
-    # Check that the part install directory looks correct.
-    assert (install_path / "src" / "charm.py").read_text() == "# Charm file in subdir"
-    assert (install_path / "venv" / "lib").is_dir()
-
-    # Check that the stage directory looks correct.
-    assert (stage_path / "src" / "charm.py").read_text() == "# Charm file in subdir"
     assert (stage_path / "venv" / "lib").is_dir()
     assert not (stage_path / "venv" / "lib64").is_symlink()

--- a/tests/integration/parts/plugins/test_poetry.py
+++ b/tests/integration/parts/plugins/test_poetry.py
@@ -71,11 +71,9 @@ def test_poetry_plugin(
 
     service_factory.lifecycle.run("stage")
 
-    # Check that the part install directory looks correct.
     assert (install_path / "src" / "charm.py").read_text() == "# Charm file"
     assert (install_path / "venv" / "lib").is_dir()
 
-    # Check that the stage directory looks correct.
     assert (stage_path / "src" / "charm.py").read_text() == "# Charm file"
     assert (stage_path / "venv" / "lib").is_dir()
     assert not (stage_path / "venv" / "lib64").is_symlink()

--- a/tests/integration/parts/plugins/test_python.py
+++ b/tests/integration/parts/plugins/test_python.py
@@ -17,6 +17,7 @@
 
 import pathlib
 import sys
+import typing
 
 import craft_application
 import pytest
@@ -26,34 +27,31 @@ pytestmark = [
 ]
 
 
-@pytest.fixture(autouse=True)
-def add_part(
-    service_factory: craft_application.ServiceFactory, project_path: pathlib.Path
-):
-    service_factory.get("project").get().parts = {
-        "my-charm": {
-            "plugin": "python",
-            "python-requirements": ["requirements.txt"],
-            "source": str(project_path),
-            "source-type": "local",
-        }
-    }
-
-
-@pytest.fixture
-def python_project(project_path: pathlib.Path) -> None:
-    source_path = project_path / "src"
-    source_path.mkdir()
-    (source_path / "charm.py").write_text("# Charm file")
-    (project_path / "requirements.txt").write_text("distro==1.4.0")
-
-
 @pytest.mark.slow
-@pytest.mark.usefixtures("python_project")
+@pytest.mark.parametrize("source_subdir", [None, "charm_dir"])
 def test_python_plugin(
     service_factory: craft_application.ServiceFactory,
+    project_path: pathlib.Path,
     tmp_path: pathlib.Path,
+    source_subdir: str | None,
 ):
+    charm_dir = project_path / source_subdir if source_subdir else project_path
+    source_path = charm_dir / "src"
+    source_path.mkdir(parents=True)
+    (source_path / "charm.py").write_text("# Charm file")
+    (charm_dir / "requirements.txt").write_text("distro==1.4.0")
+
+    part_def: dict[str, typing.Any] = {
+        "plugin": "python",
+        "python-requirements": ["requirements.txt"],
+        "source": str(project_path),
+        "source-type": "local",
+    }
+    if source_subdir:
+        part_def["source-subdir"] = source_subdir
+
+    service_factory.get("project").get().parts = {"my-charm": part_def}
+
     install_path = tmp_path / "parts" / "my-charm" / "install"
     stage_path = tmp_path / "stage"
 
@@ -73,50 +71,5 @@ def test_python_plugin(
 
     # Check that the stage directory looks correct.
     assert (stage_path / "src" / "charm.py").read_text() == "# Charm file"
-    assert (stage_path / "venv" / "lib").is_dir()
-    assert not (stage_path / "venv" / "lib64").is_symlink()
-
-
-@pytest.mark.slow
-def test_python_plugin_source_subdir(
-    service_factory: craft_application.ServiceFactory,
-    project_path: pathlib.Path,
-    tmp_path: pathlib.Path,
-):
-    subdir = project_path / "charm_dir"
-    source_path = subdir / "src"
-    source_path.mkdir(parents=True)
-    (source_path / "charm.py").write_text("# Charm file in subdir")
-    (subdir / "requirements.txt").write_text("distro==1.4.0")
-
-    service_factory.get("project").get().parts = {
-        "my-charm": {
-            "plugin": "python",
-            "python-requirements": ["requirements.txt"],
-            "source": str(project_path),
-            "source-subdir": "charm_dir",
-            "source-type": "local",
-        }
-    }
-
-    install_path = tmp_path / "parts" / "my-charm" / "install"
-    stage_path = tmp_path / "stage"
-
-    service_factory.lifecycle.run("stage")
-
-    # Check that the part install directory looks correct.
-    assert (install_path / "src" / "charm.py").read_text() == "# Charm file in subdir"
-    assert (install_path / "venv" / "lib").is_dir()
-    assert (
-        len(
-            list(
-                (install_path / "venv" / "lib").glob("python*/site-packages/distro.py")
-            )
-        )
-        == 1
-    )
-
-    # Check that the stage directory looks correct.
-    assert (stage_path / "src" / "charm.py").read_text() == "# Charm file in subdir"
     assert (stage_path / "venv" / "lib").is_dir()
     assert not (stage_path / "venv" / "lib64").is_symlink()

--- a/tests/integration/parts/plugins/test_python.py
+++ b/tests/integration/parts/plugins/test_python.py
@@ -57,7 +57,6 @@ def test_python_plugin(
 
     service_factory.lifecycle.run("stage")
 
-    # Check that the part install directory looks correct.
     assert (install_path / "src" / "charm.py").read_text() == "# Charm file"
     assert (install_path / "venv" / "lib").is_dir()
     assert (
@@ -69,7 +68,6 @@ def test_python_plugin(
         == 1
     )
 
-    # Check that the stage directory looks correct.
     assert (stage_path / "src" / "charm.py").read_text() == "# Charm file"
     assert (stage_path / "venv" / "lib").is_dir()
     assert not (stage_path / "venv" / "lib64").is_symlink()

--- a/tests/integration/parts/plugins/test_python.py
+++ b/tests/integration/parts/plugins/test_python.py
@@ -75,3 +75,48 @@ def test_python_plugin(
     assert (stage_path / "src" / "charm.py").read_text() == "# Charm file"
     assert (stage_path / "venv" / "lib").is_dir()
     assert not (stage_path / "venv" / "lib64").is_symlink()
+
+
+@pytest.mark.slow
+def test_python_plugin_source_subdir(
+    service_factory: craft_application.ServiceFactory,
+    project_path: pathlib.Path,
+    tmp_path: pathlib.Path,
+):
+    subdir = project_path / "charm_dir"
+    source_path = subdir / "src"
+    source_path.mkdir(parents=True)
+    (source_path / "charm.py").write_text("# Charm file in subdir")
+    (subdir / "requirements.txt").write_text("distro==1.4.0")
+
+    service_factory.get("project").get().parts = {
+        "my-charm": {
+            "plugin": "python",
+            "python-requirements": ["requirements.txt"],
+            "source": str(project_path),
+            "source-subdir": "charm_dir",
+            "source-type": "local",
+        }
+    }
+
+    install_path = tmp_path / "parts" / "my-charm" / "install"
+    stage_path = tmp_path / "stage"
+
+    service_factory.lifecycle.run("stage")
+
+    # Check that the part install directory looks correct.
+    assert (install_path / "src" / "charm.py").read_text() == "# Charm file in subdir"
+    assert (install_path / "venv" / "lib").is_dir()
+    assert (
+        len(
+            list(
+                (install_path / "venv" / "lib").glob("python*/site-packages/distro.py")
+            )
+        )
+        == 1
+    )
+
+    # Check that the stage directory looks correct.
+    assert (stage_path / "src" / "charm.py").read_text() == "# Charm file in subdir"
+    assert (stage_path / "venv" / "lib").is_dir()
+    assert not (stage_path / "venv" / "lib64").is_symlink()

--- a/tests/integration/parts/plugins/test_uv.py
+++ b/tests/integration/parts/plugins/test_uv.py
@@ -19,6 +19,7 @@ import platform
 import shutil
 import subprocess
 import sys
+import typing
 
 import craft_application
 import pytest
@@ -28,21 +29,17 @@ pytestmark = [
 ]
 
 
-@pytest.fixture(autouse=True)
-def add_part(
-    service_factory: craft_application.ServiceFactory, project_path: pathlib.Path
+@pytest.mark.slow
+@pytest.mark.parametrize("source_subdir", [None, "charm_dir"])
+def test_uv_plugin(
+    service_factory: craft_application.ServiceFactory,
+    project_path: pathlib.Path,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+    source_subdir: str | None,
 ):
-    service_factory.get("project").get().parts = {
-        "my-charm": {
-            "plugin": "uv",
-            "source": str(project_path),
-            "source-type": "local",
-        }
-    }
-
-
-@pytest.fixture
-def uv_project(project_path: pathlib.Path, monkeypatch) -> None:
+    charm_dir = project_path / source_subdir if source_subdir else project_path
+    charm_dir.mkdir(parents=True, exist_ok=True)
     subprocess.run(
         [
             "uv",
@@ -52,35 +49,37 @@ def uv_project(project_path: pathlib.Path, monkeypatch) -> None:
             "--no-progress",
             "--no-workspace",
         ],
-        cwd=project_path,
+        cwd=charm_dir,
         check=True,
     )
-    subprocess.run(
-        ["uv", "add", "ops>=2.0.0", "pyyaml>=5"], cwd=project_path, check=True
-    )
+    subprocess.run(["uv", "add", "ops>=2.0.0", "pyyaml>=5"], cwd=charm_dir, check=True)
     monkeypatch.delenv("UV_FROZEN", raising=False)
     subprocess.run(
         [
             "uv",
             "lock",
         ],
-        cwd=project_path,
+        cwd=charm_dir,
         check=True,
     )
-    source_dir = project_path / "src"
+    source_dir = charm_dir / "src"
     # Newer versions of `uv init` already scaffold a src/<package> layout;
     # discard it so only the fixture's own charm.py ends up in the source tree.
     if source_dir.exists():
         shutil.rmtree(source_dir)
-    source_dir.mkdir()
+    source_dir.mkdir(parents=True, exist_ok=True)
     (source_dir / "charm.py").write_text("# Charm file")
 
+    part_def: dict[str, typing.Any] = {
+        "plugin": "uv",
+        "source": str(project_path),
+        "source-type": "local",
+    }
+    if source_subdir:
+        part_def["source-subdir"] = source_subdir
 
-@pytest.mark.slow
-@pytest.mark.usefixtures("uv_project")
-def test_uv_plugin(
-    service_factory: craft_application.ServiceFactory, tmp_path: pathlib.Path
-):
+    service_factory.get("project").get().parts = {"my-charm": part_def}
+
     install_path = tmp_path / "parts" / "my-charm" / "install"
     stage_path = tmp_path / "stage"
 
@@ -92,66 +91,5 @@ def test_uv_plugin(
 
     # Check that the stage directory looks correct.
     assert (stage_path / "src" / "charm.py").read_text() == "# Charm file"
-    assert (stage_path / "venv" / "lib").is_dir()
-    assert not (stage_path / "venv" / "lib64").is_symlink()
-
-
-@pytest.mark.slow
-def test_uv_plugin_source_subdir(
-    service_factory: craft_application.ServiceFactory,
-    project_path: pathlib.Path,
-    tmp_path: pathlib.Path,
-    monkeypatch: pytest.MonkeyPatch,
-):
-    subdir = project_path / "charm_dir"
-    subdir.mkdir(parents=True)
-    subprocess.run(
-        [
-            "uv",
-            "init",
-            "--name=test-charm",
-            f"--python={platform.python_version()}",
-            "--no-progress",
-            "--no-workspace",
-        ],
-        cwd=subdir,
-        check=True,
-    )
-    subprocess.run(["uv", "add", "ops>=2.0.0", "pyyaml>=5"], cwd=subdir, check=True)
-    monkeypatch.delenv("UV_FROZEN", raising=False)
-    subprocess.run(
-        [
-            "uv",
-            "lock",
-        ],
-        cwd=subdir,
-        check=True,
-    )
-    source_dir = subdir / "src"
-    if source_dir.exists():
-        shutil.rmtree(source_dir)
-    source_dir.mkdir()
-    (source_dir / "charm.py").write_text("# Charm file in subdir")
-
-    service_factory.get("project").get().parts = {
-        "my-charm": {
-            "plugin": "uv",
-            "source": str(project_path),
-            "source-subdir": "charm_dir",
-            "source-type": "local",
-        }
-    }
-
-    install_path = tmp_path / "parts" / "my-charm" / "install"
-    stage_path = tmp_path / "stage"
-
-    service_factory.lifecycle.run("stage")
-
-    # Check that the part install directory looks correct.
-    assert (install_path / "src" / "charm.py").read_text() == "# Charm file in subdir"
-    assert (install_path / "venv" / "lib").is_dir()
-
-    # Check that the stage directory looks correct.
-    assert (stage_path / "src" / "charm.py").read_text() == "# Charm file in subdir"
     assert (stage_path / "venv" / "lib").is_dir()
     assert not (stage_path / "venv" / "lib64").is_symlink()

--- a/tests/integration/parts/plugins/test_uv.py
+++ b/tests/integration/parts/plugins/test_uv.py
@@ -94,3 +94,64 @@ def test_uv_plugin(
     assert (stage_path / "src" / "charm.py").read_text() == "# Charm file"
     assert (stage_path / "venv" / "lib").is_dir()
     assert not (stage_path / "venv" / "lib64").is_symlink()
+
+
+@pytest.mark.slow
+def test_uv_plugin_source_subdir(
+    service_factory: craft_application.ServiceFactory,
+    project_path: pathlib.Path,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    subdir = project_path / "charm_dir"
+    subdir.mkdir(parents=True)
+    subprocess.run(
+        [
+            "uv",
+            "init",
+            "--name=test-charm",
+            f"--python={platform.python_version()}",
+            "--no-progress",
+            "--no-workspace",
+        ],
+        cwd=subdir,
+        check=True,
+    )
+    subprocess.run(["uv", "add", "ops>=2.0.0", "pyyaml>=5"], cwd=subdir, check=True)
+    monkeypatch.delenv("UV_FROZEN", raising=False)
+    subprocess.run(
+        [
+            "uv",
+            "lock",
+        ],
+        cwd=subdir,
+        check=True,
+    )
+    source_dir = subdir / "src"
+    if source_dir.exists():
+        shutil.rmtree(source_dir)
+    source_dir.mkdir()
+    (source_dir / "charm.py").write_text("# Charm file in subdir")
+
+    service_factory.get("project").get().parts = {
+        "my-charm": {
+            "plugin": "uv",
+            "source": str(project_path),
+            "source-subdir": "charm_dir",
+            "source-type": "local",
+        }
+    }
+
+    install_path = tmp_path / "parts" / "my-charm" / "install"
+    stage_path = tmp_path / "stage"
+
+    service_factory.lifecycle.run("stage")
+
+    # Check that the part install directory looks correct.
+    assert (install_path / "src" / "charm.py").read_text() == "# Charm file in subdir"
+    assert (install_path / "venv" / "lib").is_dir()
+
+    # Check that the stage directory looks correct.
+    assert (stage_path / "src" / "charm.py").read_text() == "# Charm file in subdir"
+    assert (stage_path / "venv" / "lib").is_dir()
+    assert not (stage_path / "venv" / "lib64").is_symlink()

--- a/tests/integration/parts/plugins/test_uv.py
+++ b/tests/integration/parts/plugins/test_uv.py
@@ -85,11 +85,9 @@ def test_uv_plugin(
 
     service_factory.lifecycle.run("stage")
 
-    # Check that the part install directory looks correct.
     assert (install_path / "src" / "charm.py").read_text() == "# Charm file"
     assert (install_path / "venv" / "lib").is_dir()
 
-    # Check that the stage directory looks correct.
     assert (stage_path / "src" / "charm.py").read_text() == "# Charm file"
     assert (stage_path / "venv" / "lib").is_dir()
     assert not (stage_path / "venv" / "lib64").is_symlink()

--- a/tests/unit/parts/plugins/test_poetry.py
+++ b/tests/unit/parts/plugins/test_poetry.py
@@ -17,6 +17,7 @@
 
 import pathlib
 
+import craft_parts
 import pytest_check
 
 from charmcraft.parts import plugins
@@ -109,4 +110,80 @@ def test_no_get_rm_command(
     assert (
         f"rm -rf {install_path / 'venv/bin'}/!(activate)"
         not in poetry_plugin.get_build_commands()
+    )
+
+
+def test_get_package_install_commands_source_subdir(
+    tmp_path: pathlib.Path,
+    install_path: pathlib.Path,
+):
+    project_dirs = craft_parts.ProjectDirs(work_dir=tmp_path)
+    spec = {
+        "plugin": "poetry",
+        "source": str(tmp_path),
+        "source-subdir": "subdir",
+    }
+    plugin_properties = plugins.PoetryPluginProperties.unmarshal(spec)
+    part_spec = craft_parts.plugins.extract_part_properties(spec, plugin_name="poetry")
+    part = craft_parts.Part(
+        "foo", part_spec, project_dirs=project_dirs, plugin_properties=plugin_properties
+    )
+    project_info = craft_parts.ProjectInfo(
+        application_name="test",
+        project_dirs=project_dirs,
+        cache_dir=tmp_path,
+    )
+    part_info = craft_parts.PartInfo(project_info=project_info, part=part)
+    plugin = craft_parts.plugins.get_plugin(
+        part=part, part_info=part_info, properties=plugin_properties
+    )
+
+    build_path = part_info.part_build_dir
+    build_subdir = part_info.part_build_subdir
+    assert build_subdir != build_path
+
+    copy_src_cmd = (
+        f"cp --archive --recursive --reflink=auto {build_subdir}/src {install_path}"
+    )
+    copy_lib_cmd = (
+        f"cp --archive --recursive --reflink=auto {build_subdir}/lib {install_path}"
+    )
+    wrong_copy_src_cmd = (
+        f"cp --archive --recursive --reflink=auto {build_path}/src {install_path}"
+    )
+    wrong_copy_lib_cmd = (
+        f"cp --archive --recursive --reflink=auto {build_path}/lib {install_path}"
+    )
+
+    # Check if no src or libs exist
+    default_commands = plugin._get_package_install_commands()
+    pytest_check.is_not_in(copy_src_cmd, default_commands)
+    pytest_check.is_not_in(copy_lib_cmd, default_commands)
+
+    # Creating src/lib in parent build_path should not trigger copy
+    (build_path / "src").mkdir(parents=True)
+    (build_path / "lib" / "charm").mkdir(parents=True)
+    commands_with_parent_dirs = plugin._get_package_install_commands()
+    pytest_check.is_not_in(wrong_copy_src_cmd, commands_with_parent_dirs)
+    pytest_check.is_not_in(wrong_copy_lib_cmd, commands_with_parent_dirs)
+    pytest_check.is_not_in(copy_src_cmd, commands_with_parent_dirs)
+    pytest_check.is_not_in(copy_lib_cmd, commands_with_parent_dirs)
+
+    # With a src directory in build_subdir
+    (build_subdir / "src").mkdir(parents=True)
+    pytest_check.equal(
+        plugin._get_package_install_commands(), [*default_commands, copy_src_cmd]
+    )
+
+    # With both src and lib in build_subdir
+    (build_subdir / "lib" / "charm").mkdir(parents=True)
+    pytest_check.equal(
+        plugin._get_package_install_commands(),
+        [*default_commands, copy_src_cmd, copy_lib_cmd],
+    )
+
+    # With only lib in build_subdir
+    (build_subdir / "src").rmdir()
+    pytest_check.equal(
+        plugin._get_package_install_commands(), [*default_commands, copy_lib_cmd]
     )

--- a/tests/unit/parts/plugins/test_poetry.py
+++ b/tests/unit/parts/plugins/test_poetry.py
@@ -19,6 +19,7 @@ import pathlib
 import typing
 
 import craft_parts
+import pytest
 import pytest_check
 
 from charmcraft.parts import plugins
@@ -49,44 +50,93 @@ def test_get_pip_install_commands(poetry_plugin: plugins.PoetryPlugin):
     ]
 
 
+@pytest.mark.parametrize("source_subdir", [None, "subdir"])
 def test_get_package_install_commands(
-    poetry_plugin: plugins.PoetryPlugin,
-    build_path: pathlib.Path,
+    tmp_path: pathlib.Path,
     install_path: pathlib.Path,
+    source_subdir: str | None,
 ):
+    project_dirs = craft_parts.ProjectDirs(work_dir=tmp_path)
+    spec: dict[str, typing.Any] = {
+        "plugin": "poetry",
+        "source": str(tmp_path),
+    }
+    if source_subdir:
+        spec["source-subdir"] = source_subdir
+    plugin_properties = plugins.PoetryPluginProperties.unmarshal(spec)
+    part_spec = craft_parts.plugins.extract_part_properties(spec, plugin_name="poetry")
+    part = craft_parts.Part(
+        "foo", part_spec, project_dirs=project_dirs, plugin_properties=plugin_properties
+    )
+    project_info = craft_parts.ProjectInfo(
+        application_name="test",
+        project_dirs=project_dirs,
+        cache_dir=tmp_path,
+    )
+    part_info = craft_parts.PartInfo(project_info=project_info, part=part)
+    plugin = typing.cast(
+        plugins.PoetryPlugin,
+        craft_parts.plugins.get_plugin(
+            part=part, part_info=part_info, properties=plugin_properties
+        ),
+    )
+
+    build_path = part_info.part_build_dir
+    build_subdir = part_info.part_build_subdir
+    if source_subdir:
+        assert build_subdir != build_path
+    else:
+        assert build_subdir == build_path
+
     copy_src_cmd = (
-        f"cp --archive --recursive --reflink=auto {build_path}/src {install_path}"
+        f"cp --archive --recursive --reflink=auto {build_subdir}/src {install_path}"
     )
     copy_lib_cmd = (
-        f"cp --archive --recursive --reflink=auto {build_path}/lib {install_path}"
+        f"cp --archive --recursive --reflink=auto {build_subdir}/lib {install_path}"
     )
 
     # Check if no src or libs exist
-    default_commands = poetry_plugin._get_package_install_commands()
+    default_commands = plugin._get_package_install_commands()
 
     pytest_check.is_not_in(copy_src_cmd, default_commands)
     pytest_check.is_not_in(copy_lib_cmd, default_commands)
 
+    if source_subdir:
+        # Creating src/lib in parent build_path should not trigger copy
+        (build_path / "src").mkdir(parents=True)
+        (build_path / "lib" / "charm").mkdir(parents=True)
+        wrong_copy_src_cmd = (
+            f"cp --archive --recursive --reflink=auto {build_path}/src {install_path}"
+        )
+        wrong_copy_lib_cmd = (
+            f"cp --archive --recursive --reflink=auto {build_path}/lib {install_path}"
+        )
+        commands_with_parent_dirs = plugin._get_package_install_commands()
+        pytest_check.is_not_in(wrong_copy_src_cmd, commands_with_parent_dirs)
+        pytest_check.is_not_in(wrong_copy_lib_cmd, commands_with_parent_dirs)
+        pytest_check.is_not_in(copy_src_cmd, commands_with_parent_dirs)
+        pytest_check.is_not_in(copy_lib_cmd, commands_with_parent_dirs)
+
     # With a src directory
-    (build_path / "src").mkdir(parents=True)
+    (build_subdir / "src").mkdir(parents=True)
 
     pytest_check.equal(
-        poetry_plugin._get_package_install_commands(), [*default_commands, copy_src_cmd]
+        plugin._get_package_install_commands(), [*default_commands, copy_src_cmd]
     )
 
     # With both src and lib
-    (build_path / "lib" / "charm").mkdir(parents=True)
+    (build_subdir / "lib" / "charm").mkdir(parents=True)
 
     pytest_check.equal(
-        poetry_plugin._get_package_install_commands(),
+        plugin._get_package_install_commands(),
         [*default_commands, copy_src_cmd, copy_lib_cmd],
     )
 
     # With only lib
-    (build_path / "src").rmdir()
+    (build_subdir / "src").rmdir()
 
     pytest_check.equal(
-        poetry_plugin._get_package_install_commands(), [*default_commands, copy_lib_cmd]
+        plugin._get_package_install_commands(), [*default_commands, copy_lib_cmd]
     )
 
 
@@ -111,83 +161,4 @@ def test_no_get_rm_command(
     assert (
         f"rm -rf {install_path / 'venv/bin'}/!(activate)"
         not in poetry_plugin.get_build_commands()
-    )
-
-
-def test_get_package_install_commands_source_subdir(
-    tmp_path: pathlib.Path,
-    install_path: pathlib.Path,
-):
-    project_dirs = craft_parts.ProjectDirs(work_dir=tmp_path)
-    spec = {
-        "plugin": "poetry",
-        "source": str(tmp_path),
-        "source-subdir": "subdir",
-    }
-    plugin_properties = plugins.PoetryPluginProperties.unmarshal(spec)
-    part_spec = craft_parts.plugins.extract_part_properties(spec, plugin_name="poetry")
-    part = craft_parts.Part(
-        "foo", part_spec, project_dirs=project_dirs, plugin_properties=plugin_properties
-    )
-    project_info = craft_parts.ProjectInfo(
-        application_name="test",
-        project_dirs=project_dirs,
-        cache_dir=tmp_path,
-    )
-    part_info = craft_parts.PartInfo(project_info=project_info, part=part)
-    plugin = typing.cast(
-        plugins.PoetryPlugin,
-        craft_parts.plugins.get_plugin(
-            part=part, part_info=part_info, properties=plugin_properties
-        ),
-    )
-
-    build_path = part_info.part_build_dir
-    build_subdir = part_info.part_build_subdir
-    assert build_subdir != build_path
-
-    copy_src_cmd = (
-        f"cp --archive --recursive --reflink=auto {build_subdir}/src {install_path}"
-    )
-    copy_lib_cmd = (
-        f"cp --archive --recursive --reflink=auto {build_subdir}/lib {install_path}"
-    )
-    wrong_copy_src_cmd = (
-        f"cp --archive --recursive --reflink=auto {build_path}/src {install_path}"
-    )
-    wrong_copy_lib_cmd = (
-        f"cp --archive --recursive --reflink=auto {build_path}/lib {install_path}"
-    )
-
-    # Check if no src or libs exist
-    default_commands = plugin._get_package_install_commands()
-    pytest_check.is_not_in(copy_src_cmd, default_commands)
-    pytest_check.is_not_in(copy_lib_cmd, default_commands)
-
-    # Creating src/lib in parent build_path should not trigger copy
-    (build_path / "src").mkdir(parents=True)
-    (build_path / "lib" / "charm").mkdir(parents=True)
-    commands_with_parent_dirs = plugin._get_package_install_commands()
-    pytest_check.is_not_in(wrong_copy_src_cmd, commands_with_parent_dirs)
-    pytest_check.is_not_in(wrong_copy_lib_cmd, commands_with_parent_dirs)
-    pytest_check.is_not_in(copy_src_cmd, commands_with_parent_dirs)
-    pytest_check.is_not_in(copy_lib_cmd, commands_with_parent_dirs)
-
-    # With a src directory in build_subdir
-    (build_subdir / "src").mkdir(parents=True)
-    pytest_check.equal(
-        plugin._get_package_install_commands(), [*default_commands, copy_src_cmd]
-    )
-
-    # With both src and lib in build_subdir
-    (build_subdir / "lib" / "charm").mkdir(parents=True)
-    pytest_check.equal(
-        plugin._get_package_install_commands(),
-        [*default_commands, copy_src_cmd, copy_lib_cmd],
-    )
-
-    # With only lib in build_subdir
-    (build_subdir / "src").rmdir()
-    pytest_check.equal(
-        plugin._get_package_install_commands(), [*default_commands, copy_lib_cmd]
     )

--- a/tests/unit/parts/plugins/test_poetry.py
+++ b/tests/unit/parts/plugins/test_poetry.py
@@ -16,6 +16,7 @@
 """Unit tests for the Charmcraft-specific poetry plugin."""
 
 import pathlib
+import typing
 
 import craft_parts
 import pytest_check
@@ -134,8 +135,11 @@ def test_get_package_install_commands_source_subdir(
         cache_dir=tmp_path,
     )
     part_info = craft_parts.PartInfo(project_info=project_info, part=part)
-    plugin = craft_parts.plugins.get_plugin(
-        part=part, part_info=part_info, properties=plugin_properties
+    plugin = typing.cast(
+        plugins.PoetryPlugin,
+        craft_parts.plugins.get_plugin(
+            part=part, part_info=part_info, properties=plugin_properties
+        ),
     )
 
     build_path = part_info.part_build_dir

--- a/tests/unit/parts/plugins/test_python.py
+++ b/tests/unit/parts/plugins/test_python.py
@@ -18,6 +18,7 @@
 import pathlib
 import shlex
 
+import craft_parts
 import pytest
 import pytest_check
 
@@ -121,3 +122,76 @@ def test_no_get_rm_command(
         f"rm -rf {install_path / 'venv/bin'}/!(activate)"
         not in python_plugin.get_build_commands()
     )
+
+
+def test_get_package_install_commands_source_subdir(
+    tmp_path: pathlib.Path,
+    install_path: pathlib.Path,
+):
+    project_dirs = craft_parts.ProjectDirs(work_dir=tmp_path)
+    spec = {
+        "plugin": "python",
+        "source": str(tmp_path),
+        "source-subdir": "subdir",
+    }
+    plugin_properties = plugins.PythonPluginProperties.unmarshal(spec)
+    part_spec = craft_parts.plugins.extract_part_properties(spec, plugin_name="python")
+    part = craft_parts.Part(
+        "foo", part_spec, project_dirs=project_dirs, plugin_properties=plugin_properties
+    )
+    project_info = craft_parts.ProjectInfo(
+        application_name="test",
+        project_dirs=project_dirs,
+        cache_dir=tmp_path,
+    )
+    part_info = craft_parts.PartInfo(project_info=project_info, part=part)
+    plugin = craft_parts.plugins.get_plugin(
+        part=part, part_info=part_info, properties=plugin_properties
+    )
+    plugin._get_pip = lambda: "/python -m pip"  # ty: ignore[invalid-assignment]
+
+    build_path = part_info.part_build_dir
+    build_subdir = part_info.part_build_subdir
+    assert build_subdir != build_path
+
+    copy_src_cmd = (
+        f"cp --archive --recursive --reflink=auto {build_subdir}/src {install_path}"
+    )
+    copy_lib_cmd = (
+        f"cp --archive --recursive --reflink=auto {build_subdir}/lib {install_path}"
+    )
+    wrong_copy_src_cmd = (
+        f"cp --archive --recursive --reflink=auto {build_path}/src {install_path}"
+    )
+    wrong_copy_lib_cmd = (
+        f"cp --archive --recursive --reflink=auto {build_path}/lib {install_path}"
+    )
+
+    # Check if no src or libs exist
+    default_commands = plugin._get_package_install_commands()
+    pytest_check.is_not_in(copy_src_cmd, default_commands)
+    pytest_check.is_not_in(copy_lib_cmd, default_commands)
+
+    # Creating src/lib in parent build_path should not trigger copy
+    (build_path / "src").mkdir(parents=True)
+    (build_path / "lib" / "charm").mkdir(parents=True)
+    commands_with_parent_dirs = plugin._get_package_install_commands()
+    pytest_check.is_not_in(wrong_copy_src_cmd, commands_with_parent_dirs)
+    pytest_check.is_not_in(wrong_copy_lib_cmd, commands_with_parent_dirs)
+    pytest_check.is_not_in(copy_src_cmd, commands_with_parent_dirs)
+    pytest_check.is_not_in(copy_lib_cmd, commands_with_parent_dirs)
+
+    # With a src directory in build_subdir
+    (build_subdir / "src").mkdir(parents=True)
+    pytest_check.is_in(copy_src_cmd, plugin._get_package_install_commands())
+    pytest_check.is_not_in(copy_lib_cmd, plugin._get_package_install_commands())
+
+    # With both src and lib in build_subdir
+    (build_subdir / "lib" / "charm").mkdir(parents=True)
+    pytest_check.is_in(copy_src_cmd, plugin._get_package_install_commands())
+    pytest_check.is_in(copy_lib_cmd, plugin._get_package_install_commands())
+
+    # With only lib in build_subdir
+    (build_subdir / "src").rmdir()
+    pytest_check.is_not_in(copy_src_cmd, plugin._get_package_install_commands())
+    pytest_check.is_in(copy_lib_cmd, plugin._get_package_install_commands())

--- a/tests/unit/parts/plugins/test_python.py
+++ b/tests/unit/parts/plugins/test_python.py
@@ -17,6 +17,7 @@
 
 import pathlib
 import shlex
+import typing
 
 import craft_parts
 import pytest
@@ -145,8 +146,11 @@ def test_get_package_install_commands_source_subdir(
         cache_dir=tmp_path,
     )
     part_info = craft_parts.PartInfo(project_info=project_info, part=part)
-    plugin = craft_parts.plugins.get_plugin(
-        part=part, part_info=part_info, properties=plugin_properties
+    plugin = typing.cast(
+        plugins.PythonPlugin,
+        craft_parts.plugins.get_plugin(
+            part=part, part_info=part_info, properties=plugin_properties
+        ),
     )
     plugin._get_pip = lambda: "/python -m pip"  # ty: ignore[invalid-assignment]
 

--- a/tests/unit/parts/plugins/test_python.py
+++ b/tests/unit/parts/plugins/test_python.py
@@ -43,33 +43,60 @@ def test_get_venv_directory(
 @pytest.mark.parametrize("constraints", [[], ["constraints.txt"]])
 @pytest.mark.parametrize("requirements", [[], ["requirements.txt"]])
 @pytest.mark.parametrize("packages", [[], ["distro==1.4.0"]])
+@pytest.mark.parametrize("source_subdir", [None, "subdir"])
 def test_get_package_install_commands(
     tmp_path: pathlib.Path,
-    python_plugin: plugins.PythonPlugin,
-    build_path: pathlib.Path,
     install_path: pathlib.Path,
     constraints: list[str],
     requirements: list[str],
     packages: list[str],
+    source_subdir: str | None,
     check,
 ):
-    spec = {
+    project_dirs = craft_parts.ProjectDirs(work_dir=tmp_path)
+    spec: dict[str, typing.Any] = {
         "plugin": "python",
         "source": str(tmp_path),
         "python-constraints": constraints,
         "python-requirements": requirements,
         "python-packages": packages,
     }
-    python_plugin._options = plugins.PythonPluginProperties.unmarshal(spec)
-    python_plugin._get_pip = lambda: "/python -m pip"  # ty: ignore[invalid-assignment]
+    if source_subdir:
+        spec["source-subdir"] = source_subdir
+    plugin_properties = plugins.PythonPluginProperties.unmarshal(spec)
+    part_spec = craft_parts.plugins.extract_part_properties(spec, plugin_name="python")
+    part = craft_parts.Part(
+        "foo", part_spec, project_dirs=project_dirs, plugin_properties=plugin_properties
+    )
+    project_info = craft_parts.ProjectInfo(
+        application_name="test",
+        project_dirs=project_dirs,
+        cache_dir=tmp_path,
+    )
+    part_info = craft_parts.PartInfo(project_info=project_info, part=part)
+    plugin = typing.cast(
+        plugins.PythonPlugin,
+        craft_parts.plugins.get_plugin(
+            part=part, part_info=part_info, properties=plugin_properties
+        ),
+    )
+    plugin._get_pip = lambda: "/python -m pip"  # ty: ignore[invalid-assignment]
+
+    build_path = part_info.part_build_dir
+    build_subdir = part_info.part_build_subdir
+    if source_subdir:
+        assert build_subdir != build_path
+    else:
+        assert build_subdir == build_path
+
     copy_src_cmd = (
-        f"cp --archive --recursive --reflink=auto {build_path}/src {install_path}"
+        f"cp --archive --recursive --reflink=auto {build_subdir}/src {install_path}"
     )
     copy_lib_cmd = (
-        f"cp --archive --recursive --reflink=auto {build_path}/lib {install_path}"
+        f"cp --archive --recursive --reflink=auto {build_subdir}/lib {install_path}"
     )
 
-    actual = python_plugin._get_package_install_commands()
+    actual = plugin._get_package_install_commands()
 
     with check():
         assert actual[0].startswith("/python -m pip")
@@ -85,20 +112,35 @@ def test_get_package_install_commands(
     pytest_check.is_not_in(copy_src_cmd, actual)
     pytest_check.is_not_in(copy_lib_cmd, actual)
 
-    (build_path / "src").mkdir()
+    if source_subdir:
+        (build_path / "src").mkdir(parents=True)
+        (build_path / "lib" / "charm").mkdir(parents=True)
+        wrong_copy_src_cmd = (
+            f"cp --archive --recursive --reflink=auto {build_path}/src {install_path}"
+        )
+        wrong_copy_lib_cmd = (
+            f"cp --archive --recursive --reflink=auto {build_path}/lib {install_path}"
+        )
+        commands_with_parent_dirs = plugin._get_package_install_commands()
+        pytest_check.is_not_in(wrong_copy_src_cmd, commands_with_parent_dirs)
+        pytest_check.is_not_in(wrong_copy_lib_cmd, commands_with_parent_dirs)
+        pytest_check.is_not_in(copy_src_cmd, commands_with_parent_dirs)
+        pytest_check.is_not_in(copy_lib_cmd, commands_with_parent_dirs)
 
-    pytest_check.is_in(copy_src_cmd, python_plugin._get_package_install_commands())
-    pytest_check.is_not_in(copy_lib_cmd, python_plugin._get_package_install_commands())
+    (build_subdir / "src").mkdir(parents=True)
 
-    (build_path / "lib").mkdir()
+    pytest_check.is_in(copy_src_cmd, plugin._get_package_install_commands())
+    pytest_check.is_not_in(copy_lib_cmd, plugin._get_package_install_commands())
 
-    pytest_check.is_in(copy_src_cmd, python_plugin._get_package_install_commands())
-    pytest_check.is_in(copy_lib_cmd, python_plugin._get_package_install_commands())
+    (build_subdir / "lib" / "charm").mkdir(parents=True)
 
-    (build_path / "src").rmdir()
+    pytest_check.is_in(copy_src_cmd, plugin._get_package_install_commands())
+    pytest_check.is_in(copy_lib_cmd, plugin._get_package_install_commands())
 
-    pytest_check.is_not_in(copy_src_cmd, python_plugin._get_package_install_commands())
-    pytest_check.is_in(copy_lib_cmd, python_plugin._get_package_install_commands())
+    (build_subdir / "src").rmdir()
+
+    pytest_check.is_not_in(copy_src_cmd, plugin._get_package_install_commands())
+    pytest_check.is_in(copy_lib_cmd, plugin._get_package_install_commands())
 
 
 def test_get_rm_command(
@@ -123,79 +165,3 @@ def test_no_get_rm_command(
         f"rm -rf {install_path / 'venv/bin'}/!(activate)"
         not in python_plugin.get_build_commands()
     )
-
-
-def test_get_package_install_commands_source_subdir(
-    tmp_path: pathlib.Path,
-    install_path: pathlib.Path,
-):
-    project_dirs = craft_parts.ProjectDirs(work_dir=tmp_path)
-    spec = {
-        "plugin": "python",
-        "source": str(tmp_path),
-        "source-subdir": "subdir",
-    }
-    plugin_properties = plugins.PythonPluginProperties.unmarshal(spec)
-    part_spec = craft_parts.plugins.extract_part_properties(spec, plugin_name="python")
-    part = craft_parts.Part(
-        "foo", part_spec, project_dirs=project_dirs, plugin_properties=plugin_properties
-    )
-    project_info = craft_parts.ProjectInfo(
-        application_name="test",
-        project_dirs=project_dirs,
-        cache_dir=tmp_path,
-    )
-    part_info = craft_parts.PartInfo(project_info=project_info, part=part)
-    plugin = typing.cast(
-        plugins.PythonPlugin,
-        craft_parts.plugins.get_plugin(
-            part=part, part_info=part_info, properties=plugin_properties
-        ),
-    )
-    plugin._get_pip = lambda: "/python -m pip"  # ty: ignore[invalid-assignment]
-
-    build_path = part_info.part_build_dir
-    build_subdir = part_info.part_build_subdir
-    assert build_subdir != build_path
-
-    copy_src_cmd = (
-        f"cp --archive --recursive --reflink=auto {build_subdir}/src {install_path}"
-    )
-    copy_lib_cmd = (
-        f"cp --archive --recursive --reflink=auto {build_subdir}/lib {install_path}"
-    )
-    wrong_copy_src_cmd = (
-        f"cp --archive --recursive --reflink=auto {build_path}/src {install_path}"
-    )
-    wrong_copy_lib_cmd = (
-        f"cp --archive --recursive --reflink=auto {build_path}/lib {install_path}"
-    )
-
-    # Check if no src or libs exist
-    default_commands = plugin._get_package_install_commands()
-    pytest_check.is_not_in(copy_src_cmd, default_commands)
-    pytest_check.is_not_in(copy_lib_cmd, default_commands)
-
-    # Creating src/lib in parent build_path should not trigger copy
-    (build_path / "src").mkdir(parents=True)
-    (build_path / "lib" / "charm").mkdir(parents=True)
-    commands_with_parent_dirs = plugin._get_package_install_commands()
-    pytest_check.is_not_in(wrong_copy_src_cmd, commands_with_parent_dirs)
-    pytest_check.is_not_in(wrong_copy_lib_cmd, commands_with_parent_dirs)
-    pytest_check.is_not_in(copy_src_cmd, commands_with_parent_dirs)
-    pytest_check.is_not_in(copy_lib_cmd, commands_with_parent_dirs)
-
-    # With a src directory in build_subdir
-    (build_subdir / "src").mkdir(parents=True)
-    pytest_check.is_in(copy_src_cmd, plugin._get_package_install_commands())
-    pytest_check.is_not_in(copy_lib_cmd, plugin._get_package_install_commands())
-
-    # With both src and lib in build_subdir
-    (build_subdir / "lib" / "charm").mkdir(parents=True)
-    pytest_check.is_in(copy_src_cmd, plugin._get_package_install_commands())
-    pytest_check.is_in(copy_lib_cmd, plugin._get_package_install_commands())
-
-    # With only lib in build_subdir
-    (build_subdir / "src").rmdir()
-    pytest_check.is_not_in(copy_src_cmd, plugin._get_package_install_commands())
-    pytest_check.is_in(copy_lib_cmd, plugin._get_package_install_commands())

--- a/tests/unit/parts/plugins/test_uv.py
+++ b/tests/unit/parts/plugins/test_uv.py
@@ -14,6 +14,7 @@
 #
 # For further info, check https://github.com/canonical/charmcraft
 
+import typing
 from pathlib import Path
 
 import craft_parts
@@ -91,8 +92,11 @@ def test_get_package_install_commands_source_subdir(tmp_path: Path, install_path
         cache_dir=tmp_path,
     )
     part_info = craft_parts.PartInfo(project_info=project_info, part=part)
-    plugin = craft_parts.plugins.get_plugin(
-        part=part, part_info=part_info, properties=plugin_properties
+    plugin = typing.cast(
+        plugins.UvPlugin,
+        craft_parts.plugins.get_plugin(
+            part=part, part_info=part_info, properties=plugin_properties
+        ),
     )
 
     build_path = part_info.part_build_dir

--- a/tests/unit/parts/plugins/test_uv.py
+++ b/tests/unit/parts/plugins/test_uv.py
@@ -16,6 +16,7 @@
 
 from pathlib import Path
 
+import craft_parts
 import pytest
 import pytest_check
 
@@ -74,3 +75,72 @@ def test_do_not_install_project(uv_plugin: plugins.UvPlugin) -> None:
             break
     else:
         pytest.fail(reason="Charms should not be installed as projects.")
+
+
+def test_get_package_install_commands_source_subdir(tmp_path: Path, install_path: Path):
+    project_dirs = craft_parts.ProjectDirs(work_dir=tmp_path)
+    spec = {"plugin": "uv", "source": str(tmp_path), "source-subdir": "subdir"}
+    plugin_properties = plugins.UvPluginProperties.unmarshal(spec)
+    part_spec = craft_parts.plugins.extract_part_properties(spec, plugin_name="uv")
+    part = craft_parts.Part(
+        "foo", part_spec, project_dirs=project_dirs, plugin_properties=plugin_properties
+    )
+    project_info = craft_parts.ProjectInfo(
+        application_name="test",
+        project_dirs=project_dirs,
+        cache_dir=tmp_path,
+    )
+    part_info = craft_parts.PartInfo(project_info=project_info, part=part)
+    plugin = craft_parts.plugins.get_plugin(
+        part=part, part_info=part_info, properties=plugin_properties
+    )
+
+    build_path = part_info.part_build_dir
+    build_subdir = part_info.part_build_subdir
+    assert build_subdir != build_path
+
+    copy_src_cmd = (
+        f"cp --archive --recursive --reflink=auto {build_subdir}/src {install_path}"
+    )
+    copy_lib_cmd = (
+        f"cp --archive --recursive --reflink=auto {build_subdir}/lib {install_path}"
+    )
+    wrong_copy_src_cmd = (
+        f"cp --archive --recursive --reflink=auto {build_path}/src {install_path}"
+    )
+    wrong_copy_lib_cmd = (
+        f"cp --archive --recursive --reflink=auto {build_path}/lib {install_path}"
+    )
+
+    # Check if no src or libs exist
+    default_commands = plugin._get_package_install_commands()
+    pytest_check.is_not_in(copy_src_cmd, default_commands)
+    pytest_check.is_not_in(copy_lib_cmd, default_commands)
+
+    # Creating src/lib in parent build_path should not trigger copy
+    (build_path / "src").mkdir(parents=True)
+    (build_path / "lib" / "charm").mkdir(parents=True)
+    commands_with_parent_dirs = plugin._get_package_install_commands()
+    pytest_check.is_not_in(wrong_copy_src_cmd, commands_with_parent_dirs)
+    pytest_check.is_not_in(wrong_copy_lib_cmd, commands_with_parent_dirs)
+    pytest_check.is_not_in(copy_src_cmd, commands_with_parent_dirs)
+    pytest_check.is_not_in(copy_lib_cmd, commands_with_parent_dirs)
+
+    # With a src directory in build_subdir
+    (build_subdir / "src").mkdir(parents=True)
+    pytest_check.equal(
+        plugin._get_package_install_commands(), [*default_commands, copy_src_cmd]
+    )
+
+    # With both src and lib in build_subdir
+    (build_subdir / "lib" / "charm").mkdir(parents=True)
+    pytest_check.equal(
+        plugin._get_package_install_commands(),
+        [*default_commands, copy_src_cmd, copy_lib_cmd],
+    )
+
+    # With only lib in build_subdir
+    (build_subdir / "src").rmdir()
+    pytest_check.equal(
+        plugin._get_package_install_commands(), [*default_commands, copy_lib_cmd]
+    )

--- a/tests/unit/parts/plugins/test_uv.py
+++ b/tests/unit/parts/plugins/test_uv.py
@@ -34,53 +34,19 @@ def test_get_venv_directory(uv_plugin: plugins.UvPlugin, install_path: Path):
     assert uv_plugin._get_venv_directory() == install_path / "venv"
 
 
+@pytest.mark.parametrize("source_subdir", [None, "subdir"])
 def test_get_package_install_commands(
-    uv_plugin: plugins.UvPlugin, build_path: Path, install_path: Path
+    tmp_path: Path,
+    install_path: Path,
+    source_subdir: str | None,
 ):
-    copy_src_cmd = (
-        f"cp --archive --recursive --reflink=auto {build_path}/src {install_path}"
-    )
-
-    copy_lib_cmd = (
-        f"cp --archive --recursive --reflink=auto {build_path}/lib {install_path}"
-    )
-
-    default_commands = uv_plugin._get_package_install_commands()
-
-    pytest_check.is_not_in(copy_src_cmd, default_commands)
-    pytest_check.is_not_in(copy_lib_cmd, default_commands)
-
-    (build_path / "src").mkdir(parents=True)
-
-    pytest_check.equal(
-        uv_plugin._get_package_install_commands(), [*default_commands, copy_src_cmd]
-    )
-
-    (build_path / "lib" / "charm").mkdir(parents=True)
-
-    pytest_check.equal(
-        uv_plugin._get_package_install_commands(),
-        [*default_commands, copy_src_cmd, copy_lib_cmd],
-    )
-
-    (build_path / "src").rmdir()
-
-    pytest_check.equal(
-        uv_plugin._get_package_install_commands(), [*default_commands, copy_lib_cmd]
-    )
-
-
-def test_do_not_install_project(uv_plugin: plugins.UvPlugin) -> None:
-    for command in uv_plugin._get_package_install_commands():
-        if command.startswith("uv sync") and "--no-install-project" in command:
-            break
-    else:
-        pytest.fail(reason="Charms should not be installed as projects.")
-
-
-def test_get_package_install_commands_source_subdir(tmp_path: Path, install_path: Path):
     project_dirs = craft_parts.ProjectDirs(work_dir=tmp_path)
-    spec = {"plugin": "uv", "source": str(tmp_path), "source-subdir": "subdir"}
+    spec: dict[str, typing.Any] = {
+        "plugin": "uv",
+        "source": str(tmp_path),
+    }
+    if source_subdir:
+        spec["source-subdir"] = source_subdir
     plugin_properties = plugins.UvPluginProperties.unmarshal(spec)
     part_spec = craft_parts.plugins.extract_part_properties(spec, plugin_name="uv")
     part = craft_parts.Part(
@@ -101,7 +67,10 @@ def test_get_package_install_commands_source_subdir(tmp_path: Path, install_path
 
     build_path = part_info.part_build_dir
     build_subdir = part_info.part_build_subdir
-    assert build_subdir != build_path
+    if source_subdir:
+        assert build_subdir != build_path
+    else:
+        assert build_subdir == build_path
 
     copy_src_cmd = (
         f"cp --archive --recursive --reflink=auto {build_subdir}/src {install_path}"
@@ -109,42 +78,51 @@ def test_get_package_install_commands_source_subdir(tmp_path: Path, install_path
     copy_lib_cmd = (
         f"cp --archive --recursive --reflink=auto {build_subdir}/lib {install_path}"
     )
-    wrong_copy_src_cmd = (
-        f"cp --archive --recursive --reflink=auto {build_path}/src {install_path}"
-    )
-    wrong_copy_lib_cmd = (
-        f"cp --archive --recursive --reflink=auto {build_path}/lib {install_path}"
-    )
 
-    # Check if no src or libs exist
     default_commands = plugin._get_package_install_commands()
+
     pytest_check.is_not_in(copy_src_cmd, default_commands)
     pytest_check.is_not_in(copy_lib_cmd, default_commands)
 
-    # Creating src/lib in parent build_path should not trigger copy
-    (build_path / "src").mkdir(parents=True)
-    (build_path / "lib" / "charm").mkdir(parents=True)
-    commands_with_parent_dirs = plugin._get_package_install_commands()
-    pytest_check.is_not_in(wrong_copy_src_cmd, commands_with_parent_dirs)
-    pytest_check.is_not_in(wrong_copy_lib_cmd, commands_with_parent_dirs)
-    pytest_check.is_not_in(copy_src_cmd, commands_with_parent_dirs)
-    pytest_check.is_not_in(copy_lib_cmd, commands_with_parent_dirs)
+    if source_subdir:
+        # Creating src/lib in parent build_path should not trigger copy
+        (build_path / "src").mkdir(parents=True)
+        (build_path / "lib" / "charm").mkdir(parents=True)
+        wrong_copy_src_cmd = (
+            f"cp --archive --recursive --reflink=auto {build_path}/src {install_path}"
+        )
+        wrong_copy_lib_cmd = (
+            f"cp --archive --recursive --reflink=auto {build_path}/lib {install_path}"
+        )
+        commands_with_parent_dirs = plugin._get_package_install_commands()
+        pytest_check.is_not_in(wrong_copy_src_cmd, commands_with_parent_dirs)
+        pytest_check.is_not_in(wrong_copy_lib_cmd, commands_with_parent_dirs)
+        pytest_check.is_not_in(copy_src_cmd, commands_with_parent_dirs)
+        pytest_check.is_not_in(copy_lib_cmd, commands_with_parent_dirs)
 
-    # With a src directory in build_subdir
     (build_subdir / "src").mkdir(parents=True)
+
     pytest_check.equal(
         plugin._get_package_install_commands(), [*default_commands, copy_src_cmd]
     )
 
-    # With both src and lib in build_subdir
     (build_subdir / "lib" / "charm").mkdir(parents=True)
+
     pytest_check.equal(
         plugin._get_package_install_commands(),
         [*default_commands, copy_src_cmd, copy_lib_cmd],
     )
 
-    # With only lib in build_subdir
     (build_subdir / "src").rmdir()
+
     pytest_check.equal(
         plugin._get_package_install_commands(), [*default_commands, copy_lib_cmd]
     )
+
+
+def test_do_not_install_project(uv_plugin: plugins.UvPlugin) -> None:
+    for command in uv_plugin._get_package_install_commands():
+        if command.startswith("uv sync") and "--no-install-project" in command:
+            break
+    else:
+        pytest.fail(reason="Charms should not be installed as projects.")

--- a/tests/unit/utils/test_parts.py
+++ b/tests/unit/utils/test_parts.py
@@ -32,57 +32,33 @@ def test_extend_python_build_environment():
     }
 
 
-def test_get_charm_copy_commands_no_dirs(tmp_path: pathlib.Path):
+@pytest.mark.parametrize(
+    ("dirs_to_create", "expected_dirs"),
+    [
+        ([], []),
+        (["src"], ["src"]),
+        (["lib"], ["lib"]),
+        (["src", "lib"], ["src", "lib"]),
+    ],
+)
+def test_get_charm_copy_commands(
+    tmp_path: pathlib.Path,
+    dirs_to_create: list[str],
+    expected_dirs: list[str],
+):
     build_dir = tmp_path / "build"
-    build_dir.mkdir()
+    build_dir.mkdir(parents=True, exist_ok=True)
+    for d in dirs_to_create:
+        (build_dir / d).mkdir(parents=True)
     install_dir = tmp_path / "install"
-    install_dir.mkdir()
+    install_dir.mkdir(parents=True, exist_ok=True)
 
     commands = parts.get_charm_copy_commands(build_dir, install_dir)
-    assert commands == []
-
-
-def test_get_charm_copy_commands_only_src(tmp_path: pathlib.Path):
-    build_dir = tmp_path / "build"
-    (build_dir / "src").mkdir(parents=True)
-    install_dir = tmp_path / "install"
-    install_dir.mkdir()
-
-    commands = parts.get_charm_copy_commands(build_dir, install_dir)
-    expected_src_cmd = (
-        f"cp --archive --recursive --reflink=auto {build_dir / 'src'} {install_dir}"
-    )
-    assert commands == [expected_src_cmd]
-
-
-def test_get_charm_copy_commands_only_lib(tmp_path: pathlib.Path):
-    build_dir = tmp_path / "build"
-    (build_dir / "lib").mkdir(parents=True)
-    install_dir = tmp_path / "install"
-    install_dir.mkdir()
-
-    commands = parts.get_charm_copy_commands(build_dir, install_dir)
-    expected_lib_cmd = (
-        f"cp --archive --recursive --reflink=auto {build_dir / 'lib'} {install_dir}"
-    )
-    assert commands == [expected_lib_cmd]
-
-
-def test_get_charm_copy_commands_both_src_and_lib(tmp_path: pathlib.Path):
-    build_dir = tmp_path / "build"
-    (build_dir / "src").mkdir(parents=True)
-    (build_dir / "lib").mkdir(parents=True)
-    install_dir = tmp_path / "install"
-    install_dir.mkdir()
-
-    commands = parts.get_charm_copy_commands(build_dir, install_dir)
-    expected_src_cmd = (
-        f"cp --archive --recursive --reflink=auto {build_dir / 'src'} {install_dir}"
-    )
-    expected_lib_cmd = (
-        f"cp --archive --recursive --reflink=auto {build_dir / 'lib'} {install_dir}"
-    )
-    assert commands == [expected_src_cmd, expected_lib_cmd]
+    expected_commands = [
+        f"cp --archive --recursive --reflink=auto {build_dir / d} {install_dir}"
+        for d in expected_dirs
+    ]
+    assert commands == expected_commands
 
 
 def test_get_charm_copy_commands_with_spaces(tmp_path: pathlib.Path):

--- a/tests/unit/utils/test_parts.py
+++ b/tests/unit/utils/test_parts.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/utils/test_parts.py
+++ b/tests/unit/utils/test_parts.py
@@ -1,0 +1,118 @@
+# Copyright 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For further info, check https://github.com/canonical/charmcraft
+"""Unit tests for craft-parts utility functions."""
+
+import pathlib
+import shlex
+
+import pytest
+
+from charmcraft.utils import parts
+
+
+def test_extend_python_build_environment():
+    base_env = {"FOO": "bar"}
+    extended = parts.extend_python_build_environment(base_env)
+    assert extended == {
+        "FOO": "bar",
+        "PARTS_PYTHON_VENV_ARGS": "--without-pip",
+    }
+
+
+def test_get_charm_copy_commands_no_dirs(tmp_path: pathlib.Path):
+    build_dir = tmp_path / "build"
+    build_dir.mkdir()
+    install_dir = tmp_path / "install"
+    install_dir.mkdir()
+
+    commands = parts.get_charm_copy_commands(build_dir, install_dir)
+    assert commands == []
+
+
+def test_get_charm_copy_commands_only_src(tmp_path: pathlib.Path):
+    build_dir = tmp_path / "build"
+    (build_dir / "src").mkdir(parents=True)
+    install_dir = tmp_path / "install"
+    install_dir.mkdir()
+
+    commands = parts.get_charm_copy_commands(build_dir, install_dir)
+    expected_src_cmd = (
+        f"cp --archive --recursive --reflink=auto {build_dir / 'src'} {install_dir}"
+    )
+    assert commands == [expected_src_cmd]
+
+
+def test_get_charm_copy_commands_only_lib(tmp_path: pathlib.Path):
+    build_dir = tmp_path / "build"
+    (build_dir / "lib").mkdir(parents=True)
+    install_dir = tmp_path / "install"
+    install_dir.mkdir()
+
+    commands = parts.get_charm_copy_commands(build_dir, install_dir)
+    expected_lib_cmd = (
+        f"cp --archive --recursive --reflink=auto {build_dir / 'lib'} {install_dir}"
+    )
+    assert commands == [expected_lib_cmd]
+
+
+def test_get_charm_copy_commands_both_src_and_lib(tmp_path: pathlib.Path):
+    build_dir = tmp_path / "build"
+    (build_dir / "src").mkdir(parents=True)
+    (build_dir / "lib").mkdir(parents=True)
+    install_dir = tmp_path / "install"
+    install_dir.mkdir()
+
+    commands = parts.get_charm_copy_commands(build_dir, install_dir)
+    expected_src_cmd = (
+        f"cp --archive --recursive --reflink=auto {build_dir / 'src'} {install_dir}"
+    )
+    expected_lib_cmd = (
+        f"cp --archive --recursive --reflink=auto {build_dir / 'lib'} {install_dir}"
+    )
+    assert commands == [expected_src_cmd, expected_lib_cmd]
+
+
+def test_get_charm_copy_commands_with_spaces(tmp_path: pathlib.Path):
+    build_dir = tmp_path / "build dir with spaces"
+    (build_dir / "src").mkdir(parents=True)
+    install_dir = tmp_path / "install dir with spaces"
+    install_dir.mkdir()
+
+    commands = parts.get_charm_copy_commands(build_dir, install_dir)
+    expected_src_cmd = shlex.join(
+        [
+            "cp",
+            "--archive",
+            "--recursive",
+            "--reflink=auto",
+            str(build_dir / "src"),
+            str(install_dir),
+        ]
+    )
+    assert commands == [expected_src_cmd]
+
+
+@pytest.mark.parametrize("keep_bins", [True, False])
+def test_get_venv_cleanup_commands(tmp_path: pathlib.Path, keep_bins: bool):
+    venv_path = tmp_path / "venv"
+    commands = parts.get_venv_cleanup_commands(venv_path, keep_bins=keep_bins)
+
+    assert any("VIRTUAL_ENV=" in cmd for cmd in commands)
+    assert any("lib64" in cmd for cmd in commands)
+    if keep_bins:
+        assert not any("rm -rf" in cmd for cmd in commands)
+    else:
+        assert any(f"rm -rf {venv_path / 'bin'}/!(activate)" in cmd for cmd in commands)

--- a/uv.lock
+++ b/uv.lock
@@ -3,8 +3,8 @@ revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version == '3.14.*'",
-    "python_full_version == '3.13.*' or python_full_version >= '3.15'",
     "python_full_version == '3.12.*'",
+    "python_full_version == '3.13.*' or python_full_version >= '3.15'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
@@ -33,7 +33,6 @@ constraints = [
     { name = "matplotlib", specifier = ">=3.7.0" },
     { name = "numpy", specifier = ">=1.22.0" },
     { name = "oauthlib", specifier = ">=3.0" },
-    { name = "ops", specifier = ">=2.0.0" },
     { name = "overrides", specifier = ">=7.3" },
     { name = "protobuf", specifier = "<6.33" },
     { name = "protobuf", specifier = ">=5.0" },
@@ -2645,8 +2644,8 @@ version = "2.4.0+ubuntu4"
 source = { registry = "https://people.canonical.com/~lengau/python-apt-ubuntu-wheels/" }
 resolution-markers = [
     "python_full_version == '3.14.*'",
-    "python_full_version == '3.13.*' or python_full_version >= '3.15'",
     "python_full_version == '3.12.*'",
+    "python_full_version == '3.13.*' or python_full_version >= '3.15'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
@@ -2690,8 +2689,8 @@ version = "2.7.7+ubuntu5"
 source = { registry = "https://people.canonical.com/~lengau/python-apt-ubuntu-wheels/" }
 resolution-markers = [
     "python_full_version == '3.14.*'",
-    "python_full_version == '3.13.*' or python_full_version >= '3.15'",
     "python_full_version == '3.12.*'",
+    "python_full_version == '3.13.*' or python_full_version >= '3.15'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
@@ -2734,8 +2733,8 @@ version = "2.9.9"
 source = { registry = "https://people.canonical.com/~lengau/python-apt-ubuntu-wheels/" }
 resolution-markers = [
     "python_full_version == '3.14.*'",
-    "python_full_version == '3.13.*' or python_full_version >= '3.15'",
     "python_full_version == '3.12.*'",
+    "python_full_version == '3.13.*' or python_full_version >= '3.15'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
@@ -2752,8 +2751,8 @@ version = "3.0.0+ubuntu1"
 source = { registry = "https://people.canonical.com/~lengau/python-apt-ubuntu-wheels/" }
 resolution-markers = [
     "python_full_version == '3.14.*'",
-    "python_full_version == '3.13.*' or python_full_version >= '3.15'",
     "python_full_version == '3.12.*'",
+    "python_full_version == '3.13.*' or python_full_version >= '3.15'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
@@ -3362,8 +3361,8 @@ version = "2025.8.25"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version == '3.14.*'",
-    "python_full_version == '3.13.*' or python_full_version >= '3.15'",
     "python_full_version == '3.12.*'",
+    "python_full_version == '3.13.*' or python_full_version >= '3.15'",
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
@@ -3424,8 +3423,8 @@ version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version == '3.14.*'",
-    "python_full_version == '3.13.*' or python_full_version >= '3.15'",
     "python_full_version == '3.12.*'",
+    "python_full_version == '3.13.*' or python_full_version >= '3.15'",
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
@@ -3524,8 +3523,8 @@ version = "2025.2.19"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version == '3.14.*'",
-    "python_full_version == '3.13.*' or python_full_version >= '3.15'",
     "python_full_version == '3.12.*'",
+    "python_full_version == '3.13.*' or python_full_version >= '3.15'",
     "python_full_version == '3.11.*'",
 ]
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -3,8 +3,8 @@ revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version == '3.14.*'",
-    "python_full_version == '3.12.*'",
     "python_full_version == '3.13.*' or python_full_version >= '3.15'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
@@ -33,6 +33,7 @@ constraints = [
     { name = "matplotlib", specifier = ">=3.7.0" },
     { name = "numpy", specifier = ">=1.22.0" },
     { name = "oauthlib", specifier = ">=3.0" },
+    { name = "ops", specifier = ">=2.0.0" },
     { name = "overrides", specifier = ">=7.3" },
     { name = "protobuf", specifier = "<6.33" },
     { name = "protobuf", specifier = ">=5.0" },
@@ -2644,8 +2645,8 @@ version = "2.4.0+ubuntu4"
 source = { registry = "https://people.canonical.com/~lengau/python-apt-ubuntu-wheels/" }
 resolution-markers = [
     "python_full_version == '3.14.*'",
-    "python_full_version == '3.12.*'",
     "python_full_version == '3.13.*' or python_full_version >= '3.15'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
@@ -2689,8 +2690,8 @@ version = "2.7.7+ubuntu5"
 source = { registry = "https://people.canonical.com/~lengau/python-apt-ubuntu-wheels/" }
 resolution-markers = [
     "python_full_version == '3.14.*'",
-    "python_full_version == '3.12.*'",
     "python_full_version == '3.13.*' or python_full_version >= '3.15'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
@@ -2733,8 +2734,8 @@ version = "2.9.9"
 source = { registry = "https://people.canonical.com/~lengau/python-apt-ubuntu-wheels/" }
 resolution-markers = [
     "python_full_version == '3.14.*'",
-    "python_full_version == '3.12.*'",
     "python_full_version == '3.13.*' or python_full_version >= '3.15'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
@@ -2751,8 +2752,8 @@ version = "3.0.0+ubuntu1"
 source = { registry = "https://people.canonical.com/~lengau/python-apt-ubuntu-wheels/" }
 resolution-markers = [
     "python_full_version == '3.14.*'",
-    "python_full_version == '3.12.*'",
     "python_full_version == '3.13.*' or python_full_version >= '3.15'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
@@ -3361,8 +3362,8 @@ version = "2025.8.25"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version == '3.14.*'",
-    "python_full_version == '3.12.*'",
     "python_full_version == '3.13.*' or python_full_version >= '3.15'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
@@ -3423,8 +3424,8 @@ version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version == '3.14.*'",
-    "python_full_version == '3.12.*'",
     "python_full_version == '3.13.*' or python_full_version >= '3.15'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
@@ -3523,8 +3524,8 @@ version = "2025.2.19"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version == '3.14.*'",
-    "python_full_version == '3.12.*'",
     "python_full_version == '3.13.*' or python_full_version >= '3.15'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
 ]
 dependencies = [


### PR DESCRIPTION
## Description

**Part of Stack:**
1. #2840 (`test(store): replace deleted mysql charmlib with operator-libs-linux.apt in store integration tests`)
2. **#2835 (this PR: `fix(plugins): use part_build_subdir for charm source copy`)**
3. #2842 (`chore(deps): update craft-application to ~=7.2 and fix docs build`)
4. #2836 (`feat: opt into git-driven build root via CHARMCRAFT_EXPERIMENTAL_MONOREPO`)

---

Fixes charm source and library copying for `poetry`, `python`, and `uv` plugins when `source-subdir` or a build subdirectory is used.

### Changes:
- In `charmcraft/parts/plugins/_poetry.py`, `_python.py`, and `_uv.py`, pass `self._part_info.part_build_subdir` instead of `self._part_info.part_build_dir` to `utils.get_charm_copy_commands()`.
- Add unit tests in `tests/unit/parts/plugins/test_poetry.py`, `test_python.py`, and `test_uv.py`.
- Add unit tests for `get_charm_copy_commands` in `tests/unit/utils/test_parts.py`.
- Add integration tests for `source-subdir` across `python`, `poetry`, and `uv` plugins in `tests/integration/parts/plugins/`.
- Update `docs/release-notes/charmcraft-4.5.rst` under Fixed bugs and issues referencing #2839.

Fixes #2839
