### PR TITLE
docs: rework terminal directives

### DIFF
--- a/docs/howto/manage-channels.rst
+++ b/docs/howto/manage-channels.rst
@@ -42,18 +42,12 @@ See more: :ref:`register-a-name`
 View the available channels
 ---------------------------
 
-To view a charm's channels on Charmhub, run ``charmcraft status`` followed by the name
-of the charm. E.g.,
-
-.. code-block:: bash
-
-    charmcraft status my-awesome-charm
-
-The following output shows four channels, all of which have the same track, ``latest``,
-but different risk levels, namely, ``edge``, ``beta``, ``candidate``, and ``stable``.
+To view your charm's channels on Charmhub, run ``charmcraft status`` followed by the
+name of the charm.
 
 .. terminal::
-    :output-only:
+
+    charmcraft status my-awesome-charm
 
     Track    Channel    Version    Revision
     latest   stable     -          -

--- a/docs/howto/manage-charmcraft.rst
+++ b/docs/howto/manage-charmcraft.rst
@@ -83,7 +83,7 @@ on any platform, as it will give you an isolated development environment.
 First, `install Multipass <https://documentation.ubuntu.com/multipass/latest/how-to-guides/install-multipass/>`_.
 
 Then, provision a virtual machine with Multipass. The following command launches
-a fresh new VM with 4 cores, 8GB RAM, a 20GB disk. and the name 'charm-dev':
+a fresh new VM with 4 cores, 8GB RAM, a 20GB disk, and the name 'charm-dev':
 
 .. code-block:: bash
 

--- a/docs/howto/manage-charmcraft.rst
+++ b/docs/howto/manage-charmcraft.rst
@@ -63,26 +63,9 @@ Charmhub commands work natively:
     username:  jdoe
     id:        xxxxxxxxxxxxxxxxxxxxxxxxx
 
-In macOS, Charmcraft defaults to Multipass to build the charms in a container matching
-the target bases. Running pack asks to setup Multipass if not already installed, and
-continues with the packing process:
-
-.. terminal::
-
-    charmcraft pack
-
-    Multipass is required, but not installed. Do you wish to install Multipass and configure it with the defaults? [y/N]: y
-    ==> Downloading https://github.com/canonical/multipass/releases/download/v1.7.2/multipass-1.7.2+mac-Darwin.pkg
-    Already downloaded: /Users/jdoe/Library/Caches/Homebrew/downloads/4237fcef800faa84459a2911c3818dfa76f1532d693b151438f1c8266318715b--multipass-1.7.2+mac-Darwin.pkg
-    ==> Installing Cask multipass
-    ==> Running installer for multipass; your password may be necessary.
-    Package installers may write to any location; options such as `--appdir` are ignored.
-    installer: Package name is multipass
-    installer: Installing at base path /
-    installer: The install was successful.
-    🍺  multipass was successfully installed!
-    Packing charm 'test-charm_ubuntu-20.04-amd64.charm'...
-    Starting charmcraft-test-charm-12886917363-0-0-amd64 ...
+On macOS, Charmcraft defaults to Multipass for the build environment. If Multipass isn't
+installed on the system, Charmcraft will offer to install it the first time you run the
+``charmcraft pack`` command.
 
 You can also install Charmcraft in an isolated environment.
 
@@ -99,26 +82,19 @@ on any platform, as it will give you an isolated development environment.
 
 First, `install Multipass <https://documentation.ubuntu.com/multipass/latest/how-to-guides/install-multipass/>`_.
 
-Second, use Multipass to provision a virtual machine. The following command will launch
-a fresh new VM with 4 cores, 8GB RAM and a 20GB disk and the name ‘charm-dev':
+Then, provision a virtual machine with Multipass. The following command launches
+a fresh new VM with 4 cores, 8GB RAM, a 20GB disk. and the name 'charm-dev':
 
 .. code-block:: bash
 
     multipass launch --cpus 4 --memory 8G --disk 20G --name charm-dev
 
-Last, open a shell in your new Ubuntu virtual machine, and install Charmcraft there:
+Open a shell in the resulting Ubuntu virtual machine and install Charmcraft there:
 
-.. terminal::
+.. code-block:: bash
 
     multipass shell charm-dev
-
-.. terminal::
-    :user: ubuntu
-    :host: charm-dev
-
     sudo snap install charmcraft --classic
-
-    charmcraft 2.2.0 from Canonical✓ installed
 
 That's it. You can now start typing in Charmcraft commands.
 

--- a/docs/howto/manage-extensions.rst
+++ b/docs/howto/manage-extensions.rst
@@ -85,7 +85,6 @@ then run  ``charmcraft expand-extensions``. For example:
 
         CHARMCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS=1 charmcraft expand-extensions
 
