### PR TITLE
chore: mark extension-provided endpoints as optional

### DIFF
--- a/charmcraft/extensions/app.py
+++ b/charmcraft/extensions/app.py
@@ -329,12 +329,18 @@ class _AppBase(SinglePlatformExtension):
             "peers": {"secret-storage": {"interface": "secret-storage"}},
             "actions": self.actions,
             "requires": {
-                "logging": {"interface": "loki_push_api"},
-                "ingress": {"interface": "ingress", "limit": 1},
+                "logging": {"interface": "loki_push_api", "optional": True},
+                "ingress": {"interface": "ingress", "limit": 1, "optional": True},
             },
             "provides": {
-                "metrics-endpoint": {"interface": "prometheus_scrape"},
-                "grafana-dashboard": {"interface": "grafana_dashboard"},
+                "metrics-endpoint": {
+                    "interface": "prometheus_scrape",
+                    "optional": True,
+                },
+                "grafana-dashboard": {
+                    "interface": "grafana_dashboard",
+                    "optional": True,
+                },
             },
             "config": {"options": copy.deepcopy(self.options)},
             "parts": {

--- a/docs/howto/manage-extensions.rst
+++ b/docs/howto/manage-extensions.rst
@@ -124,14 +124,18 @@ then run  ``charmcraft expand-extensions``. For example:
         provides:
           metrics-endpoint:
             interface: prometheus_scrape
+            optional: true
           grafana-dashboard:
             interface: grafana_dashboard
+            optional: true
         requires:
           logging:
             interface: loki_push_api
+            optional: true
           ingress:
             interface: ingress
             limit: 1
+            optional: true
         resources:
           flask-app-image:
             type: oci-image

--- a/docs/release-notes/charmcraft-4.5.rst
+++ b/docs/release-notes/charmcraft-4.5.rst
@@ -58,6 +58,21 @@ Minor features
 Charmcraft 4.5 brings the following minor changes.
 
 
+Optional relations in 12-factor app charms
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The relations supplied by the 12-factor app extensions are now marked as
+``optional: true`` in the charm's metadata. This applies to the ``logging`` and
+``ingress`` relations in ``requires``, and the ``metrics-endpoint`` and
+``grafana-dashboard`` relations in ``provides``.
+
+None of these relations were ever required for the charm to reach an active
+state. The ``optional`` key is informational only, so this change doesn't alter
+how your charm behaves. It does let tools that read charm metadata, such as
+automated test harnesses, determine which relations they need to satisfy before
+deploying your charm.
+
+
 <Feature A>
 ~~~~~~~~~~~
 

--- a/docs/reuse/reference/extensions/integrations.rst
+++ b/docs/reuse/reference/extensions/integrations.rst
@@ -13,14 +13,18 @@ relations, as they were automatically supplied by the |framework| extension:
     provides:
       metrics-endpoint:
         interface: prometheus_scrape
+        optional: true
       grafana-dashboard:
         interface: grafana_dashboard
+        optional: true
     requires:
       logging:
         interface: loki_push_api
+        optional: true
       ingress:
         interface: ingress
         limit: 1
+        optional: true
 
 In addition to these relations, in each ``provides`` and ``requires``
 block you may specify further relations, to integrate with

--- a/docs/reuse/reference/extensions/integrations.rst
+++ b/docs/reuse/reference/extensions/integrations.rst
@@ -1,3 +1,5 @@
+.. meta::
+    :description: Reference the integrations supplied by the framework extension.
 
 Relations
 ---------

--- a/tests/extensions/test_app.py
+++ b/tests/extensions/test_app.py
@@ -22,15 +22,21 @@ from charmcraft import errors, extensions
 from charmcraft.errors import ExtensionError
 from charmcraft.extensions.app import (
     DjangoFrameworkV1,
+    DjangoFrameworkV2,
     ExpressJSFrameworkFactory,
     ExpressJSFrameworkV1,
+    ExpressJSFrameworkV2,
     FastAPIFrameworkFactory,
     FastAPIFrameworkV1,
+    FastAPIFrameworkV2,
     FlaskFrameworkFactory,
     FlaskFrameworkV1,
+    FlaskFrameworkV2,
     GoFrameworkFactory,
     GoFrameworkV1,
+    GoFrameworkV2,
     SpringBootFrameworkV1,
+    SpringBootFrameworkV2,
 )
 
 NON_OPTIONAL_OPTIONS = {
@@ -121,12 +127,22 @@ def make_spring_boot_input_yaml():
                 },
                 "peers": {"secret-storage": {"interface": "secret-storage"}},
                 "provides": {
-                    "metrics-endpoint": {"interface": "prometheus_scrape"},
-                    "grafana-dashboard": {"interface": "grafana_dashboard"},
+                    "metrics-endpoint": {
+                        "interface": "prometheus_scrape",
+                        "optional": True,
+                    },
+                    "grafana-dashboard": {
+                        "interface": "grafana_dashboard",
+                        "optional": True,
+                    },
                 },
                 "requires": {
-                    "logging": {"interface": "loki_push_api"},
-                    "ingress": {"interface": "ingress", "limit": 1},
+                    "logging": {"interface": "loki_push_api", "optional": True},
+                    "ingress": {
+                        "interface": "ingress",
+                        "limit": 1,
+                        "optional": True,
+                    },
                 },
                 "resources": {
                     "flask-app-image": {
@@ -206,12 +222,22 @@ def make_spring_boot_input_yaml():
                 },
                 "peers": {"secret-storage": {"interface": "secret-storage"}},
                 "provides": {
-                    "metrics-endpoint": {"interface": "prometheus_scrape"},
-                    "grafana-dashboard": {"interface": "grafana_dashboard"},
+                    "metrics-endpoint": {
+                        "interface": "prometheus_scrape",
+                        "optional": True,
+                    },
+                    "grafana-dashboard": {
+                        "interface": "grafana_dashboard",
+                        "optional": True,
+                    },
                 },
                 "requires": {
-                    "logging": {"interface": "loki_push_api"},
-                    "ingress": {"interface": "ingress", "limit": 1},
+                    "logging": {"interface": "loki_push_api", "optional": True},
+                    "ingress": {
+                        "interface": "ingress",
+                        "limit": 1,
+                        "optional": True,
+                    },
                 },
                 "resources": {
                     "django-app-image": {
@@ -281,12 +307,22 @@ def make_spring_boot_input_yaml():
                 },
                 "peers": {"secret-storage": {"interface": "secret-storage"}},
                 "provides": {
-                    "metrics-endpoint": {"interface": "prometheus_scrape"},
-                    "grafana-dashboard": {"interface": "grafana_dashboard"},
+                    "metrics-endpoint": {
+                        "interface": "prometheus_scrape",
+                        "optional": True,
+                    },
+                    "grafana-dashboard": {
+                        "interface": "grafana_dashboard",
+                        "optional": True,
+                    },
                 },
                 "requires": {
-                    "logging": {"interface": "loki_push_api"},
-                    "ingress": {"interface": "ingress", "limit": 1},
+                    "logging": {"interface": "loki_push_api", "optional": True},
+                    "ingress": {
+                        "interface": "ingress",
+                        "limit": 1,
+                        "optional": True,
+                    },
                 },
                 "resources": {
                     "app-image": {
@@ -356,12 +392,22 @@ def make_spring_boot_input_yaml():
                 },
                 "peers": {"secret-storage": {"interface": "secret-storage"}},
                 "provides": {
-                    "metrics-endpoint": {"interface": "prometheus_scrape"},
-                    "grafana-dashboard": {"interface": "grafana_dashboard"},
+                    "metrics-endpoint": {
+                        "interface": "prometheus_scrape",
+                        "optional": True,
+                    },
+                    "grafana-dashboard": {
+                        "interface": "grafana_dashboard",
+                        "optional": True,
+                    },
                 },
                 "requires": {
-                    "logging": {"interface": "loki_push_api"},
-                    "ingress": {"interface": "ingress", "limit": 1},
+                    "logging": {"interface": "loki_push_api", "optional": True},
+                    "ingress": {
+                        "interface": "ingress",
+                        "limit": 1,
+                        "optional": True,
+                    },
                 },
                 "resources": {
                     "app-image": {
@@ -431,12 +477,22 @@ def make_spring_boot_input_yaml():
                 },
                 "peers": {"secret-storage": {"interface": "secret-storage"}},
                 "provides": {
-                    "metrics-endpoint": {"interface": "prometheus_scrape"},
-                    "grafana-dashboard": {"interface": "grafana_dashboard"},
+                    "metrics-endpoint": {
+                        "interface": "prometheus_scrape",
+                        "optional": True,
+                    },
+                    "grafana-dashboard": {
+                        "interface": "grafana_dashboard",
+                        "optional": True,
+                    },
                 },
                 "requires": {
-                    "logging": {"interface": "loki_push_api"},
-                    "ingress": {"interface": "ingress", "limit": 1},
+                    "logging": {"interface": "loki_push_api", "optional": True},
+                    "ingress": {
+                        "interface": "ingress",
+                        "limit": 1,
+                        "optional": True,
+                    },
                 },
                 "resources": {
                     "app-image": {
@@ -495,12 +551,22 @@ def make_spring_boot_input_yaml():
                 },
                 "peers": {"secret-storage": {"interface": "secret-storage"}},
                 "provides": {
-                    "metrics-endpoint": {"interface": "prometheus_scrape"},
-                    "grafana-dashboard": {"interface": "grafana_dashboard"},
+                    "metrics-endpoint": {
+                        "interface": "prometheus_scrape",
+                        "optional": True,
+                    },
+                    "grafana-dashboard": {
+                        "interface": "grafana_dashboard",
+                        "optional": True,
+                    },
                 },
                 "requires": {
-                    "logging": {"interface": "loki_push_api"},
-                    "ingress": {"interface": "ingress", "limit": 1},
+                    "logging": {"interface": "loki_push_api", "optional": True},
+                    "ingress": {
+                        "interface": "ingress",
+                        "limit": 1,
+                        "optional": True,
+                    },
                 },
                 "resources": {
                     "app-image": {
@@ -954,15 +1020,42 @@ def test_flask_merge_relation(flask_input_yaml, tmp_path):
     flask_input_yaml["requires"] = new_requires
     applied = extensions.apply_extensions(tmp_path, flask_input_yaml)
     assert applied["provides"] == {
-        "metrics-endpoint": {"interface": "prometheus_scrape"},
-        "grafana-dashboard": {"interface": "grafana_dashboard"},
+        "metrics-endpoint": {"interface": "prometheus_scrape", "optional": True},
+        "grafana-dashboard": {"interface": "grafana_dashboard", "optional": True},
         **new_provides,
     }
     assert applied["requires"] == {
-        "logging": {"interface": "loki_push_api"},
-        "ingress": {"interface": "ingress", "limit": 1},
+        "logging": {"interface": "loki_push_api", "optional": True},
+        "ingress": {"interface": "ingress", "limit": 1, "optional": True},
         **new_requires,
     }
+
+
+@pytest.mark.parametrize(
+    "extension_class",
+    [
+        DjangoFrameworkV1,
+        DjangoFrameworkV2,
+        ExpressJSFrameworkV1,
+        ExpressJSFrameworkV2,
+        FastAPIFrameworkV1,
+        FastAPIFrameworkV2,
+        FlaskFrameworkV1,
+        FlaskFrameworkV2,
+        GoFrameworkV1,
+        GoFrameworkV2,
+        SpringBootFrameworkV1,
+        SpringBootFrameworkV2,
+    ],
+)
+def test_extension_supplied_relations_are_optional(extension_class, tmp_path):
+    extension = extension_class(project_root=tmp_path, yaml_data={})
+    snippet = extension._get_root_snippet()
+
+    assert snippet["requires"]["logging"]["optional"] is True
+    assert snippet["requires"]["ingress"]["optional"] is True
+    assert snippet["provides"]["metrics-endpoint"]["optional"] is True
+    assert snippet["provides"]["grafana-dashboard"]["optional"] is True
 
 
 def test_flask_merge_charm_libs(flask_input_yaml, tmp_path):


### PR DESCRIPTION
This PR updates the extensions to mark the observability and ingress endpoints with `optional: true`. This addresses https://github.com/canonical/charmcraft/issues/2868

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/charmcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
- [x] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [x] I've updated the relevant release notes.
