### PR TITLE
test: add retry on reactive tests

### DIFF
--- a/tests/spread/smoketests/reactive-legacy/task.yaml
+++ b/tests/spread/smoketests/reactive-legacy/task.yaml
@@ -1,5 +1,6 @@
 summary: pack a simple reactive charm on older systems
 priority: 100
+kill-timeout: 30m # These sometimes take a while to download bases.
 
 systems:
   - ubuntu-20.04-64
@@ -33,5 +34,6 @@ restore: |
 
 execute: |
   cd reactivecharm
-  charmcraft pack
+  # Retry: priming the LXD base instance can hit transient proxy 503s.
+  retry -n 3 --wait 30 charmcraft pack
   test -f reactive-test*.charm

--- a/tests/spread/smoketests/reactive-resolute/task.yaml
+++ b/tests/spread/smoketests/reactive-resolute/task.yaml
@@ -1,5 +1,6 @@
 summary: pack a simple reactive charm on 26.04
 priority: 100
+kill-timeout: 30m # These sometimes take a while to download bases.
 
 systems:
   - ubuntu-26.04-64
@@ -26,5 +27,6 @@ restore: |
 
 execute: |
   cd reactivecharm
-  charmcraft pack
+  # Retry: priming the LXD base instance can hit transient proxy 503s.
+  retry -n 3 --wait 30 charmcraft pack
   test -f reactive-test*.charm


### PR DESCRIPTION
The reactive tests are rather flaky. While they don't do anything particularly special (they just pack a charm, as do many other spread tests), what sets them apart is they are also remarkably slow and so can run up against `kill-timeout`s often too.

This isn't a very great long-term change, but it's a pilot solution that we can look to to inform our decision on rerun mechanisms in our spread tests later.

Across 5 runs (the initial 3 + 2 reruns of the 20.04 variant), the reactive tests never failed.

CHARMCRAFT-712

---

- [ ] I've followed the [contribution guidelines](https://github.com/canonical/charmcraft/blob/main/CONTRIBUTING.md).
- [ ] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