-
         *EXPERIMENTAL* extension 'flask-framework' enabled
         name: my-flask-app-k8s
         summary: A very short one-line summary of the flask application.

--- a/docs/howto/manage-libraries.rst
+++ b/docs/howto/manage-libraries.rst
@@ -82,13 +82,12 @@ inside the library file, then repeat the publish procedure.
 To share your library with other charm developers, navigate to the host charm's Charmhub
 page, go to **Libraries** tab, then copy and share the URL at the top of the page.
 
-View the libs published for a charm
------------------------------------
+View a charm's published libraries
+----------------------------------
 
-The easiest way to find an existing library for a given charm is via
-:ref:`charmcraft list-lib <ref_commands_list-lib>`, as shown below. This
-will query Charmhub and show which libraries are published for the specified
-charm, along with API/patch versions.
+To view a charm's libraries, run the :ref:`charmcraft list-lib <ref_commands_list-lib>`
+command. This will show the given charm's libraries alongside their API and patch
+versions.
 
 .. terminal::
 

--- a/docs/howto/manage-resources.rst
+++ b/docs/howto/manage-resources.rst
@@ -47,9 +47,8 @@ the resource (cf. ``charmcraft.yaml``), and ``--filepath=<path to file resource>
 
     Revision 1 created of resource 'someresource' for charm 'my-super-charm'
 
-The ``--image`` option must be passed the OCI image's long or short SHA hash. If the
-short SHA hash is used, the image must be present locally so its long SHA hash can be
-retrieved.
+The ``--image`` option must be passed an OCI image digest, prefixed with ``sha256:``, or
+a local image ID.
 
 .. terminal::
 

--- a/docs/howto/manage-resources.rst
+++ b/docs/howto/manage-resources.rst
@@ -36,24 +36,20 @@ Publish a resource on Charmhub
 
     You must have already :ref:`published the charm <publish-a-charm>`.
 
-To publish a resource on its charm's Charmhub page, run
-:ref:`charmcraft upload-resource <ref_commands_upload-resource>`
-followed by the name of the charm, the name of the resource (cf. ``charmcraft.yaml``),
-and ``--filepath=<path to file resource>`` / ``--image=<OCI image>``. For example:
-
-.. note::
-
-    The option ``--image`` must indicate an OCI image's digest, being it in the short or
-    long form (e.g.: ``70aa8983ec5c`` or
-    ``sha256:64aa8983ec5cea7bc143af18829836914fa405184d56dcbdfd9df672ade85249``). When
-    using the "short form" of the digest, the image needs to be present locally so its
-    proper ID (the "long form") can be retrieved.
+To publish a resource for a charm, run the :ref:`charmcraft upload-resource
+<ref_commands_upload-resource>` command followed by the name of the charm, the name of
+the resource (cf. ``charmcraft.yaml``), and ``--filepath=<path to file resource>`` /
+``--image=<OCI image>``. For example:
 
 .. terminal::
 
     charmcraft upload-resource my-super-charm someresource --filepath=/tmp/superdb.bin
 
     Revision 1 created of resource 'someresource' for charm 'my-super-charm'
+
+The ``--image`` option must be passed the OCI image's long or short SHA hash. If the
+short SHA hash is used, the image must be present locally so its long SHA hash can be
+retrieved.
 
 .. terminal::
 

--- a/docs/howto/manage-revisions.rst
+++ b/docs/howto/manage-revisions.rst
@@ -69,9 +69,9 @@ maintained separately from Charmcraft.
 Release a charm revision into a channel
 ---------------------------------------
 
-To :ref:`ref_commands_release` a specific charm revision to a channel, run ``charmcraft release``,
-followed by the name of the charm and flags specifying the revision and
-its target channel. For example,
+To release a charm revision to a channel, run :ref:`charmcraft release
+<ref_commands_release>` followed by the name of the charm, the revision number, and the
+target channel. For example:
 
 .. terminal::
 

--- a/docs/howto/manage-the-current-charmhub-user.rst
+++ b/docs/howto/manage-the-current-charmhub-user.rst
@@ -14,8 +14,13 @@ How you log in depends on whether you're working in a local or remote environmen
 Local environments
 ~~~~~~~~~~~~~~~~~~
 
-To log in to Charmhub, run the :ref:`charmcraft login <ref_commands_login>` command,
-which will open a web browser and prompt you to log in with your Ubuntu One account.
+To log in to Charmhub, run:
+
+.. code-block:: bash
+
+    charmcraft login
+
+This will open a web browser and prompt you to log in with your Ubuntu One account.
 
 Remote environments
 ~~~~~~~~~~~~~~~~~~~

