### PR TITLE
fix(snap): install python3-apt as a stage-package instead of building…

### DIFF
--- a/.github/workflows/policy.yaml
+++ b/.github/workflows/policy.yaml
@@ -36,10 +36,9 @@ jobs:
     if: ${{ needs.filter.outputs.source-files }}
     with:
       packages: python-apt-dev
-      # 1. requirements-noble.txt can't build on jammy
-      # 2. Ignore requirements files in spread tests, as some of these intentionally
+      # 1. Ignore requirements files in spread tests, as some of these intentionally
       #    contain vulnerable versions.
-      # 3. Docs contain requirements.txt files that don't specify versions.
+      # 2. Docs contain requirements.txt files that don't specify versions.
       osv-extra-args: "--config=osv-scanner.toml"
       osv-exclude-paths: |
         docs

--- a/requirements-noble.txt
+++ b/requirements-noble.txt
@@ -1,1 +1,0 @@
-python-apt @ https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/python-apt/2.7.7ubuntu5/python-apt_2.7.7ubuntu5.tar.xz

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -87,8 +87,6 @@ parts:
       - libssl-dev
       # Foreign function integration (libapt, rust deps, etc.)
       - libffi-dev
-      # Allow building python3-apt
-      - libapt-pkg-dev
       # Other bits and pieces
       - libgit2-dev # Needed to build pygit2
       - liblzma-dev # Compression/decompression
@@ -122,8 +120,17 @@ parts:
       - libxslt1.1 # Used by craft-parts's maven plugin.
     build-attributes:
       - enable-patchelf
+  python3-apt:
+    # Distro package providing libapt-pkg bindings, avoiding uv's PEP 625 sdist restriction.
+    plugin: nil
+    build-attributes:
+      - enable-patchelf
+    stage-packages:
+      - python3-apt
+    organize:
+      "usr/lib/python3/dist-packages/*": "lib/python3.12/site-packages/"
   charmcraft:
-    after: [charmcraft-libs, build-deps]
+    after: [charmcraft-libs, build-deps, python3-apt]
     source: .
     plugin: uv
     build-environment:
@@ -133,7 +140,7 @@ parts:
       - UV_NO_BINARY: "true"
       - CRYPTOGRAPHY_OPENSSL_NO_LEGACY: "true"
       - UV_FROZEN: "true"
-      - MAKEOPTS: -j$(nproc --all) # Parallel make jobs for things like python-apt
+      - MAKEOPTS: -j$(nproc --all) # Parallel make jobs for source builds (e.g. cryptography, pygit2)
       - UV_COMPILE_BYTECODE: "true"
       - CLICOLOR_FORCE: "true"
       - RUSTC: rustc-1.91
@@ -142,10 +149,6 @@ parts:
       - enable-patchelf
     override-build: |
       /snap/snapcraft/current/libexec/snapcraft/craftctl default
-
-      # Install python3-apt
-      . $CRAFT_PART_INSTALL/bin/activate
-      uv pip install -r requirements-noble.txt
 
       # No need for this symlink
       rm -f $CRAFT_PART_INSTALL/lib64


### PR DESCRIPTION
… from source (#2818)

* fix(snap): install python3-apt as a stage-package instead of building from source

uv now rejects source distributions with non-PEP 625-compliant filenames (e.g. python-apt's .tar.xz release from Launchpad), which broke the snap build. Since the snap can't use the prebuilt python-apt wheels (they're built for a different environment), install python3-apt as a distro stage-package in the charmcraft-libs part instead, and organize its files into the charmcraft venv's site-packages.



* fix(tests): resolve ruff lint failures in test suite

Fix 4 ruff errors from the lint job:
- PLR0917 (too many positional args) in tests/conftest.py and tests/unit/commands/test_store.py fixtures/tests, resolved by marking excess parameters as keyword-only since pytest injects fixtures by name.
- ISC004 (unparenthesized implicit string concatenation in a list) in tests/unit/parts/plugins/test_charm.py and test_reactive.py, resolved by wrapping the concatenated string in parentheses.



* refactor(snap): move python3-apt to its own part, matching snapcraft's approach

Mirrors canonical/snapcraft#5872: split python3-apt into a dedicated nil-plugin part with a single glob organize rule, rather than stacking it onto charmcraft-libs with per-file organize entries.



---------

Describe your changes.

---

- [ ] I've followed the [contribution guidelines](https://github.com/canonical/charmcraft/blob/main/CONTRIBUTING.md).
- [ ] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
