### PR TITLE
chore: update renovate rules around 12-factor Spread test materials- #1353

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -38,5 +38,5 @@
       datasourceTemplate: "maven",
       depNameTemplate: "org.springframework.boot:spring-boot-starter-parent",
     },
-  ],  
+  ],
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,4 +1,42 @@
 {
   extends: ["github>canonical/starflow:renovate.json5"],
-  ignorePaths: ["docs/**", "tests/**"],
+  ignorePaths: ["docs/requirements.txt", "tests/**"],
+
+  packageRules: [
+    // Major bumps for tutorial deps must be reviewed/updated manually
+    // (tutorial prose, screenshots and Spread tests may need matching edits).
+    {
+      matchFileNames: ["docs/tutorial/code/**"],
+      matchUpdateTypes: ["major"],
+      enabled: false,
+    },
+    // Lump all minor/patch bumps for tutorial deps into a single PR.
+    {
+      matchFileNames: ["docs/tutorial/code/**"],
+      matchUpdateTypes: ["minor", "patch"],
+      groupName: "docs tutorial Spread dependencies (non-major)",
+      commitMessagePrefix: "docs(build-deps): ",
+    },
+  ],
+
+  customManagers: [
+    // `sudo npm install -g express-generator@<version>` in the ExpressJS Spread task.
+    {
+      customType: "regex",
+      managerFilePatterns: ["/^docs/tutorial/code/expressjs/task\\.yaml$/"],
+      matchStrings: ["express-generator@(?<currentValue>\\S+)"],
+      datasourceTemplate: "npm",
+      depNameTemplate: "express-generator",
+    },
+    // `--boot-version <version>` passed to `devpack-for-spring boot start` in the
+    // Spring Boot Spread task. Renovate has no start.spring.io datasource, so
+    // track spring-boot-starter-parent on Maven Central (identical version stream).
+    {
+      customType: "regex",
+      managerFilePatterns: ["/^docs/tutorial/code/spring-boot/task\\.yaml$/"],
+      matchStrings: ["--boot-version (?<currentValue>\\S+)"],
+      datasourceTemplate: "maven",
+      depNameTemplate: "org.springframework.boot:spring-boot-starter-parent",
+    },
+  ],  
 }


### PR DESCRIPTION
This PR updates `renovate.json5` to manage the version updates for the 12-factor documentation Spread tests. This PR was prepared using AI assistance. 

I used the following policy as a starting place for the updates:
1. Ignore `docs/requirements.txt`
2. For other files in the `docs` folder, disable major release updates in Renovate (someone would have to do those manually).
3. Lump minor/patch releases together (so you'd have one PR that updates everything)

Note that the Go extension is not included because its version is handled through the snap; the Spread test and tutorial use `sudo snap install go --classic` with explicitly defining a version of Go.

For Spring Boot, there is no native `start.spring.io` data source, so the custom rule uses `spring-boot-starter-parent` instead. The LLM claims that this data source tracks identical versions to `start.spring.io`

### Summary of changes

* Updated `ignorePaths` to ignore `docs/requirements.txt` only
* Added `packageRules` to disable major release updates and lump minor/patch releases together for files under `docs/tutorial/code/`.
* Added `customManagers` to add custom rules for updating the `task.yaml` files for ExpressJS and Spring Boot.


---

- [X] I've followed the [contribution guidelines](https://github.com/canonical/charmcraft/blob/main/CONTRIBUTING.md).
- [X] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [Failures unrelated to the changes in this PR] I've successfully run `make lint && make test`.
- [N/A] I've added or updated any relevant documentation.
- [N/A] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