--- a/docs/howto/manage-the-current-charmhub-user.rst
+++ b/docs/howto/manage-the-current-charmhub-user.rst
@@ -14,15 +14,8 @@ How you log in depends on whether you're working in a local or remote environmen
 Local environments
 ~~~~~~~~~~~~~~~~~~
 
-To log in to Charmhub, run :ref:`charmcraft login <ref_commands_login>`:
-
-.. terminal::
-
-    charmcraft login
-
-    Opening an authorization web page in your browser.
-    If it does not open, please open this URL:
-    ...
+To log in to Charmhub, run the :ref:`charmcraft login <ref_commands_login>` command,
+which will open a web browser and prompt you to log in with your Ubuntu One account.
 
 Remote environments
 ~~~~~~~~~~~~~~~~~~~

--- a/docs/howto/manage-web-app-charms/configure-web-app-charm.rst
+++ b/docs/howto/manage-web-app-charms/configure-web-app-charm.rst
@@ -193,8 +193,7 @@ Finally, call the action using:
 If successful, the terminal will output something like:
 
 .. terminal::
-
-    juju run django-app/0 clearsession
+    :output-only:
 
     Running operation 1 with 1 task
       - task 2 on unit-django-app-0
@@ -244,8 +243,7 @@ Finally, call the action using:
 If successful, the terminal will output something like:
 
 .. terminal::
-
-    juju run flask-app/0 updatelogfile logfile="/tmp/example.log"
+    :output-only:
 
     Running operation 1 with 1 task
       - task 2 on unit-flask-app-0

--- a/docs/howto/pack-a-hooks-based-charm-with-charmcraft.rst
+++ b/docs/howto/pack-a-hooks-based-charm-with-charmcraft.rst
@@ -44,19 +44,11 @@ hooks-based charm, as shown below:
           - icon.svg
           - metadata.yaml
 
-After this, you can pack your charm with ``charmcraft pack``, as usual:
+Then, you can pack the charm by running:
 
 .. code-block:: bash
 
    charmcraft pack
-
-If successful, the result should look like the following.
-
-.. terminal::
-    :output-only:
-
-    Charms packed:
-        tiny-bash_ubuntu-20.04-amd64.charm
 
 The charm file should contain all the files listed in the ``prime`` section of the
 ``tiny-bash`` part and the charm manifest.
@@ -86,31 +78,3 @@ The charm file should contain all the files listed in the ``prime`` section of t
           625  2021-11-12 19:37   hooks/config-changed
     ---------                     -------
         44762                     16 files
-
-And you can also deploy your application with ``juju deploy``, as usual:
-
-.. terminal::
-
-    juju deploy ./tiny-bash_ubuntu-20.04-amd64.charm
-
-    Located local charm "tiny-bash", revision 0
-    Deploying "tiny-bash" from local charm "tiny-bash", revision 0
-
-If successful, the result should look as below, i.e., with the application status
-active.
-
-.. terminal::
-
-    juju status
-
-    Model    Controller           Cloud/Region         Version  SLA          Timestamp
-    default  localhost-localhost  localhost/localhost  2.9.12   unsupported  17:23:23-03:00
-
-    App        Version  Status  Scale  Charm      Store  Channel  Rev  OS      Message
-    tiny-bash           active      1  tiny-bash  local             0  ubuntu  update-status ran: 20:22
-
-    Unit          Workload  Agent  Machine  Public address  Ports  Message
-    tiny-bash/0*  active    idle   0        10.2.17.31             update-status ran: 20:22
-
-    Machine  State    DNS         Inst id        Series  AZ  Message
-    0        started  10.2.17.31  juju-55481c-0  focal       Running

--- a/docs/howto/pack-a-hooks-based-charm-with-charmcraft.rst
+++ b/docs/howto/pack-a-hooks-based-charm-with-charmcraft.rst
@@ -44,7 +44,7 @@ hooks-based charm, as shown below:
           - icon.svg
           - metadata.yaml
 
-Then, you can pack the charm by running:
+Then, pack the charm by running:
 
 .. code-block:: bash
 

--- a/uv.lock
+++ b/uv.lock
@@ -3,8 +3,8 @@ revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version == '3.14.*'",
-    "python_full_version == '3.12.*'",
     "python_full_version == '3.13.*' or python_full_version >= '3.15'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
