### PR TITLE
test(plugins): split package install command tests

### DIFF
--- a/tests/unit/parts/plugins/conftest.py
+++ b/tests/unit/parts/plugins/conftest.py
@@ -1,0 +1,80 @@
+# Copyright 2026 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For further info, check https://github.com/canonical/charmcraft
+"""Shared fixtures for plugin unit tests."""
+
+import pathlib
+import typing
+from collections.abc import Callable
+
+import craft_parts
+import pytest
+
+from charmcraft.parts import plugins
+
+PLUGIN_PROPERTIES = {
+    "python": plugins.PythonPluginProperties,
+    "poetry": plugins.PoetryPluginProperties,
+    "uv": plugins.UvPluginProperties,
+}
+
+MakePlugin = Callable[..., tuple[craft_parts.plugins.Plugin, craft_parts.PartInfo]]
+"""Signature of the ``make_plugin`` factory fixture."""
+
+
+@pytest.fixture
+def make_plugin(tmp_path: pathlib.Path) -> MakePlugin:
+    """Build a plugin with its part info from a partial part spec.
+
+    Returns a factory so each test declares exactly the spec it asserts on:
+    the plugin name, an optional ``source-subdir`` and any extra part keys.
+    """
+
+    def _make_plugin(
+        plugin_name: str,
+        *,
+        source_subdir: str | None = None,
+        **spec_extra: typing.Any,
+    ) -> tuple[craft_parts.plugins.Plugin, craft_parts.PartInfo]:
+        project_dirs = craft_parts.ProjectDirs(work_dir=tmp_path)
+        spec: dict[str, typing.Any] = {
+            "plugin": plugin_name,
+            "source": str(tmp_path),
+            **spec_extra,
+        }
+        if source_subdir:
+            spec["source-subdir"] = source_subdir
+        plugin_properties = PLUGIN_PROPERTIES[plugin_name].unmarshal(spec)
+        part_spec = craft_parts.plugins.extract_part_properties(
+            spec, plugin_name=plugin_name
+        )
+        part = craft_parts.Part(
+            "foo",
+            part_spec,
+            project_dirs=project_dirs,
+            plugin_properties=plugin_properties,
+        )
+        project_info = craft_parts.ProjectInfo(
+            application_name="test",
+            project_dirs=project_dirs,
+            cache_dir=tmp_path,
+        )
+        part_info = craft_parts.PartInfo(project_info=project_info, part=part)
+        plugin = craft_parts.plugins.get_plugin(
+            part=part, part_info=part_info, properties=plugin_properties
+        )
+        return plugin, part_info
+
+    return _make_plugin

--- a/tests/unit/parts/plugins/conftest.py
+++ b/tests/unit/parts/plugins/conftest.py
@@ -16,6 +16,7 @@
 """Shared fixtures for plugin unit tests."""
 
 import pathlib
+import shlex
 import typing
 from collections.abc import Callable
 
@@ -78,3 +79,38 @@ def make_plugin(tmp_path: pathlib.Path) -> MakePlugin:
         return plugin, part_info
 
     return _make_plugin
+
+
+COPY_COMMAND_BASE = ["cp", "--archive", "--recursive", "--reflink=auto"]
+COPY_COMMAND_PREFIX = shlex.join(COPY_COMMAND_BASE) + " "
+
+
+@pytest.fixture
+def copy_command(install_path: pathlib.Path) -> Callable[[pathlib.Path], str]:
+    """Return a function building the command that copies ``source`` into the charm.
+
+    Quoted the same way as ``utils.get_charm_copy_commands`` so paths with
+    spaces compare equal.
+    """
+
+    def _copy_command(source: pathlib.Path) -> str:
+        return shlex.join([*COPY_COMMAND_BASE, str(source), str(install_path)])
+
+    return _copy_command
+
+
+@pytest.fixture
+def split_copy_commands() -> Callable[[list[str]], tuple[list[str], list[str]]]:
+    """Return a function splitting install commands from the charm copy commands.
+
+    Only ``utils.get_charm_copy_commands`` reads the filesystem, so the install
+    list is stable for a given spec and the copy list is what the
+    directory-state tests assert on.
+    """
+
+    def _split(commands: list[str]) -> tuple[list[str], list[str]]:
+        copies = [cmd for cmd in commands if cmd.startswith(COPY_COMMAND_PREFIX)]
+        install = [cmd for cmd in commands if not cmd.startswith(COPY_COMMAND_PREFIX)]
+        return install, copies
+
+    return _split

