### PR TITLE
chore: remove live logging from pytest configs in k8s and machine profiles

### DIFF
--- a/charmcraft/templates/init-kubernetes/pyproject.toml.j2
+++ b/charmcraft/templates/init-kubernetes/pyproject.toml.j2
@@ -46,8 +46,6 @@ show_missing = true
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-log_cli = true
-log_cli_level = "INFO"
 log_cli_format = "%(levelname)s %(name)s %(message)s"
 filterwarnings = ["error"]
 

--- a/charmcraft/templates/init-machine/pyproject.toml.j2
+++ b/charmcraft/templates/init-machine/pyproject.toml.j2
@@ -45,8 +45,6 @@ show_missing = true
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-log_cli = true
-log_cli_level = "INFO"
 log_cli_format = "%(levelname)s %(name)s %(message)s"
 filterwarnings = ["error"]
 


### PR DESCRIPTION
This PR removes `log_cli_level` and `log_cli` from `[tool.pytest.ini_options]` in `pyproject.toml` for the `kubernetes` and `machine` init profiles.

**Removing `log_cli`**

This change follows the fixes in canonical/operator#2654. Setting `log_cli = true` in `pyproject.toml` causes live logging to appear in **tox -e unit** as a side effect:

```
tests/unit/test_charm.py::test_two
------------------------- live log call -------------------------
ERROR <error_level_message>
PASSED
```

**Removing `log_cli_level`**

`tox -e unit` and `tox -e integration` both don't need `log_cli_level` in `pyproject.toml`:
- `[testenv:integration]` already has `--log-cli-level=INFO` in the CLI command
- `[testenv:unit]` doesn't need `log_cli_level=INFO`, and should just rely on the default level `WARNING`.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/charmcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
