### PR TITLE
chore(profiles): remove MODEL_SETTINGS from all tox.ini templates

### DIFF
--- a/charmcraft/templates/init-django-framework-26.04/tox.ini.j2
+++ b/charmcraft/templates/init-django-framework-26.04/tox.ini.j2
@@ -20,7 +20,6 @@ set_env =
 pass_env =
     PYTHONPATH
     CHARM_BUILD_DIR
-    MODEL_SETTINGS
 
 [testenv:format]
 description = Apply coding style standards to code

--- a/charmcraft/templates/init-django-framework/tox.ini.j2
+++ b/charmcraft/templates/init-django-framework/tox.ini.j2
@@ -20,7 +20,6 @@ set_env =
 pass_env =
     PYTHONPATH
     CHARM_BUILD_DIR
-    MODEL_SETTINGS
 
 [testenv:format]
 description = Apply coding style standards to code

--- a/charmcraft/templates/init-expressjs-framework-26.04/tox.ini.j2
+++ b/charmcraft/templates/init-expressjs-framework-26.04/tox.ini.j2
@@ -20,7 +20,6 @@ set_env =
 pass_env =
     PYTHONPATH
     CHARM_BUILD_DIR
-    MODEL_SETTINGS
 
 [testenv:format]
 description = Apply coding style standards to code

--- a/charmcraft/templates/init-expressjs-framework/tox.ini.j2
+++ b/charmcraft/templates/init-expressjs-framework/tox.ini.j2
@@ -20,7 +20,6 @@ set_env =
 pass_env =
     PYTHONPATH
     CHARM_BUILD_DIR
-    MODEL_SETTINGS
 
 [testenv:format]
 description = Apply coding style standards to code

--- a/charmcraft/templates/init-fastapi-framework-26.04/tox.ini.j2
+++ b/charmcraft/templates/init-fastapi-framework-26.04/tox.ini.j2
@@ -20,7 +20,6 @@ set_env =
 pass_env =
     PYTHONPATH
     CHARM_BUILD_DIR
-    MODEL_SETTINGS
 
 [testenv:format]
 description = Apply coding style standards to code

--- a/charmcraft/templates/init-fastapi-framework/tox.ini.j2
+++ b/charmcraft/templates/init-fastapi-framework/tox.ini.j2
@@ -20,7 +20,6 @@ set_env =
 pass_env =
     PYTHONPATH
     CHARM_BUILD_DIR
-    MODEL_SETTINGS
 
 [testenv:format]
 description = Apply coding style standards to code

--- a/charmcraft/templates/init-flask-framework-26.04/tox.ini.j2
+++ b/charmcraft/templates/init-flask-framework-26.04/tox.ini.j2
@@ -20,7 +20,6 @@ set_env =
 pass_env =
     PYTHONPATH
     CHARM_BUILD_DIR
-    MODEL_SETTINGS
 
 [testenv:format]
 description = Apply coding style standards to code

--- a/charmcraft/templates/init-flask-framework/tox.ini.j2
+++ b/charmcraft/templates/init-flask-framework/tox.ini.j2
@@ -20,7 +20,6 @@ set_env =
 pass_env =
     PYTHONPATH
     CHARM_BUILD_DIR
-    MODEL_SETTINGS
 
 [testenv:format]
 description = Apply coding style standards to code

--- a/charmcraft/templates/init-go-framework-26.04/tox.ini.j2
+++ b/charmcraft/templates/init-go-framework-26.04/tox.ini.j2
@@ -20,7 +20,6 @@ set_env =
 pass_env =
     PYTHONPATH
     CHARM_BUILD_DIR
-    MODEL_SETTINGS
 
 [testenv:format]
 description = Apply coding style standards to code

--- a/charmcraft/templates/init-go-framework/tox.ini.j2
+++ b/charmcraft/templates/init-go-framework/tox.ini.j2
@@ -20,7 +20,6 @@ set_env =
 pass_env =
     PYTHONPATH
     CHARM_BUILD_DIR
-    MODEL_SETTINGS
 
 [testenv:format]
 description = Apply coding style standards to code

--- a/charmcraft/templates/init-kubernetes/tox.ini.j2
+++ b/charmcraft/templates/init-kubernetes/tox.ini.j2
@@ -20,7 +20,6 @@ set_env =
 pass_env =
     PYTHONPATH
     CHARM_BUILD_DIR
-    MODEL_SETTINGS
 
 [testenv:format]
 description = Apply coding style standards to code

--- a/charmcraft/templates/init-machine/tox.ini.j2
+++ b/charmcraft/templates/init-machine/tox.ini.j2
@@ -20,7 +20,6 @@ set_env =
 pass_env =
     PYTHONPATH
     CHARM_BUILD_DIR
-    MODEL_SETTINGS
 
 [testenv:format]
 description = Apply coding style standards to code

--- a/charmcraft/templates/init-spring-boot-framework-26.04/tox.ini.j2
+++ b/charmcraft/templates/init-spring-boot-framework-26.04/tox.ini.j2
@@ -20,7 +20,6 @@ set_env =
 pass_env =
     PYTHONPATH
     CHARM_BUILD_DIR
-    MODEL_SETTINGS
 
 [testenv:format]
 description = Apply coding style standards to code

--- a/charmcraft/templates/init-spring-boot-framework/tox.ini.j2
+++ b/charmcraft/templates/init-spring-boot-framework/tox.ini.j2
@@ -20,7 +20,6 @@ set_env =
 pass_env =
     PYTHONPATH
     CHARM_BUILD_DIR
-    MODEL_SETTINGS
 
 [testenv:format]
 description = Apply coding style standards to code


### PR DESCRIPTION
This PR removes the `MODEL_SETTINGS` passthrough from `tox.ini` of **all profiles** (normally I only update the `kubernetes` and `machine` profiles). Per https://github.com/canonical/operator/issues/2652, I don't believe there's any value in keeping `MODEL_SETTINGS` around. I don't think we need to mention anything in the Charmcraft release notes.