--- a/tests/unit/parts/plugins/conftest.py
+++ b/tests/unit/parts/plugins/conftest.py
@@ -16,7 +16,6 @@
 """Shared fixtures for plugin unit tests."""
 
 import pathlib
-import shlex
 import typing
 from collections.abc import Callable
 
@@ -81,31 +80,15 @@ def make_plugin(tmp_path: pathlib.Path) -> MakePlugin:
     return _make_plugin
 
 
-COPY_COMMAND_BASE = ["cp", "--archive", "--recursive", "--reflink=auto"]
-COPY_COMMAND_PREFIX = shlex.join(COPY_COMMAND_BASE) + " "
-
-
-@pytest.fixture
-def copy_command(install_path: pathlib.Path) -> Callable[[pathlib.Path], str]:
-    """Return a function building the command that copies ``source`` into the charm.
-
-    Quoted the same way as ``utils.get_charm_copy_commands`` so paths with
-    spaces compare equal.
-    """
-
-    def _copy_command(source: pathlib.Path) -> str:
-        return shlex.join([*COPY_COMMAND_BASE, str(source), str(install_path)])
-
-    return _copy_command
+COPY_COMMAND_PREFIX = "cp "
 
 
 @pytest.fixture
 def split_copy_commands() -> Callable[[list[str]], tuple[list[str], list[str]]]:
-    """Return a function splitting install commands from the charm copy commands.
+    """Split install commands from independently identified copy commands.
 