@@ -33,6 +33,7 @@ constraints = [
     { name = "matplotlib", specifier = ">=3.7.0" },
     { name = "numpy", specifier = ">=1.22.0" },
     { name = "oauthlib", specifier = ">=3.0" },
+    { name = "ops", specifier = ">=2.0.0" },
     { name = "overrides", specifier = ">=7.3" },
     { name = "protobuf", specifier = "<6.33" },
     { name = "protobuf", specifier = ">=5.0" },
@@ -2644,8 +2645,8 @@ version = "2.4.0+ubuntu4"
 source = { registry = "https://people.canonical.com/~lengau/python-apt-ubuntu-wheels/" }
 resolution-markers = [
     "python_full_version == '3.14.*'",
-    "python_full_version == '3.12.*'",
     "python_full_version == '3.13.*' or python_full_version >= '3.15'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
@@ -2689,8 +2690,8 @@ version = "2.7.7+ubuntu5"
 source = { registry = "https://people.canonical.com/~lengau/python-apt-ubuntu-wheels/" }
 resolution-markers = [
     "python_full_version == '3.14.*'",
-    "python_full_version == '3.12.*'",
     "python_full_version == '3.13.*' or python_full_version >= '3.15'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
@@ -2733,8 +2734,8 @@ version = "2.9.9"
 source = { registry = "https://people.canonical.com/~lengau/python-apt-ubuntu-wheels/" }
 resolution-markers = [
     "python_full_version == '3.14.*'",
-    "python_full_version == '3.12.*'",
     "python_full_version == '3.13.*' or python_full_version >= '3.15'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
@@ -2751,8 +2752,8 @@ version = "3.0.0+ubuntu1"
 source = { registry = "https://people.canonical.com/~lengau/python-apt-ubuntu-wheels/" }
 resolution-markers = [
     "python_full_version == '3.14.*'",
-    "python_full_version == '3.12.*'",
     "python_full_version == '3.13.*' or python_full_version >= '3.15'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
@@ -3361,8 +3362,8 @@ version = "2025.8.25"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version == '3.14.*'",
-    "python_full_version == '3.12.*'",
     "python_full_version == '3.13.*' or python_full_version >= '3.15'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
@@ -3423,8 +3424,8 @@ version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version == '3.14.*'",
-    "python_full_version == '3.12.*'",
     "python_full_version == '3.13.*' or python_full_version >= '3.15'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
@@ -3523,8 +3524,8 @@ version = "2025.2.19"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version == '3.14.*'",
-    "python_full_version == '3.12.*'",
     "python_full_version == '3.13.*' or python_full_version >= '3.15'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
@@ -3540,16 +3541,16 @@ wheels = [
 
 [[package]]
 name = "sphinx-terminal"
-version = "1.0.3"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docutils" },
     { name = "sphinx" },
     { name = "sphinx-copybutton" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e6/f7/c48cfa302ba9e82687972334b1995e687cab79999a1805cb3d96d67b80dd/sphinx_terminal-1.0.3.tar.gz", hash = "sha256:7a5ae9d20f5e9fd96d7df753e62b5415e33816a4833b73fcd8d60afee4695cbb", size = 95465, upload-time = "2025-12-02T01:10:18.08Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/6a/8a40612509f222dc966d80f9438f6780c3a0b7ed6e849420e9d277e0e15f/sphinx_terminal-1.1.0.tar.gz", hash = "sha256:447d883c33a6d790b66bc23cce90ef5ce87d19af63ff4bbb8d44eb441152333a", size = 106116, upload-time = "2026-07-16T17:13:15.092Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4b/09/6afb984b5b58f6d522dea00f59b19ffa2405fb72b298803f51ac3df0f31d/sphinx_terminal-1.0.3-py3-none-any.whl", hash = "sha256:127ca5f21d4a4880bb5f8d18e7114f89d66f96df425478fb376376697e8315ac", size = 20096, upload-time = "2025-12-02T01:10:16.851Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/e2/09e3f6530238d3a654a74ca36af4187be72938f8adfcf9b0fd24bf92fe06/sphinx_terminal-1.1.0-py3-none-any.whl", hash = "sha256:a2985d7982b68cd2271473148c65ccef62259ef644b5b76053cd709a5e15175d", size = 21265, upload-time = "2026-07-16T17:13:13.815Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Remove terminal directives that don't display meaningful output or show an example command interaction
- Clean up text around some terminal directives (not really in the scope but I wanted to fix some issues while I was here)
- Remove deployment instructions from 'Pack a hooks-based' charm (these were terminal directives so it counts)
- Bump `sphinx-terminal` to 1.1.0

Resolves https://github.com/canonical/charmcraft/issues/2563

---

- [X] I've followed the [contribution guidelines](https://github.com/canonical/charmcraft/blob/main/CONTRIBUTING.md).
- [X] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
~~I've successfully run `make lint && make test`.~~
~~I've added or updated any relevant documentation.~~
~~In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.~~ Planning to refactor most of these pages soon, so this would be wasted effort.
~~I've updated the relevant release notes.~~
