### PR TITLE
chore: remove prime key deprecation warning

### DIFF
--- a/charmcraft/application/main.py
+++ b/charmcraft/application/main.py
@@ -51,14 +51,6 @@ APP_METADATA = craft_application.AppMetadata(
     allow_git_build_root=True,
 )
 
-PRIME_BEHAVIOUR_CHANGE_MESSAGE = (
-    "IMPORTANT: The behaviour of the 'prime' keyword has changed in Charmcraft 3. This "
-    "keyword will no longer add files that would otherwise be excluded from the "
-    "charm, instead filtering existing files. Additional files may be added using the "
-    "'dump' plugin.\n"
-    "To include extra files, see: https://juju.is/docs/sdk/include-extra-files-in-a-charm"
-)
-
 
 class Charmcraft(craft_application.Application):
     """Charmcraft application definition."""
@@ -77,22 +69,6 @@ class Charmcraft(craft_application.Application):
     def command_groups(self) -> list[craft_cli.CommandGroup]:
         """Return command groups."""
         return self._command_groups
-
-    def _check_deprecated(self, yaml_data: dict[str, Any]) -> None:
-        """Check for deprecated fields in the yaml_data."""
-        # We only need to warn people once.
-        if self.is_managed():
-            return
-        has_primed_part = False
-        if "parts" in yaml_data:
-            prime_changed_extensions = {"charm", "reactive"}
-            for name, part in yaml_data["parts"].items():
-                if not {name, part.get("plugin", None)} & prime_changed_extensions:
-                    continue
-                if "prime" in part:
-                    has_primed_part = True
-        if has_primed_part:
-            craft_cli.emit.progress(PRIME_BEHAVIOUR_CHANGE_MESSAGE, permanent=True)
 
     def _configure_services(self, provider_name: str | None) -> None:
         super()._configure_services(provider_name)


### PR DESCRIPTION
From the issue description: "By 2026 this should have been sufficient time
that the warning is no longer necessary."

Fixes #1786
---

- [ ] I've followed the [contribution guidelines](https://github.com/canonical/charmcraft/blob/main/CONTRIBUTING.md).
- [ ] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