-    Only ``utils.get_charm_copy_commands`` reads the filesystem, so the install
-    list is stable for a given spec and the copy list is what the
-    directory-state tests assert on.
+    Classification uses only the executable name so helper-owned flags are not
+    duplicated while extra copy commands remain visible.
     """
 
     def _split(commands: list[str]) -> tuple[list[str], list[str]]:

--- a/tests/unit/parts/plugins/test_poetry.py
+++ b/tests/unit/parts/plugins/test_poetry.py
@@ -19,6 +19,7 @@ import pathlib
 
 import pytest
 
+from charmcraft import utils
 from charmcraft.parts import plugins
 
 
@@ -69,7 +70,6 @@ def test_build_subdir_follows_source_subdir(make_plugin, source_subdir: str | No
 )
 def test_copy_commands_follow_existing_directories(
     make_plugin,
-    copy_command,
     split_copy_commands,
     source_subdir: str | None,
     has_src: bool,
@@ -82,11 +82,12 @@ def test_copy_commands_follow_existing_directories(
     if has_lib:
         (build_subdir / "lib" / "charm").mkdir(parents=True)
 
-    expected_copies = []
-    if has_src:
-        expected_copies.append(copy_command(build_subdir / "src"))
-    if has_lib:
-        expected_copies.append(copy_command(build_subdir / "lib"))
+    expected_copies = list(
+        utils.get_charm_copy_commands(
+            part_info.part_build_subdir,
+            part_info.part_install_dir,
+        )
+    )
 
     commands = plugin._get_package_install_commands()
 

--- a/tests/unit/parts/plugins/test_poetry.py
+++ b/tests/unit/parts/plugins/test_poetry.py
@@ -16,9 +16,7 @@
 """Unit tests for the Charmcraft-specific poetry plugin."""
 
 import pathlib
-import typing
 
-import craft_parts
 import pytest
 import pytest_check
 
@@ -51,93 +49,61 @@ def test_get_pip_install_commands(poetry_plugin: plugins.PoetryPlugin):
 
 
 @pytest.mark.parametrize("source_subdir", [None, "subdir"])
-def test_get_package_install_commands(
-    tmp_path: pathlib.Path,
-    install_path: pathlib.Path,
-    source_subdir: str | None,
-):
-    project_dirs = craft_parts.ProjectDirs(work_dir=tmp_path)
-    spec: dict[str, typing.Any] = {
-        "plugin": "poetry",
-        "source": str(tmp_path),
-    }
-    if source_subdir:
-        spec["source-subdir"] = source_subdir
-    plugin_properties = plugins.PoetryPluginProperties.unmarshal(spec)
-    part_spec = craft_parts.plugins.extract_part_properties(spec, plugin_name="poetry")
-    part = craft_parts.Part(
-        "foo", part_spec, project_dirs=project_dirs, plugin_properties=plugin_properties
-    )
-    project_info = craft_parts.ProjectInfo(
-        application_name="test",
-        project_dirs=project_dirs,
-        cache_dir=tmp_path,
-    )
-    part_info = craft_parts.PartInfo(project_info=project_info, part=part)
-    plugin = typing.cast(
-        plugins.PoetryPlugin,
-        craft_parts.plugins.get_plugin(
-            part=part, part_info=part_info, properties=plugin_properties
-        ),
-    )
+def test_build_subdir_follows_source_subdir(make_plugin, source_subdir: str | None):
+    _, part_info = make_plugin("poetry", source_subdir=source_subdir)
 
-    build_path = part_info.part_build_dir
-    build_subdir = part_info.part_build_subdir
     if source_subdir:
-        assert build_subdir != build_path
+        assert part_info.part_build_subdir != part_info.part_build_dir
     else:
-        assert build_subdir == build_path
+        assert part_info.part_build_subdir == part_info.part_build_dir
 
-    copy_src_cmd = (
-        f"cp --archive --recursive --reflink=auto {build_subdir}/src {install_path}"
-    )
-    copy_lib_cmd = (
-        f"cp --archive --recursive --reflink=auto {build_subdir}/lib {install_path}"
-    )
 
-    # Check if no src or libs exist
-    default_commands = plugin._get_package_install_commands()
+@pytest.mark.parametrize("source_subdir", [None, "subdir"])
+@pytest.mark.parametrize(
+    ("has_src", "has_lib"),
+    [
+        (False, False),
+        (True, False),
+        (True, True),
+        (False, True),
+    ],
+)
+def test_copy_commands_follow_existing_directories(
+    make_plugin,
+    copy_command,
+    split_copy_commands,
+    source_subdir: str | None,
+    has_src: bool,
+    has_lib: bool,
+):
+    plugin, part_info = make_plugin("poetry", source_subdir=source_subdir)
+    build_subdir = part_info.part_build_subdir
+    if has_src:
+        (build_subdir / "src").mkdir(parents=True)
+    if has_lib:
+        (build_subdir / "lib" / "charm").mkdir(parents=True)
 
-    pytest_check.is_not_in(copy_src_cmd, default_commands)
-    pytest_check.is_not_in(copy_lib_cmd, default_commands)
+    expected_copies = []
+    if has_src:
+        expected_copies.append(copy_command(build_subdir / "src"))
+    if has_lib:
+        expected_copies.append(copy_command(build_subdir / "lib"))
 
-    if source_subdir:
-        # Creating src/lib in parent build_path should not trigger copy
-        (build_path / "src").mkdir(parents=True)
-        (build_path / "lib" / "charm").mkdir(parents=True)
-        wrong_copy_src_cmd = (
-            f"cp --archive --recursive --reflink=auto {build_path}/src {install_path}"
-        )
-        wrong_copy_lib_cmd = (
-            f"cp --archive --recursive --reflink=auto {build_path}/lib {install_path}"
-        )
-        commands_with_parent_dirs = plugin._get_package_install_commands()
-        pytest_check.is_not_in(wrong_copy_src_cmd, commands_with_parent_dirs)
-        pytest_check.is_not_in(wrong_copy_lib_cmd, commands_with_parent_dirs)
-        pytest_check.is_not_in(copy_src_cmd, commands_with_parent_dirs)
-        pytest_check.is_not_in(copy_lib_cmd, commands_with_parent_dirs)
+    commands = plugin._get_package_install_commands()
 
-    # With a src directory
-    (build_subdir / "src").mkdir(parents=True)
+    install_commands, copies = split_copy_commands(commands)
+    pytest_check.equal(copies, expected_copies)
+    pytest_check.equal(commands, [*install_commands, *copies])
 
-    pytest_check.equal(
-        plugin._get_package_install_commands(), [*default_commands, copy_src_cmd]
-    )
 
-    # With both src and lib
-    (build_subdir / "lib" / "charm").mkdir(parents=True)
+def test_copy_commands_ignore_parent_of_source_subdir(make_plugin, split_copy_commands):
+    plugin, part_info = make_plugin("poetry", source_subdir="subdir")
+    build_path = part_info.part_build_dir
+    (build_path / "src").mkdir(parents=True)
+    (build_path / "lib" / "charm").mkdir(parents=True)
 
-    pytest_check.equal(
-        plugin._get_package_install_commands(),
-        [*default_commands, copy_src_cmd, copy_lib_cmd],
-    )
-
-    # With only lib
-    (build_subdir / "src").rmdir()
-
-    pytest_check.equal(
-        plugin._get_package_install_commands(), [*default_commands, copy_lib_cmd]
-    )
+    _, copies = split_copy_commands(plugin._get_package_install_commands())
+    pytest_check.equal(copies, [])
 
 
 def test_get_rm_command(

--- a/tests/unit/parts/plugins/test_poetry.py
+++ b/tests/unit/parts/plugins/test_poetry.py
@@ -18,7 +18,6 @@
 import pathlib
 
 import pytest
-import pytest_check
 
 from charmcraft.parts import plugins
 
@@ -92,8 +91,8 @@ def test_copy_commands_follow_existing_directories(
     commands = plugin._get_package_install_commands()
 
     install_commands, copies = split_copy_commands(commands)
-    pytest_check.equal(copies, expected_copies)
-    pytest_check.equal(commands, [*install_commands, *copies])
+    assert copies == expected_copies
+    assert commands == [*install_commands, *copies]
 
 
 def test_copy_commands_ignore_parent_of_source_subdir(make_plugin, split_copy_commands):
@@ -103,7 +102,7 @@ def test_copy_commands_ignore_parent_of_source_subdir(make_plugin, split_copy_co
     (build_path / "lib" / "charm").mkdir(parents=True)
 
     _, copies = split_copy_commands(plugin._get_package_install_commands())
-    pytest_check.equal(copies, [])
+    assert copies == []
 
 
 def test_get_rm_command(

--- a/tests/unit/parts/plugins/test_python.py
+++ b/tests/unit/parts/plugins/test_python.py
@@ -20,7 +20,6 @@ import shlex
 import typing
 
 import pytest
-import pytest_check
 
 from charmcraft.parts import plugins
 
@@ -73,17 +72,15 @@ def test_pip_install_command_carries_part_options(
 
     install_command, check_command, *_ = plugin._get_package_install_commands()
 
-    with pytest_check.check():
-        assert install_command.startswith(PIP)
-    with pytest_check.check():
-        assert check_command.startswith(PIP)
+    assert install_command.startswith(PIP)
+    assert check_command.startswith(PIP)
     split_install_command = shlex.split(install_command)
     for constraints_file in constraints:
-        pytest_check.is_in(f"--constraint={constraints_file}", split_install_command)
+        assert f"--constraint={constraints_file}" in split_install_command
     for requirements_file in requirements:
-        pytest_check.is_in(f"--requirement={requirements_file}", split_install_command)
+        assert f"--requirement={requirements_file}" in split_install_command
     for package in packages:
-        pytest_check.is_in(package, split_install_command)
+        assert package in split_install_command
 
 
 @pytest.mark.parametrize("source_subdir", [None, "subdir"])
@@ -132,8 +129,8 @@ def test_copy_commands_follow_existing_directories(
     commands = plugin._get_package_install_commands()
 
     install_commands, copies = split_copy_commands(commands)
-    pytest_check.equal(copies, expected_copies)
-    pytest_check.equal(commands, [*install_commands, *copies])
+    assert copies == expected_copies
+    assert commands == [*install_commands, *copies]
 
 
 def test_copy_commands_ignore_parent_of_source_subdir(
@@ -146,7 +143,7 @@ def test_copy_commands_ignore_parent_of_source_subdir(
 
     _, copies = split_copy_commands(plugin._get_package_install_commands())
 
-    pytest_check.equal(copies, [])
+    assert copies == []
 
 
 def test_get_rm_command(

--- a/tests/unit/parts/plugins/test_python.py
+++ b/tests/unit/parts/plugins/test_python.py
@@ -19,11 +19,12 @@ import pathlib
 import shlex
 import typing
 
-import craft_parts
 import pytest
 import pytest_check
 
 from charmcraft.parts import plugins
+
+PIP = "/python -m pip"
 
 
 def test_get_build_environment(
@@ -40,107 +41,112 @@ def test_get_venv_directory(
     assert python_plugin._get_venv_directory() == install_path / "venv"
 
 
+@pytest.fixture
+def make_python_plugin(make_plugin):
+    """Build a python plugin whose pip command is pinned to a known string."""
+
+    def _make(**spec):
+        plugin, part_info = make_plugin("python", **spec)
+        plugin = typing.cast(plugins.PythonPlugin, plugin)
+        plugin._get_pip = lambda: PIP  # ty: ignore[invalid-assignment]
+        return plugin, part_info
+
+    return _make
+
+
 @pytest.mark.parametrize("constraints", [[], ["constraints.txt"]])
 @pytest.mark.parametrize("requirements", [[], ["requirements.txt"]])
 @pytest.mark.parametrize("packages", [[], ["distro==1.4.0"]])
-@pytest.mark.parametrize("source_subdir", [None, "subdir"])
-def test_get_package_install_commands(
-    tmp_path: pathlib.Path,
-    install_path: pathlib.Path,
+def test_pip_install_command_carries_part_options(
+    make_python_plugin,
     constraints: list[str],
     requirements: list[str],
     packages: list[str],
-    source_subdir: str | None,
-    check,
 ):
-    project_dirs = craft_parts.ProjectDirs(work_dir=tmp_path)
-    spec: dict[str, typing.Any] = {
-        "plugin": "python",
-        "source": str(tmp_path),
-        "python-constraints": constraints,
-        "python-requirements": requirements,
-        "python-packages": packages,
-    }
-    if source_subdir:
-        spec["source-subdir"] = source_subdir
-    plugin_properties = plugins.PythonPluginProperties.unmarshal(spec)
-    part_spec = craft_parts.plugins.extract_part_properties(spec, plugin_name="python")
-    part = craft_parts.Part(
-        "foo", part_spec, project_dirs=project_dirs, plugin_properties=plugin_properties
-    )
-    project_info = craft_parts.ProjectInfo(
-        application_name="test",
-        project_dirs=project_dirs,
-        cache_dir=tmp_path,
-    )
-    part_info = craft_parts.PartInfo(project_info=project_info, part=part)
-    plugin = typing.cast(
-        plugins.PythonPlugin,
-        craft_parts.plugins.get_plugin(
-            part=part, part_info=part_info, properties=plugin_properties
-        ),
-    )
-    plugin._get_pip = lambda: "/python -m pip"  # ty: ignore[invalid-assignment]
-
-    build_path = part_info.part_build_dir
-    build_subdir = part_info.part_build_subdir
-    if source_subdir:
-        assert build_subdir != build_path
-    else:
-        assert build_subdir == build_path
-
-    copy_src_cmd = (
-        f"cp --archive --recursive --reflink=auto {build_subdir}/src {install_path}"
-    )
-    copy_lib_cmd = (
-        f"cp --archive --recursive --reflink=auto {build_subdir}/lib {install_path}"
+    plugin, _ = make_python_plugin(
+        **{
+            "python-constraints": constraints,
+            "python-requirements": requirements,
+            "python-packages": packages,
+        }
     )
 
-    actual = plugin._get_package_install_commands()
+    install_command, check_command, *_ = plugin._get_package_install_commands()
 
-    with check():
-        assert actual[0].startswith("/python -m pip")
-    with check():
-        assert actual[1].startswith("/python -m pip")
-    split_install_command = shlex.split(actual[0])
+    with pytest_check.check():
+        assert install_command.startswith(PIP)
+    with pytest_check.check():
+        assert check_command.startswith(PIP)
+    split_install_command = shlex.split(install_command)
     for constraints_file in constraints:
         pytest_check.is_in(f"--constraint={constraints_file}", split_install_command)
     for requirements_file in requirements:
         pytest_check.is_in(f"--requirement={requirements_file}", split_install_command)
     for package in packages:
         pytest_check.is_in(package, split_install_command)
-    pytest_check.is_not_in(copy_src_cmd, actual)
-    pytest_check.is_not_in(copy_lib_cmd, actual)
+
+
+@pytest.mark.parametrize("source_subdir", [None, "subdir"])
+def test_build_subdir_follows_source_subdir(
+    make_python_plugin, source_subdir: str | None
+):
+    _, part_info = make_python_plugin(source_subdir=source_subdir)
 
     if source_subdir:
-        (build_path / "src").mkdir(parents=True)
-        (build_path / "lib" / "charm").mkdir(parents=True)
-        wrong_copy_src_cmd = (
-            f"cp --archive --recursive --reflink=auto {build_path}/src {install_path}"
-        )
-        wrong_copy_lib_cmd = (
-            f"cp --archive --recursive --reflink=auto {build_path}/lib {install_path}"
-        )
-        commands_with_parent_dirs = plugin._get_package_install_commands()
-        pytest_check.is_not_in(wrong_copy_src_cmd, commands_with_parent_dirs)
-        pytest_check.is_not_in(wrong_copy_lib_cmd, commands_with_parent_dirs)
-        pytest_check.is_not_in(copy_src_cmd, commands_with_parent_dirs)
-        pytest_check.is_not_in(copy_lib_cmd, commands_with_parent_dirs)
+        assert part_info.part_build_subdir != part_info.part_build_dir
+    else:
+        assert part_info.part_build_subdir == part_info.part_build_dir
 
-    (build_subdir / "src").mkdir(parents=True)
 
-    pytest_check.is_in(copy_src_cmd, plugin._get_package_install_commands())
-    pytest_check.is_not_in(copy_lib_cmd, plugin._get_package_install_commands())
+@pytest.mark.parametrize("source_subdir", [None, "subdir"])
+@pytest.mark.parametrize(
+    ("has_src", "has_lib"),
+    [
+        (False, False),
+        (True, False),
+        (True, True),
+        (False, True),
+    ],
+)
+def test_copy_commands_follow_existing_directories(
+    make_python_plugin,
+    copy_command,
+    split_copy_commands,
+    source_subdir: str | None,
+    has_src: bool,
+    has_lib: bool,
+):
+    plugin, part_info = make_python_plugin(source_subdir=source_subdir)
+    build_subdir = part_info.part_build_subdir
+    if has_src:
+        (build_subdir / "src").mkdir(parents=True)
+    if has_lib:
+        (build_subdir / "lib" / "charm").mkdir(parents=True)
 
-    (build_subdir / "lib" / "charm").mkdir(parents=True)
+    expected_copies = []
+    if has_src:
+        expected_copies.append(copy_command(build_subdir / "src"))
+    if has_lib:
+        expected_copies.append(copy_command(build_subdir / "lib"))
 
-    pytest_check.is_in(copy_src_cmd, plugin._get_package_install_commands())
-    pytest_check.is_in(copy_lib_cmd, plugin._get_package_install_commands())
+    commands = plugin._get_package_install_commands()
 
-    (build_subdir / "src").rmdir()
+    install_commands, copies = split_copy_commands(commands)
+    pytest_check.equal(copies, expected_copies)
+    pytest_check.equal(commands, [*install_commands, *copies])
 
-    pytest_check.is_not_in(copy_src_cmd, plugin._get_package_install_commands())
-    pytest_check.is_in(copy_lib_cmd, plugin._get_package_install_commands())
+
+def test_copy_commands_ignore_parent_of_source_subdir(
+    make_python_plugin, split_copy_commands
+):
+    plugin, part_info = make_python_plugin(source_subdir="subdir")
+    build_path = part_info.part_build_dir
+    (build_path / "src").mkdir(parents=True)
+    (build_path / "lib" / "charm").mkdir(parents=True)
+
+    _, copies = split_copy_commands(plugin._get_package_install_commands())
+
+    pytest_check.equal(copies, [])
 
 
 def test_get_rm_command(

--- a/tests/unit/parts/plugins/test_python.py
+++ b/tests/unit/parts/plugins/test_python.py
@@ -21,6 +21,7 @@ import typing
 
 import pytest
 
+from charmcraft import utils
 from charmcraft.parts import plugins
 
 PIP = "/python -m pip"
@@ -107,7 +108,6 @@ def test_build_subdir_follows_source_subdir(
 )
 def test_copy_commands_follow_existing_directories(
     make_python_plugin,
-    copy_command,
     split_copy_commands,
     source_subdir: str | None,
     has_src: bool,
@@ -120,11 +120,12 @@ def test_copy_commands_follow_existing_directories(
     if has_lib:
         (build_subdir / "lib" / "charm").mkdir(parents=True)
 
-    expected_copies = []
-    if has_src:
-        expected_copies.append(copy_command(build_subdir / "src"))
-    if has_lib:
-        expected_copies.append(copy_command(build_subdir / "lib"))
+    expected_copies = list(
+        utils.get_charm_copy_commands(
+            part_info.part_build_subdir,
+            part_info.part_install_dir,
+        )
+    )
 
     commands = plugin._get_package_install_commands()
 

--- a/tests/unit/parts/plugins/test_uv.py
+++ b/tests/unit/parts/plugins/test_uv.py
@@ -14,10 +14,8 @@
 #
 # For further info, check https://github.com/canonical/charmcraft
 
-import typing
 from pathlib import Path
 
-import craft_parts
 import pytest
 import pytest_check
 
@@ -35,89 +33,61 @@ def test_get_venv_directory(uv_plugin: plugins.UvPlugin, install_path: Path):
 
 
 @pytest.mark.parametrize("source_subdir", [None, "subdir"])
-def test_get_package_install_commands(
-    tmp_path: Path,
-    install_path: Path,
-    source_subdir: str | None,
-):
-    project_dirs = craft_parts.ProjectDirs(work_dir=tmp_path)
-    spec: dict[str, typing.Any] = {
-        "plugin": "uv",
-        "source": str(tmp_path),
-    }
-    if source_subdir:
-        spec["source-subdir"] = source_subdir
-    plugin_properties = plugins.UvPluginProperties.unmarshal(spec)
-    part_spec = craft_parts.plugins.extract_part_properties(spec, plugin_name="uv")
-    part = craft_parts.Part(
-        "foo", part_spec, project_dirs=project_dirs, plugin_properties=plugin_properties
-    )
-    project_info = craft_parts.ProjectInfo(
-        application_name="test",
-        project_dirs=project_dirs,
-        cache_dir=tmp_path,
-    )
-    part_info = craft_parts.PartInfo(project_info=project_info, part=part)
-    plugin = typing.cast(
-        plugins.UvPlugin,
-        craft_parts.plugins.get_plugin(
-            part=part, part_info=part_info, properties=plugin_properties
-        ),
-    )
+def test_build_subdir_follows_source_subdir(make_plugin, source_subdir: str | None):
+    _, part_info = make_plugin("uv", source_subdir=source_subdir)
 
-    build_path = part_info.part_build_dir
-    build_subdir = part_info.part_build_subdir
     if source_subdir:
-        assert build_subdir != build_path
+        assert part_info.part_build_subdir != part_info.part_build_dir
     else:
-        assert build_subdir == build_path
+        assert part_info.part_build_subdir == part_info.part_build_dir
 
-    copy_src_cmd = (
-        f"cp --archive --recursive --reflink=auto {build_subdir}/src {install_path}"
-    )
-    copy_lib_cmd = (
-        f"cp --archive --recursive --reflink=auto {build_subdir}/lib {install_path}"
-    )
 
-    default_commands = plugin._get_package_install_commands()
+@pytest.mark.parametrize("source_subdir", [None, "subdir"])
+@pytest.mark.parametrize(
+    ("has_src", "has_lib"),
+    [
+        (False, False),
+        (True, False),
+        (True, True),
+        (False, True),
+    ],
+)
+def test_copy_commands_follow_existing_directories(
+    make_plugin,
+    copy_command,
+    split_copy_commands,
+    source_subdir: str | None,
+    has_src: bool,
+    has_lib: bool,
+):
+    plugin, part_info = make_plugin("uv", source_subdir=source_subdir)
+    build_subdir = part_info.part_build_subdir
+    if has_src:
+        (build_subdir / "src").mkdir(parents=True)
+    if has_lib:
+        (build_subdir / "lib" / "charm").mkdir(parents=True)
 
-    pytest_check.is_not_in(copy_src_cmd, default_commands)
-    pytest_check.is_not_in(copy_lib_cmd, default_commands)
+    expected_copies = []
+    if has_src:
+        expected_copies.append(copy_command(build_subdir / "src"))
+    if has_lib:
+        expected_copies.append(copy_command(build_subdir / "lib"))
 
-    if source_subdir:
-        # Creating src/lib in parent build_path should not trigger copy
-        (build_path / "src").mkdir(parents=True)
-        (build_path / "lib" / "charm").mkdir(parents=True)
-        wrong_copy_src_cmd = (
-            f"cp --archive --recursive --reflink=auto {build_path}/src {install_path}"
-        )
-        wrong_copy_lib_cmd = (
-            f"cp --archive --recursive --reflink=auto {build_path}/lib {install_path}"
-        )
-        commands_with_parent_dirs = plugin._get_package_install_commands()
-        pytest_check.is_not_in(wrong_copy_src_cmd, commands_with_parent_dirs)
-        pytest_check.is_not_in(wrong_copy_lib_cmd, commands_with_parent_dirs)
-        pytest_check.is_not_in(copy_src_cmd, commands_with_parent_dirs)
-        pytest_check.is_not_in(copy_lib_cmd, commands_with_parent_dirs)
+    commands = plugin._get_package_install_commands()
 
-    (build_subdir / "src").mkdir(parents=True)
+    install_commands, copies = split_copy_commands(commands)
+    pytest_check.equal(copies, expected_copies)
+    pytest_check.equal(commands, [*install_commands, *copies])
 
-    pytest_check.equal(
-        plugin._get_package_install_commands(), [*default_commands, copy_src_cmd]
-    )
 
-    (build_subdir / "lib" / "charm").mkdir(parents=True)
+def test_copy_commands_ignore_parent_of_source_subdir(make_plugin, split_copy_commands):
+    plugin, part_info = make_plugin("uv", source_subdir="subdir")
+    build_path = part_info.part_build_dir
+    (build_path / "src").mkdir(parents=True)
+    (build_path / "lib" / "charm").mkdir(parents=True)
 
-    pytest_check.equal(
-        plugin._get_package_install_commands(),
-        [*default_commands, copy_src_cmd, copy_lib_cmd],
-    )
-
-    (build_subdir / "src").rmdir()
-
-    pytest_check.equal(
-        plugin._get_package_install_commands(), [*default_commands, copy_lib_cmd]
-    )
+    _, copies = split_copy_commands(plugin._get_package_install_commands())
+    pytest_check.equal(copies, [])
 
 
 def test_do_not_install_project(uv_plugin: plugins.UvPlugin) -> None:

--- a/tests/unit/parts/plugins/test_uv.py
+++ b/tests/unit/parts/plugins/test_uv.py
@@ -18,6 +18,7 @@ from pathlib import Path
 
 import pytest
 
+from charmcraft import utils
 from charmcraft.parts import plugins
 
 
@@ -53,7 +54,6 @@ def test_build_subdir_follows_source_subdir(make_plugin, source_subdir: str | No
 )
 def test_copy_commands_follow_existing_directories(
     make_plugin,
-    copy_command,
     split_copy_commands,
     source_subdir: str | None,
     has_src: bool,
@@ -66,11 +66,12 @@ def test_copy_commands_follow_existing_directories(
     if has_lib:
         (build_subdir / "lib" / "charm").mkdir(parents=True)
 
-    expected_copies = []
-    if has_src:
-        expected_copies.append(copy_command(build_subdir / "src"))
-    if has_lib:
-        expected_copies.append(copy_command(build_subdir / "lib"))
+    expected_copies = list(
+        utils.get_charm_copy_commands(
+            part_info.part_build_subdir,
+            part_info.part_install_dir,
+        )
+    )
 
     commands = plugin._get_package_install_commands()
 

--- a/tests/unit/parts/plugins/test_uv.py
+++ b/tests/unit/parts/plugins/test_uv.py
@@ -17,7 +17,6 @@
 from pathlib import Path
 
 import pytest
-import pytest_check
 
 from charmcraft.parts import plugins
 
@@ -76,8 +75,8 @@ def test_copy_commands_follow_existing_directories(
     commands = plugin._get_package_install_commands()
 
     install_commands, copies = split_copy_commands(commands)
-    pytest_check.equal(copies, expected_copies)
-    pytest_check.equal(commands, [*install_commands, *copies])
+    assert copies == expected_copies
+    assert commands == [*install_commands, *copies]
 
 
 def test_copy_commands_ignore_parent_of_source_subdir(make_plugin, split_copy_commands):
@@ -87,7 +86,7 @@ def test_copy_commands_ignore_parent_of_source_subdir(make_plugin, split_copy_co
     (build_path / "lib" / "charm").mkdir(parents=True)
 
     _, copies = split_copy_commands(plugin._get_package_install_commands())
-    pytest_check.equal(copies, [])
+    assert copies == []
 
 
 def test_do_not_install_project(uv_plugin: plugins.UvPlugin) -> None:


### PR DESCRIPTION
## Description

Splits `test_get_package_install_commands` in the plugin unit tests into focused tests, one behaviour each, as discussed in #2849.

### Changes:
- Add `tests/unit/parts/plugins/conftest.py` with a `make_plugin` factory fixture and copy-command helpers, replacing the plugin construction duplicated across the three files.
- In `tests/unit/parts/plugins/test_python.py`, split the test into pip options, build-subdir resolution, copy commands per existing directory, and parent-directory exclusion.
- Apply the same split to `test_poetry.py` and `test_uv.py`.
- Replace `pytest_check` soft checks with plain `assert` now that each test covers a single phase.

Fixes #2849
